### PR TITLE
(DOCSP-32066): Q&A server reduce amount of backoff on embedding

### DIFF
--- a/chat-server/src/config.ts
+++ b/chat-server/src/config.ts
@@ -103,6 +103,10 @@ export const config: AppConfig = {
     apiVersion: OPENAI_EMBEDDING_MODEL_VERSION,
     baseUrl: OPENAI_ENDPOINT,
     deployment: OPENAI_EMBEDDING_DEPLOYMENT,
+    backoffOptions: {
+      numOfAttempts: 3,
+      maxDelay: 5000,
+    },
   },
   embeddedContentStore: {
     connectionUri: MONGODB_CONNECTION_URI,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32066

## Changes

- Reduce amount of backoff when embedding fails in QA server. 

## Notes

- Added b/c yesterday we had an issue where the QA server was going into exponential backoff and getting timed out when the embedding failed 
