### PR TITLE
Get current branch from Snooty Data API plus allow override

### DIFF
--- a/ingest/.eslintrc.cjs
+++ b/ingest/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   },
   root: true,
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "jsdoc"],
   extends: [
     "eslint:recommended",
     "prettier",
@@ -12,4 +12,5 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
   ],
   ignorePatterns: ["**/build/*"],
+  rules: { "jsdoc/require-asterisk-prefix": ["error", "never"] },
 };

--- a/ingest/package.json
+++ b/ingest/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
     "eslint-config-prettier": "^8",
+    "eslint-plugin-jsdoc": "^46.4.5",
     "eslint-plugin-prettier": "^4",
     "eslint-plugin-tsdoc": "^0.2.14",
     "jest": "^29.5.0",

--- a/ingest/src/ProjectBase.d.ts
+++ b/ingest/src/ProjectBase.d.ts
@@ -1,20 +1,20 @@
 /**
- * Base project type used in all project data sources (snooty sites, devcenter, etc.)
+  Base project type used in all project data sources (snooty sites, devcenter, etc.)
  */
 export interface ProjectBase {
   /**
-   * Type of project
-   * @example "snooty" | "devcenter"
+    Type of project
+    @example "snooty" | "devcenter"
    */
   type: string;
   /**
-   * Snooty project name
-   * @example "kotlin"
+    Snooty project name
+    @example "kotlin"
    */
   name: string;
   /**
-   * Tags to include in all documents from the site in the embedded_content collection
-   * @example ["kotlin", "docs", "driver"]
+    Tags to include in all documents from the site in the embedded_content collection
+    @example ["kotlin", "docs", "driver"]
    */
   tags?: string[];
 }

--- a/ingest/src/SnootyDataSource.test.ts
+++ b/ingest/src/SnootyDataSource.test.ts
@@ -9,11 +9,6 @@ import {
 } from "./SnootyDataSource";
 import { sampleSnootyMetadata } from "./test_data/snooty_sample_metadata";
 import { snootyAstToMd } from "./snootyAstToMd";
-import {
-  SnootyProjectsInfo,
-  makeSnootyProjectsInfo,
-  prepareSnootySources,
-} from "./SnootyProjectsInfo";
 
 jest.setTimeout(15000);
 
@@ -107,66 +102,6 @@ describe("SnootyDataSource", () => {
         tags: ["docs", "manual"],
         url: "https://mongodb.com/docs/v6.0/administration/change-streams-production-recommendations/how-to-index/",
       });
-    });
-  });
-  describe("SnootyProjectsInfo", () => {
-    let projectsInfo: SnootyProjectsInfo | undefined;
-    beforeAll(async () => {
-      projectsInfo = await makeSnootyProjectsInfo({
-        snootyDataApiBaseUrl,
-      });
-    });
-    afterAll(() => {
-      projectsInfo = undefined;
-    });
-
-    it("gets project base url", async () => {
-      const baseUrl = await projectsInfo?.getBaseUrl({
-        projectName: "docs",
-        branchName: "v4.4",
-      });
-      expect(baseUrl).toBe("https://mongodb.com/docs/v4.4");
-    });
-    it("throws for invalid branch", async () => {
-      const baseUrlPromise = projectsInfo?.getBaseUrl({
-        projectName: "docs",
-        branchName: "not-a-branch",
-      });
-      await expect(baseUrlPromise).rejects.toThrow();
-    });
-    it("throws for invalid project", async () => {
-      const baseUrlPromise = projectsInfo?.getBaseUrl({
-        projectName: "not-a-project",
-        branchName: "v4.4",
-      });
-      await expect(baseUrlPromise).rejects.toThrow();
-    });
-  });
-  describe("prepareSnootySources", () => {
-    it("allows override baseUrl", async () => {
-      const sources = await prepareSnootySources({
-        projects: [
-          {
-            type: "snooty",
-            name: "cloud-docs",
-            currentBranch: "master",
-            tags: ["atlas", "docs"],
-            // No override
-          },
-          {
-            type: "snooty",
-            name: "cloud-docs",
-            currentBranch: "master",
-            tags: ["atlas", "docs"],
-            baseUrl: "https://override.example.com", // Override
-          },
-        ],
-        snootyDataApiBaseUrl,
-      });
-      expect((sources[0] as any).baseUrl).toBe(
-        "https://mongodb.com/docs/atlas/"
-      );
-      expect((sources[1] as any).baseUrl).toBe("https://override.example.com/");
     });
   });
 });

