### PR TITLE
(DOCSP-32206): Strip comments from rst -> md

### DIFF
--- a/ingest/src/snootyAstToMd.test.ts
+++ b/ingest/src/snootyAstToMd.test.ts
@@ -194,140 +194,15 @@ Stop and fail the aggregation operation. Any changes to the output collection fr
   });
 
   it("renders HTML tables with multiple header rows", () => {
-    const ast: SnootyNode = {
-      type: "root",
-      position: { start: { line: 0 } },
-      children: [
-        {
-          type: "directive",
-          children: [
-            {
-              type: "list",
-              children: [
-                {
-                  type: "listItem",
-                  children: [
-                    {
-                      type: "list",
-                      children: [
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "h1",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "h2",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  type: "listItem",
-                  children: [
-                    {
-                      type: "list",
-                      children: [
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "h3",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "h4",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  type: "listItem",
-                  children: [
-                    {
-                      type: "list",
-                      children: [
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "d1",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                        {
-                          type: "listItem",
-                          children: [
-                            {
-                              type: "paragraph",
-                              children: [
-                                {
-                                  type: "text",
-                                  value: "d2",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          name: "list-table",
-          options: {
-            "header-rows": 2,
-          },
-        },
-      ],
-    };
+    const ast: SnootyNode = JSON.parse(
+      readFileSync(
+        Path.resolve(
+          __dirname,
+          "./test_data/samplePageWithMultiHeaderTableAst.json"
+        ),
+        "utf-8"
+      )
+    );
     const result = snootyAstToMd(ast, {
       baseUrl: "/",
     });
@@ -363,6 +238,48 @@ d2
 </td>
 </tr>
 </table>`;
+    expect(result).toBe(expected);
+  });
+
+  it("strips comments", () => {
+    const ast: SnootyNode = JSON.parse(
+      readFileSync(
+        Path.resolve(__dirname, "./test_data/samplePageWithCommentAst.json"),
+        "utf-8"
+      )
+    );
+    const result = snootyAstToMd(ast, {
+      baseUrl: "/",
+    });
+    const expected = `# Data Model Examples and Patterns
+
+For additional patterns and use cases, see also: Building with Patterns
+
+The following documents provide overviews of various data modeling patterns and common schema design considerations:
+
+Examples for modeling relationships between documents.
+
+Presents a data model that uses embedded documents to describe one-to-one relationships between connected data.
+
+Presents a data model that uses embedded documents to describe one-to-many relationships between connected data.
+
+Presents a data model that uses references to describe one-to-many relationships between documents.
+
+Examples for modeling tree structures.
+
+Presents a data model that organizes documents in a tree-like structure by storing references to "parent" nodes in "child" nodes.
+
+Presents a data model that organizes documents in a tree-like structure by storing references to "child" nodes in "parent" nodes.
+
+See Model Tree Structures for additional examples of data models for tree structures.
+
+Examples for models for specific application contexts.
+
+Illustrates how embedding fields related to an atomic update within the same document ensures that the fields are in sync.
+
+Describes one method for supporting keyword search by storing keywords in an array in the same document as the text field. Combined with a multi-key index, this pattern can support application's keyword search operations.
+
+`;
     expect(result).toBe(expected);
   });
 

--- a/ingest/src/snootyAstToMd.ts
+++ b/ingest/src/snootyAstToMd.ts
@@ -49,6 +49,9 @@ export const snootyAstToMd = (
 
   // parent nodes
   switch (node.type) {
+    case "comment":
+      // Do not render comments
+      break;
     case "section":
       if (node.children[0].type === "heading") {
         parentHeadingLevel++;

--- a/ingest/src/test_data/samplePageWithCommentAst.json
+++ b/ingest/src/test_data/samplePageWithCommentAst.json
@@ -1,0 +1,725 @@
+{
+  "type": "root",
+  "position": { "start": { "line": 0 } },
+  "children": [
+    {
+      "type": "target",
+      "position": { "start": { "line": 0 } },
+      "children": [
+        {
+          "type": "target_identifier",
+          "position": { "start": { "line": 0 } },
+          "children": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 5 } },
+              "value": "Data Model Examples and Patterns"
+            }
+          ],
+          "ids": ["data-modeling-patterns"]
+        }
+      ],
+      "domain": "std",
+      "name": "label",
+      "html_id": "std-label-data-modeling-patterns"
+    },
+    {
+      "type": "target",
+      "position": { "start": { "line": 1 } },
+      "children": [
+        {
+          "type": "target_identifier",
+          "position": { "start": { "line": 1 } },
+          "children": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 5 } },
+              "value": "Data Model Examples and Patterns"
+            }
+          ],
+          "ids": ["data-modeling-examples"]
+        }
+      ],
+      "domain": "std",
+      "name": "label",
+      "html_id": "std-label-data-modeling-examples"
+    },
+    {
+      "type": "section",
+      "position": { "start": { "line": 5 } },
+      "children": [
+        {
+          "type": "heading",
+          "position": { "start": { "line": 5 } },
+          "children": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 5 } },
+              "value": "Data Model Examples and Patterns"
+            }
+          ],
+          "id": "data-model-examples-and-patterns"
+        },
+        {
+          "type": "directive",
+          "position": { "start": { "line": 7 } },
+          "children": [],
+          "domain": "",
+          "name": "default-domain",
+          "argument": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 7 } },
+              "value": "mongodb"
+            }
+          ]
+        },
+        {
+          "type": "directive",
+          "position": { "start": { "line": 9 } },
+          "children": [],
+          "domain": "",
+          "name": "contents",
+          "argument": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 9 } },
+              "value": "On this page"
+            }
+          ],
+          "options": {
+            "local": true,
+            "backlinks": "none",
+            "depth": 1,
+            "class": "singlecol"
+          }
+        },
+        {
+          "type": "directive",
+          "position": { "start": { "line": 15 } },
+          "children": [
+            {
+              "type": "paragraph",
+              "position": { "start": { "line": 17 } },
+              "children": [
+                {
+                  "type": "text",
+                  "position": { "start": { "line": 17 } },
+                  "value": "For additional patterns and use cases, see also: "
+                },
+                {
+                  "type": "reference",
+                  "position": { "start": { "line": 17 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 17 } },
+                      "value": "Building with\nPatterns"
+                    }
+                  ],
+                  "refuri": "https://www.mongodb.com/blog/post/building-with-patterns-a-summary"
+                },
+                {
+                  "type": "named_reference",
+                  "position": { "start": { "line": 17 } },
+                  "refname": "Building with Patterns",
+                  "refuri": "https://www.mongodb.com/blog/post/building-with-patterns-a-summary"
+                }
+              ]
+            }
+          ],
+          "domain": "",
+          "name": "seealso",
+          "argument": []
+        },
+        {
+          "type": "comment",
+          "position": { "start": { "line": 23 } },
+          "children": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 23 } },
+              "value": "/tutorial/model-tree-structures.txt is just a composite page that\nincludes all the tree structure pages for easy overview."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "position": { "start": { "line": 24 } },
+          "children": [
+            {
+              "type": "text",
+              "position": { "start": { "line": 24 } },
+              "value": "The following documents provide overviews of various data modeling\npatterns and common schema design considerations:"
+            }
+          ]
+        },
+        {
+          "type": "definitionList",
+          "position": { "start": { "line": 5 } },
+          "children": [
+            {
+              "type": "definitionListItem",
+              "position": { "start": { "line": 43 } },
+              "children": [
+                {
+                  "type": "paragraph",
+                  "position": { "start": { "line": 28 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 28 } },
+                      "value": "Examples for modeling relationships between documents."
+                    }
+                  ]
+                },
+                {
+                  "type": "definitionList",
+                  "position": { "start": { "line": 43 } },
+                  "children": [
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 33 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 31 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 31 } },
+                              "value": "Presents a data model that uses "
+                            },
+                            {
+                              "type": "ref_role",
+                              "position": { "start": { "line": 31 } },
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "position": { "start": { "line": 31 } },
+                                  "value": "embedded documents"
+                                }
+                              ],
+                              "domain": "std",
+                              "name": "label",
+                              "target": "data-modeling-embedding",
+                              "flag": "",
+                              "fileid": [
+                                "core/data-model-design",
+                                "std-label-data-modeling-embedding"
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 31 } },
+                              "value": " to describe one-to-one relationships\nbetween connected data."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 33 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 4 } },
+                              "value": "Model One-to-One Relationships with Embedded Documents"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-embedded-one-to-one-relationships-between-documents",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 38 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 36 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 36 } },
+                              "value": "Presents a data model that uses "
+                            },
+                            {
+                              "type": "ref_role",
+                              "position": { "start": { "line": 36 } },
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "position": { "start": { "line": 36 } },
+                                  "value": "embedded documents"
+                                }
+                              ],
+                              "domain": "std",
+                              "name": "label",
+                              "target": "data-modeling-embedding",
+                              "flag": "",
+                              "fileid": [
+                                "core/data-model-design",
+                                "std-label-data-modeling-embedding"
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 36 } },
+                              "value": " to describe one-to-many\nrelationships between connected data."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 38 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 4 } },
+                              "value": "Model One-to-Many Relationships with Embedded Documents"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-embedded-one-to-many-relationships-between-documents",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 43 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 41 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 41 } },
+                              "value": "Presents a data model that uses "
+                            },
+                            {
+                              "type": "ref_role",
+                              "position": { "start": { "line": 41 } },
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "position": { "start": { "line": 41 } },
+                                  "value": "references"
+                                }
+                              ],
+                              "domain": "std",
+                              "name": "label",
+                              "target": "data-modeling-referencing",
+                              "flag": "",
+                              "fileid": [
+                                "core/data-model-design",
+                                "std-label-data-modeling-referencing"
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 41 } },
+                              "value": " to describe one-to-many\nrelationships between documents."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 43 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 4 } },
+                              "value": "Model One-to-Many Relationships with Document References"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-referenced-one-to-many-relationships-between-documents",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "term": [
+                {
+                  "type": "ref_role",
+                  "position": { "start": { "line": 43 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 2 } },
+                      "value": "Model Relationships Between Documents"
+                    }
+                  ],
+                  "domain": "std",
+                  "name": "doc",
+                  "target": "",
+                  "flag": "",
+                  "fileid": ["/applications/data-models-relationships", ""]
+                }
+              ]
+            },
+            {
+              "type": "definitionListItem",
+              "position": { "start": { "line": 61 } },
+              "children": [
+                {
+                  "type": "paragraph",
+                  "position": { "start": { "line": 46 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 46 } },
+                      "value": "Examples for modeling tree structures."
+                    }
+                  ]
+                },
+                {
+                  "type": "definitionList",
+                  "position": { "start": { "line": 61 } },
+                  "children": [
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 52 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 49 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 49 } },
+                              "value": "Presents a data model that organizes documents in a tree-like\nstructure by storing "
+                            },
+                            {
+                              "type": "ref_role",
+                              "position": { "start": { "line": 49 } },
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "position": { "start": { "line": 49 } },
+                                  "value": "references"
+                                }
+                              ],
+                              "domain": "std",
+                              "name": "label",
+                              "target": "data-modeling-referencing",
+                              "flag": "",
+                              "fileid": [
+                                "core/data-model-design",
+                                "std-label-data-modeling-referencing"
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 49 } },
+                              "value": " to \"parent\" nodes in \"child\"\nnodes."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 52 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 2 } },
+                              "value": "Model Tree Structures with Parent References"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-tree-structures-with-parent-references",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 58 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 55 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 55 } },
+                              "value": "Presents a data model that organizes documents in a tree-like\nstructure by storing "
+                            },
+                            {
+                              "type": "ref_role",
+                              "position": { "start": { "line": 55 } },
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "position": { "start": { "line": 55 } },
+                                  "value": "references"
+                                }
+                              ],
+                              "domain": "std",
+                              "name": "label",
+                              "target": "data-modeling-referencing",
+                              "flag": "",
+                              "fileid": [
+                                "core/data-model-design",
+                                "std-label-data-modeling-referencing"
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 55 } },
+                              "value": " to \"child\" nodes in \"parent\"\nnodes."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 58 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 2 } },
+                              "value": "Model Tree Structures with Child References"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-tree-structures-with-child-references",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "paragraph",
+                  "position": { "start": { "line": 60 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 60 } },
+                      "value": "See "
+                    },
+                    {
+                      "type": "ref_role",
+                      "position": { "start": { "line": 60 } },
+                      "children": [
+                        {
+                          "type": "text",
+                          "position": { "start": { "line": 2 } },
+                          "value": "Model Tree Structures"
+                        }
+                      ],
+                      "domain": "std",
+                      "name": "doc",
+                      "target": "",
+                      "flag": "",
+                      "fileid": [
+                        "/applications/data-models-tree-structures",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 60 } },
+                      "value": " for additional\nexamples of data models for tree structures."
+                    }
+                  ]
+                }
+              ],
+              "term": [
+                {
+                  "type": "ref_role",
+                  "position": { "start": { "line": 61 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 2 } },
+                      "value": "Model Tree Structures"
+                    }
+                  ],
+                  "domain": "std",
+                  "name": "doc",
+                  "target": "",
+                  "flag": "",
+                  "fileid": ["/applications/data-models-tree-structures", ""]
+                }
+              ]
+            },
+            {
+              "type": "definitionListItem",
+              "position": { "start": { "line": 75 } },
+              "children": [
+                {
+                  "type": "paragraph",
+                  "position": { "start": { "line": 64 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 64 } },
+                      "value": "Examples for models for specific application contexts."
+                    }
+                  ]
+                },
+                {
+                  "type": "definitionList",
+                  "position": { "start": { "line": 75 } },
+                  "children": [
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 68 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 67 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 67 } },
+                              "value": "Illustrates how embedding fields related to an atomic update\nwithin the same document ensures that the fields are in sync."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 68 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 4 } },
+                              "value": "Model Data for Atomic Operations"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-data-for-atomic-operations",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "definitionListItem",
+                      "position": { "start": { "line": 75 } },
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "position": { "start": { "line": 71 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 71 } },
+                              "value": "Describes one method for supporting keyword search by storing\nkeywords in an array in the same document as the text field.\nCombined with a multi-key index, this pattern can support\napplication's keyword search operations."
+                            }
+                          ]
+                        }
+                      ],
+                      "term": [
+                        {
+                          "type": "ref_role",
+                          "position": { "start": { "line": 75 } },
+                          "children": [
+                            {
+                              "type": "text",
+                              "position": { "start": { "line": 2 } },
+                              "value": "Model Data to Support Keyword Search"
+                            }
+                          ],
+                          "domain": "std",
+                          "name": "doc",
+                          "target": "",
+                          "flag": "",
+                          "fileid": [
+                            "/tutorial/model-data-for-keyword-search",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "term": [
+                {
+                  "type": "ref_role",
+                  "position": { "start": { "line": 75 } },
+                  "children": [
+                    {
+                      "type": "text",
+                      "position": { "start": { "line": 2 } },
+                      "value": "Model Specific Application Contexts"
+                    }
+                  ],
+                  "domain": "std",
+                  "name": "doc",
+                  "target": "",
+                  "flag": "",
+                  "fileid": ["/applications/data-models-applications", ""]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "directive",
+          "position": { "start": { "line": 77 } },
+          "children": [],
+          "domain": "",
+          "name": "toctree",
+          "argument": [],
+          "options": { "titlesonly": true, "hidden": true },
+          "entries": [
+            { "slug": "/applications/data-models-relationships" },
+            { "slug": "/applications/data-models-tree-structures" },
+            { "slug": "/applications/data-models-applications" }
+          ]
+        }
+      ]
+    }
+  ],
+  "fileid": "applications/data-models.txt"
+}

--- a/ingest/src/test_data/samplePageWithMultiHeaderTableAst.json
+++ b/ingest/src/test_data/samplePageWithMultiHeaderTableAst.json
@@ -1,0 +1,134 @@
+{
+  "type": "root",
+  "position": { "start": { "line": 0 } },
+  "children": [
+    {
+      "type": "directive",
+      "children": [
+        {
+          "type": "list",
+          "children": [
+            {
+              "type": "listItem",
+              "children": [
+                {
+                  "type": "list",
+                  "children": [
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "h1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "h2"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "children": [
+                {
+                  "type": "list",
+                  "children": [
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "h3"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "h4"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "children": [
+                {
+                  "type": "list",
+                  "children": [
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "d1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "d2"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "name": "list-table",
+      "options": {
+        "header-rows": 2
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32206

## Changes

- Skips comment nodes in rst parser

## Notes

- Also added the external sample file for another test that I apparently forgot to push to a previous PR
- Is there something special about definition lists that we need to handle?
