### PR TITLE
(DOCSP-32247): Fix preprocessed content not added to DB

### DIFF
--- a/chat-server/src/services/conversations.test.ts
+++ b/chat-server/src/services/conversations.test.ts
@@ -60,6 +60,34 @@ describe("Conversations Service", () => {
     expect(conversationInDb?.messages).toHaveLength(2);
     expect(conversationInDb?.messages[1].content).toStrictEqual(content);
   });
+  test("Should add a message to a conversation with optional fields", async () => {
+    const ipAddress = new BSON.UUID().toString();
+    const conversation = await conversationsService.create({
+      ipAddress,
+    });
+    const content = "Tell me about MongoDB";
+    const preprocessedContent = "<preprocessed> Tell me about MongoDB";
+    const references = [{ title: "ref", url: "ref.com" }];
+    const newMessage = await conversationsService.addConversationMessage({
+      conversationId: conversation._id,
+      role: "user",
+      content,
+      preprocessedContent,
+      references,
+    });
+    expect(newMessage.content).toBe(content);
+
+    const conversationInDb = await mongodb.db
+      .collection<Conversation>("conversations")
+      .findOne({ _id: conversation._id });
+    expect(conversationInDb).toHaveProperty("messages");
+    expect(conversationInDb?.messages).toHaveLength(2);
+    expect(conversationInDb?.messages[1].content).toStrictEqual(content);
+    expect(conversationInDb?.messages[1]?.preprocessedContent).toStrictEqual(
+      preprocessedContent
+    );
+    expect(conversationInDb?.messages[1]?.references).toStrictEqual(references);
+  });
   test("Should find a conversation by id", async () => {
     const ipAddress = new BSON.UUID().toString();
     const conversation = await conversationsService.create({

--- a/chat-server/src/services/conversations.ts
+++ b/chat-server/src/services/conversations.ts
@@ -10,7 +10,7 @@ export interface Message {
   /** Message that occurs in the conversation. */
   content: string;
   /** Only used when role is "user". The preprocessed content of the message that is sent to vector search. */
-  preProcessedContent?: string;
+  preprocessedContent?: string;
   /** Set to `true` if the user liked the response, `false` if the user didn't like the response. No value if user didn't rate the response. Note that only messages with `role: "assistant"` can be rated. */
   rating?: boolean;
   /** The date the message was created. */
@@ -104,12 +104,18 @@ export function makeConversationsService(
       conversationId,
       content,
       role,
+      preprocessedContent,
       references,
     }: AddConversationMessageParams) {
-      const newMessage = createMessageFromOpenAIChatMessage({ role, content });
-      if (references) {
-        newMessage.references = references;
-      }
+      const newMessage = createMessageFromOpenAIChatMessage({
+        role,
+        content,
+      });
+      Object.assign(
+        newMessage,
+        preprocessedContent && { preprocessedContent: preprocessedContent },
+        references && { references: references }
+      );
 
       const updateResult = await conversationsCollection.updateOne(
         {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32247

## Changes

- Bug fix: Add `preprocessedContent` to conversations in the DB
- testing for optional fields on conversation messages (having this test would have caught the bug before)
- light code refactoring

## Notes

- `preprocessedContent` was already working in the application, just not being persisted to DB
