### PR TITLE
Add ability to override Snooty project baseUrl

### DIFF
--- a/ingest/src/SnootyDataSource.test.ts
+++ b/ingest/src/SnootyDataSource.test.ts
@@ -5,33 +5,36 @@ import JSONL from "jsonl-parse-stringify";
 import {
   SnootyNode,
   SnootyProjectConfig,
-  getSnootyProjectBaseUrl,
   makeSnootyDataSource,
 } from "./SnootyDataSource";
 import { sampleSnootyMetadata } from "./test_data/snooty_sample_metadata";
 import { snootyAstToMd } from "./snootyAstToMd";
+import {
+  SnootyProjectsInfo,
+  makeSnootyProjectsInfo,
+  prepareSnootySources,
+} from "./SnootyProjectsInfo";
 
 jest.setTimeout(15000);
 
 describe("SnootyDataSource", () => {
-  const sourceConfig: SnootyProjectConfig = {
+  const project: SnootyProjectConfig = {
     type: "snooty",
     name: "docs",
     currentBranch: "v6.0",
     tags: ["docs", "manual"],
+    baseUrl: "https://mongodb.com/docs/v6.0/",
   };
-  const snootyDataApiEndpoint = "https://snooty-data-api.mongodb.com/prod";
+  const snootyDataApiBaseUrl = "https://snooty-data-api.mongodb.com/prod/";
   describe("makeSnootyDataSource()", () => {
     const sampleDataPath = Path.resolve(
       __dirname,
       "./test_data/snooty_sample_data.txt"
     );
-    const baseMock = nock(snootyDataApiEndpoint);
+    const baseMock = nock(snootyDataApiBaseUrl);
     beforeAll(() => {
       baseMock
-        .get(
-          `/projects/${sourceConfig.name}/${sourceConfig.currentBranch}/documents`
-        )
+        .get(`/projects/${project.name}/${project.currentBranch}/documents`)
         .reply(200, () => fs.createReadStream(sampleDataPath));
       baseMock.get("/projects").reply(200, sampleSnootyMetadata);
     });
@@ -40,16 +43,18 @@ describe("SnootyDataSource", () => {
     });
     it("successfully loads pages", async () => {
       // TODO: fix typescript typing
-      const source = await makeSnootyDataSource(
-        sourceConfig as SnootyProjectConfig
-      );
+      const source = await makeSnootyDataSource({
+        name: `snooty-test`,
+        project,
+        snootyDataApiBaseUrl,
+      });
 
       const pages = await source.fetchPages();
       expect(pages.length).toBe(12);
       const astPages = JSONL.parse<{ type: string; data: { ast: SnootyNode } }>(
         fs.readFileSync(sampleDataPath, "utf8")
       );
-      const baseUrl = "https://mongodb.com/docs/v6.0";
+      const baseUrl = "https://mongodb.com/docs/v6.0/";
       const pageAst = astPages.find(
         (entry: { type: string }) => entry.type === "page"
       )?.data.ast;
@@ -58,37 +63,71 @@ describe("SnootyDataSource", () => {
       const firstPageText = snootyAstToMd(pageAst!, { baseUrl });
       expect(pages[0]).toMatchObject({
         format: "md",
-        sourceName: "snooty-docs",
+        sourceName: "snooty-test",
         tags: ["docs", "manual"],
         url: "https://mongodb.com/docs/v6.0/about",
         body: firstPageText,
       });
     });
   });
-  describe("getSnootyProjectBaseUrl()", () => {
+  describe("SnootyProjectsInfo", () => {
+    let projectsInfo: SnootyProjectsInfo | undefined;
+    beforeAll(async () => {
+      projectsInfo = await makeSnootyProjectsInfo({
+        snootyDataApiBaseUrl,
+      });
+    });
+    afterAll(() => {
+      projectsInfo = undefined;
+    });
+
     it("gets project base url", async () => {
-      const baseUrl = await getSnootyProjectBaseUrl({
+      const baseUrl = await projectsInfo?.getBaseUrl({
         projectName: "docs",
         branchName: "v4.4",
-        snootyDataApiEndpoint,
       });
       expect(baseUrl).toBe("https://mongodb.com/docs/v4.4");
     });
     it("throws for invalid branch", async () => {
-      const baseUrlPromise = getSnootyProjectBaseUrl({
+      const baseUrlPromise = projectsInfo?.getBaseUrl({
         projectName: "docs",
         branchName: "not-a-branch",
-        snootyDataApiEndpoint,
       });
       await expect(baseUrlPromise).rejects.toThrow();
     });
     it("throws for invalid project", async () => {
-      const baseUrlPromise = getSnootyProjectBaseUrl({
+      const baseUrlPromise = projectsInfo?.getBaseUrl({
         projectName: "not-a-project",
         branchName: "v4.4",
-        snootyDataApiEndpoint,
       });
       await expect(baseUrlPromise).rejects.toThrow();
+    });
+  });
+  describe("prepareSnootySources", () => {
+    it("allows override baseUrl", async () => {
+      const sources = await prepareSnootySources({
+        projects: [
+          {
+            type: "snooty",
+            name: "cloud-docs",
+            currentBranch: "master",
+            tags: ["atlas", "docs"],
+            // No override
+          },
+          {
+            type: "snooty",
+            name: "cloud-docs",
+            currentBranch: "master",
+            tags: ["atlas", "docs"],
+            baseUrl: "https://override.example.com", // Override
+          },
+        ],
+        snootyDataApiBaseUrl,
+      });
+      expect((sources[0] as any).baseUrl).toBe(
+        "https://mongodb.com/docs/atlas/"
+      );
+      expect((sources[1] as any).baseUrl).toBe("https://override.example.com/");
     });
   });
 });

--- a/ingest/src/SnootyProjectsInfo.ts
+++ b/ingest/src/SnootyProjectsInfo.ts
@@ -1,0 +1,82 @@
+import fetch from "node-fetch";
+import {
+  SnootyProjectConfig,
+  SnootyProject,
+  makeSnootyDataSource,
+} from "./SnootyDataSource";
+
+/** Schema for API response from https://snooty-data-api.mongodb.com/prod/projects */
+type GetSnootyProjectsResponse = {
+  data: SnootyProject[];
+};
+
+export type SnootyProjectsInfo = {
+  getBaseUrl(args: {
+    projectName: string;
+    branchName: string;
+  }): Promise<string>;
+};
+
+/**
+  Creates a SnootyProjectsInfo object from the Snooty Data API GET projects endpoint.
+ */
+export const makeSnootyProjectsInfo = async ({
+  snootyDataApiBaseUrl,
+}: {
+  snootyDataApiBaseUrl: string;
+}): Promise<SnootyProjectsInfo> => {
+  const response = await fetch(new URL("projects", snootyDataApiBaseUrl));
+  const { data }: GetSnootyProjectsResponse = await response.json();
+  return {
+    async getBaseUrl({ projectName, branchName }) {
+      const siteMetadata = data.find(
+        (snootyProject) => snootyProject.project === projectName
+      );
+      const branchMetaData = siteMetadata?.branches.find(
+        (branch) => branch.active && branch.gitBranchName === branchName
+      );
+      // Make sure there is an active branch at the specified branch name
+      if (branchMetaData === undefined) {
+        throw new Error(
+          `For project '${projectName}', no active branch found for '${branchName}'.`
+        );
+      }
+      return branchMetaData.fullUrl.replace("http://", "https://");
+    },
+  };
+};
+
+/**
+  Fill the details of the defined Snooty data sources with the info in the
+  Snooty Data API projects endpoint.
+ */
+export const prepareSnootySources = async ({
+  projects,
+  snootyDataApiBaseUrl,
+}: {
+  projects: (Omit<SnootyProjectConfig, "baseUrl"> & {
+    baseUrl?: string;
+  })[];
+  snootyDataApiBaseUrl: string;
+}) => {
+  const snootyProjectsInfo = await makeSnootyProjectsInfo({
+    snootyDataApiBaseUrl,
+  });
+  return await Promise.all(
+    projects.map(async (project) => {
+      return await makeSnootyDataSource({
+        name: `snooty-${project.name}`,
+        project: {
+          ...project,
+          baseUrl:
+            project.baseUrl?.replace(/\/?$/, "/") ??
+            (await snootyProjectsInfo.getBaseUrl({
+              projectName: project.name,
+              branchName: project.currentBranch,
+            })),
+        },
+        snootyDataApiBaseUrl,
+      });
+    })
+  );
+};

--- a/ingest/src/commands/pages.ts
+++ b/ingest/src/commands/pages.ts
@@ -6,13 +6,13 @@ import {
   PageStore,
 } from "chat-core";
 import { updatePages } from "../updatePages";
-import { makeSnootyDataSource, SnootyProjectConfig } from "../SnootyDataSource";
 import {
   DevCenterProjectConfig,
   makeDevCenterDataSource,
 } from "../DevCenterDataSource";
-import { projectSourcesConfig } from "../projectSources";
+import { projectSourcesConfig, snootyProjectConfig } from "../projectSources";
 import { INGEST_ENV_VARS } from "../IngestEnvVars";
+import { prepareSnootySources } from "../SnootyProjectsInfo";
 
 type PagesCommandArgs = {
   source?: string | string[];
@@ -55,16 +55,12 @@ export const doPagesCommand = async ({
 }: PagesCommandArgs & {
   store: PageStore;
 }) => {
-  const { DEVCENTER_CONNECTION_URI } = assertEnvVars(INGEST_ENV_VARS);
-
   const requestedSources = new Set(Array.isArray(source) ? source : [source]);
 
-  const snootyConfigs = projectSourcesConfig.filter(
-    (project) => project.type === "snooty"
-  ) as SnootyProjectConfig[];
-  const snootySources = await Promise.all(
-    snootyConfigs.map(makeSnootyDataSource)
-  );
+  const snootySources = await prepareSnootySources({
+    projects: snootyProjectConfig,
+    snootyDataApiBaseUrl: "https://snooty-data-api.mongodb.com/prod/",
+  });
 
   const devCenterConfig = projectSourcesConfig.find(
     (project) => project.type === "devcenter"

--- a/ingest/src/projectSources.ts
+++ b/ingest/src/projectSources.ts
@@ -5,7 +5,11 @@ import { INGEST_ENV_VARS } from "./IngestEnvVars";
 
 const { DEVCENTER_CONNECTION_URI } = assertEnvVars(INGEST_ENV_VARS);
 
-export const snootyProjectConfig: SnootyProjectConfig[] = [
+// 'baseUrl' to be filled in by the Snooty Data API GET projects endpoint -
+// unless you want to specify one to override whatever the Data API says
+export const snootyProjectConfig: (Omit<SnootyProjectConfig, "baseUrl"> & {
+  baseUrl?: string;
+})[] = [
   {
     type: "snooty",
     name: "cloud-docs",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-31600

## Changes

- Refactors the Snooty data source to not need to call the projects list endpoint every time
- Allows baseUrl override in project configuration