--- a/ingest/src/SnootyDataSource.ts
+++ b/ingest/src/SnootyDataSource.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { createInterface } from "readline";
 import { Page } from "chat-core";
 import fetch from "node-fetch";
@@ -49,11 +48,11 @@ export type SnootyPageData = {
 
 export type SnootyProjectConfig = ProjectBase & {
   type: "snooty";
+
   /**
-   * Git branch name for the current (search indexed) version of the site
-   * @example "v4.10"
+    Git branch name for the current (search indexed) version of the site.
+    @example "v4.10"
    */
-  // TODO: we won't need this when it's added to the Snooty Data API (https://jira.mongodb.org/browse/DOP-3860)
   currentBranch: string;
 
   // TODO: we don't need the following config option yet, but we will when we
@@ -91,12 +90,19 @@ export const makeSnootyDataSource = async ({
   name: sourceName,
   project,
   snootyDataApiBaseUrl,
-}: MakeSnootyDataSourceArgs): Promise<DataSource> => {
+}: MakeSnootyDataSourceArgs): Promise<
+  DataSource & {
+    _baseUrl: string;
+    _currentBranch: string;
+    _snootyProjectName: string;
+  }
+> => {
   const { baseUrl, currentBranch, name: snootyProjectName, tags } = project;
   return {
-    baseUrl,
-    currentBranch,
-    snootyProjectName,
+    // Additional members for testing purposes
+    _baseUrl: baseUrl,
+    _currentBranch: currentBranch,
+    _snootyProjectName: snootyProjectName,
     name: sourceName,
     async fetchPages() {
       // TODO: The manifest can be quite large (>100MB) so this could stand to
@@ -153,44 +159,51 @@ export const makeSnootyDataSource = async ({
       await Promise.allSettled(linePromises);
       return pages;
     },
-  } as DataSource;
+  };
 };
 
 /**
- * Branch with site
+  Branch with site
  */
 export interface Branch {
   /**
-   * Name of git branch
-   * @example "master"
+    Name of git branch
+    @example "master"
    */
   gitBranchName: string;
+
   /**
-   * Whether or not the branch is active. Note that this is either a boolean or a string "true"
-   * For more context, see https://jira.mongodb.org/browse/DOP-3862
-   * @example true | "true"
+    Whether or not the branch is active.
+    @example true
    */
-  active: boolean | "true";
+  active: boolean;
+
   /**
-   * Base URL of the site
-   * @example "https://mongodb.com/docs/kotlin/coroutine/upcoming"
+    Base URL of the site
+    @example "https://mongodb.com/docs/kotlin/coroutine/upcoming"
    */
   fullUrl: string;
+
+  /**
+    Whether this is the 'current, active branch' (rather than a previous or
+    upcoming version).
+   */
+  isStableBranch: boolean;
 }
 
 export interface SnootyProject {
   /**
-   * Snooty repo name
-   * @example "docs-kotlin"
+    Snooty repo name
+    @example "docs-kotlin"
    */
   repoName: string;
   /**
-   * Snooty project name
-   * @example "kotlin"
+    Snooty project name
+    @example "kotlin"
    */
   project: string;
   /**
-   * Branches of repo that correspond to a site
+    Branches of repo that correspond to a site
    */
   branches: Branch[];
 }

--- a/ingest/src/SnootyProjectsInfo.test.ts
+++ b/ingest/src/SnootyProjectsInfo.test.ts
@@ -1,0 +1,158 @@
+import { strict as assert } from "assert";
+import {
+  GetSnootyProjectsResponse,
+  makeSnootyProjectsInfo,
+  prepareSnootySources,
+} from "./SnootyProjectsInfo";
+
+const snootyDataApiBaseUrl = "https://snooty-data-api.mongodb.com/prod/";
+
+describe("SnootyProjectsInfo", () => {
+  let projectsInfo:
+    | Awaited<ReturnType<typeof makeSnootyProjectsInfo>>
+    | undefined;
+  beforeAll(async () => {
+    projectsInfo = await makeSnootyProjectsInfo({
+      snootyDataApiBaseUrl,
+    });
+  });
+  afterAll(() => {
+    projectsInfo = undefined;
+  });
+
+  it("gets project base url", async () => {
+    const baseUrl = await projectsInfo?.getBaseUrl({
+      projectName: "docs",
+      branchName: "v4.4",
+    });
+    expect(baseUrl).toBe("https://mongodb.com/docs/v4.4");
+  });
+  it("throws for invalid branch", async () => {
+    const baseUrlPromise = projectsInfo?.getBaseUrl({
+      projectName: "docs",
+      branchName: "not-a-branch",
+    });
+    await expect(baseUrlPromise).rejects.toThrow();
+  });
+  it("throws for invalid project", async () => {
+    const baseUrlPromise = projectsInfo?.getBaseUrl({
+      projectName: "not-a-project",
+      branchName: "v4.4",
+    });
+    await expect(baseUrlPromise).rejects.toThrow();
+  });
+
+  it("corrects any string 'true' instead of boolean", async () => {
+    // First let's check whether the original data had some errors
+    const response = await fetch(new URL("projects", snootyDataApiBaseUrl));
+    const { data }: GetSnootyProjectsResponse = await response.json();
+    const findBadBoolBranches = (theData?: typeof data) =>
+      theData?.find(({ branches }) => {
+        return (
+          branches.find(({ active }) => (active as unknown) === "true") !==
+          undefined
+        );
+      });
+
+    const branch = data[0].branches[0];
+
+    // Check implementation of findBadBoolBranches
+    expect(
+      findBadBoolBranches([
+        {
+          project: "x",
+          repoName: "x",
+          branches: [
+            {
+              active: "true" as unknown as boolean,
+            } as unknown as typeof branch,
+          ],
+        },
+      ])
+    ).toBeDefined();
+    expect(
+      findBadBoolBranches([
+        {
+          project: "x",
+          repoName: "x",
+          branches: [
+            {
+              active: true,
+            } as unknown as typeof branch,
+          ],
+        },
+      ])
+    ).toBeUndefined();
+
+    if (findBadBoolBranches(data) !== undefined) {
+      console.log("Found bad bools in Snooty Data API response.");
+    }
+    expect(findBadBoolBranches(projectsInfo?._data)).toBeUndefined();
+  });
+
+  describe("prepareSnootySources", () => {
+    it("allows override baseUrl", async () => {
+      const sources = await prepareSnootySources({
+        projects: [
+          {
+            type: "snooty",
+            name: "cloud-docs",
+            currentBranch: "master",
+            tags: ["atlas", "docs"],
+            // No override
+          },
+          {
+            type: "snooty",
+            name: "cloud-docs",
+            currentBranch: "master",
+            tags: ["atlas", "docs"],
+            baseUrl: "https://override.example.com", // Override
+          },
+        ],
+        snootyDataApiBaseUrl,
+      });
+      expect(sources[0]._baseUrl).toBe("https://mongodb.com/docs/atlas/");
+      expect(sources[1]._baseUrl).toBe("https://override.example.com/");
+    });
+
+    it("allows override currentBranch", async () => {
+      // Find some real branch names to test with in the data so that
+      // prepareSnootySources() doesn't throw exceptions about unknown branches.
+      const testProject = projectsInfo?._data.find(
+        ({ branches }) => branches.length > 1
+      );
+      expect(testProject).toBeDefined();
+      assert(testProject !== undefined);
+      const actualCurrentBranch = testProject?.branches.find(
+        ({ isStableBranch }) => isStableBranch
+      );
+      expect(actualCurrentBranch).toBeDefined();
+      const someOtherBranch = testProject?.branches.find(
+        ({ isStableBranch }) => !isStableBranch
+      );
+      assert(someOtherBranch !== undefined);
+      const sources = await prepareSnootySources({
+        projects: [
+          {
+            type: "snooty",
+            name: testProject.project,
+            tags: [],
+            // No currentBranch override
+          },
+          {
+            type: "snooty",
+            name: testProject.project,
+            tags: [],
+            // currentBranch override
+            currentBranch: someOtherBranch.gitBranchName,
+          },
+        ],
+        snootyDataApiBaseUrl,
+      });
+      expect(sources[0]._currentBranch).toBe(
+        actualCurrentBranch?.gitBranchName
+      );
+      expect(sources[1]._currentBranch).toBe(someOtherBranch.gitBranchName);
+    });
+  });
+});

--- a/ingest/src/projectSources.ts
+++ b/ingest/src/projectSources.ts
@@ -1,11 +1,19 @@
 import { DevCenterProjectConfig } from "./DevCenterDataSource";
 import { SnootyProjectConfig } from "./SnootyDataSource";
 
-// 'baseUrl' to be filled in by the Snooty Data API GET projects endpoint -
-// unless you want to specify one to override whatever the Data API says
-export const snootyProjectConfig: (Omit<SnootyProjectConfig, "baseUrl"> & {
+// `baseUrl` and `currentBranch` to be filled in by the Snooty Data API GET
+// projects endpoint - unless you want to specify one to override whatever the
+// Data API says. `currentBranch` will be the name of the first branch entry has
+// `isStableBranch` set to true in the Data API response.
+export type LocallySpecifiedSnootyProjectConfig = Omit<
+  SnootyProjectConfig,
+  "baseUrl" | "currentBranch"
+> & {
   baseUrl?: string;
-})[] = [
+  currentBranch?: string;
+};
+
+export const snootyProjectConfig: LocallySpecifiedSnootyProjectConfig[] = [
   {
     type: "snooty",
     name: "cloud-docs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1804,6 +1804,7 @@
         "@typescript-eslint/parser": "^5",
         "eslint": "^8",
         "eslint-config-prettier": "^8",
+        "eslint-plugin-jsdoc": "^46.4.5",
         "eslint-plugin-prettier": "^4",
         "eslint-plugin-tsdoc": "^0.2.14",
         "jest": "^29.5.0",
@@ -5058,6 +5059,20 @@
     "node_modules/@emotion/weak-memoize": {
       "version": "0.3.1",
       "license": "MIT"
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
+      "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.19",
@@ -12227,6 +12242,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "dev": true,
@@ -13096,6 +13120,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "dev": true,
@@ -13708,6 +13744,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/common-ancestor-path": {
@@ -15754,6 +15799,41 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "46.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.5.tgz",
+      "integrity": "sha512-HjTuxqDYplAQFu29F3MHFCDDBgeqOxPXI6TyBhL0u2rr4XntJ0z3C9PmJvpjFscKdHwkZDN/0l1QCG0QwyRi4g==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.39.4",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.4",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -18103,6 +18183,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "license": "MIT",
@@ -19791,6 +19886,15 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-31757

## Changes

- Loads the current branch from the Snooty Data API if not specified in the configuration
- Moves data format fixing logic to the actual loading of the data rather than in the TypeScript type (which should be more idealized)
- Also adds JSDoc linting to avoid asterisks on every comment block line

## Notes

- 
