### PR TITLE
Define engines to remove EBADENGINE warning

### DIFF
--- a/chat-core/package.json
+++ b/chat-core/package.json
@@ -2,6 +2,13 @@
   "name": "chat-core",
   "version": "0.0.1",
   "description": "Common elements used by the chatbot components.",
+  "author": "MongoDB, Inc.",
+  "license": "MIT",
+  "keywords": [],
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "main": "./build/index.js",
   "scripts": {
     "clean": "rm -rf build",
@@ -10,8 +17,6 @@
     "test": "jest",
     "docs": "npx typedoc --excludePrivate --exclude '**/*.test.ts' --out docs src"
   },
-  "author": "MongoDB, Inc.",
-  "license": "MIT",
   "devDependencies": {
     "@babel/preset-typescript": "^7",
     "@babel/types": "^7",

--- a/chat-server/package.json
+++ b/chat-server/package.json
@@ -2,6 +2,13 @@
   "name": "chat-server",
   "version": "1.0.2",
   "description": "Q&A server for the MongoDB Docs AI chatbot.",
+  "author": "MongoDB, Inc.",
+  "license": "ISC",
+  "keywords": [],
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "main": "index.js",
   "scripts": {
     "build": "rm -rf ./dist/ && tsc",
@@ -14,13 +21,6 @@
     "test:llmQualitative": "jest --config jest.config.llmQualitative.js --forceExit",
     "release": "release-it"
   },
-  "engines": {
-    "node": "^18",
-    "npm": "8.*"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.3",
     "chat-core": "file:../chat-core",

--- a/chat-ui/package.json
+++ b/chat-ui/package.json
@@ -1,9 +1,14 @@
 {
   "name": "mongodb-chatbot-ui",
+  "version": "0.0.0",
   "description": "UI for the MongoDB AI Chatbot",
   "author": "MongoDB, Inc.",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "keywords": [],
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "type": "module",
   "files": [
     "dist",

--- a/ingest/package.json
+++ b/ingest/package.json
@@ -2,6 +2,13 @@
   "name": "ingest",
   "version": "0.0.6-0",
   "description": "Ingests data sources and stores embeddings.",
+  "author": "",
+  "license": "ISC",
+  "keywords": [],
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "main": "./build/main.js",
   "bin": {
     "ingest": "./build/main.js"
@@ -15,8 +22,6 @@
     "docs": "npx typedoc --excludePrivate --exclude '**/*.test.ts' --out docs src",
     "release": "release-it"
   },
-  "author": "",
-  "license": "ISC",
   "devDependencies": {
     "@babel/preset-typescript": "^7",
     "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,10 @@
         "ts-node": "^10",
         "typedoc": "^0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "chat-core/node_modules/dotenv": {
@@ -137,8 +141,8 @@
         "yaml": "^2.3.1"
       },
       "engines": {
-        "node": "^18",
-        "npm": "8.*"
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "chat-server/node_modules/@types/jest": {
@@ -294,6 +298,10 @@
         "vite": "^4.4.7",
         "vite-plugin-libcss": "^1.1.0",
         "vite-plugin-node-polyfills": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "chat-ui/node_modules/@esbuild/android-arm": {
@@ -1089,6 +1097,10 @@
         "ts-jest": "^29.1.0",
         "typedoc": "^0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "ingest/node_modules/@anthropic-ai/sdk": {
@@ -30990,8 +31002,8 @@
         "typescript": "^5.0.3"
       },
       "engines": {
-        "node": "^18",
-        "npm": "8.*"
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "seed-content/node_modules/dotenv": {

--- a/seed-content/package.json
+++ b/seed-content/package.json
@@ -2,6 +2,13 @@
   "name": "seed-content",
   "version": "1.0.0",
   "description": "Tool that seeds content in the database for dev, test, and staging.",
+  "author": "",
+  "license": "ISC",
+  "keywords": [],
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "main": "build/index.js",
   "scripts": {
     "build": "rm -rf ./build/ && tsc",
@@ -10,13 +17,6 @@
     "seed-content:staging": "npm run build && node ./build/index.js .env.staging",
     "seed-content:qa": "npm run build && node ./build/index.js .env.qa"
   },
-  "engines": {
-    "node": "^18",
-    "npm": "8.*"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "chat-core": "file:../chat-core",
     "common-tags": "^1.8.2",


### PR DESCRIPTION
## Changes

- Define a consistent `engines` field across all of our `package.json` files + use a consistent format
