### PR TITLE
(DOCSP-32596): Add CORS config to Q&A server

### DIFF
--- a/chat-server/environments/production.yml
+++ b/chat-server/environments/production.yml
@@ -8,6 +8,7 @@ env:
   MONGODB_DATABASE_NAME: docs-chatbot-prod
   VECTOR_SEARCH_INDEX_NAME: default
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
+  ALLOWED_ORIGINS: https://mongodb.com,https://www.mongodb.com
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-prod

--- a/chat-server/environments/staging.yml
+++ b/chat-server/environments/staging.yml
@@ -8,6 +8,7 @@ env:
   MONGODB_DATABASE_NAME: docs-chatbot-staging
   VECTOR_SEARCH_INDEX_NAME: default
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
+  ALLOWED_ORIGINS: https://knowledge.staging.corp.mongodb.com
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-staging

--- a/chat-server/src/AppConfig.ts
+++ b/chat-server/src/AppConfig.ts
@@ -7,6 +7,7 @@ import {
   FindNearestNeighborsOptions,
 } from "chat-core";
 import { QueryPreprocessorFunc } from "./processors/QueryPreprocessorFunc";
+import { CorsOptions } from "cors";
 
 export type EmbedConfig = MakeOpenAiEmbedFuncArgs;
 
@@ -41,4 +42,5 @@ export interface AppConfig {
   mongodb: MongoDbConfig;
   embed: EmbedConfig;
   maxRequestTimeoutMs?: number;
+  corsOptions?: CorsOptions;
 }

--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -88,6 +88,7 @@ export const makeApp = async ({
   findNearestNeighborsOptions,
   searchBoosters,
   userQueryPreprocessor,
+  corsOptions,
 }: {
   embed: EmbedFunc;
   store: EmbeddedContentStore;
@@ -99,11 +100,12 @@ export const makeApp = async ({
   findNearestNeighborsOptions?: Partial<FindNearestNeighborsOptions>;
   searchBoosters?: SearchBooster[];
   userQueryPreprocessor?: QueryPreprocessorFunc;
+  corsOptions?: cors.CorsOptions;
 }): Promise<Express> => {
   const app = express();
   app.use(makeHandleTimeoutMiddleware(maxRequestTimeoutMs));
   app.set("trust proxy", true);
-  app.use(cors()); // TODO: add specific options to only allow certain origins
+  app.use(cors(corsOptions)); // TODO: add specific options to only allow certain origins
   app.use(express.json());
   app.use(reqHandler);
   // TODO: consider only serving this from the staging env

--- a/chat-server/src/config.ts
+++ b/chat-server/src/config.ts
@@ -15,6 +15,8 @@ const {
   OPENAI_CHAT_COMPLETION_DEPLOYMENT,
 } = assertEnvVars(CORE_ENV_VARS);
 
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",") || [];
+
 /**
   Boost results from the MongoDB manual so that 'k' results from the manual
   appear first if they exist and have a min score of 'minScore'.
@@ -133,4 +135,7 @@ export const config: AppConfig = {
     vectorSearchIndexName: VECTOR_SEARCH_INDEX_NAME,
   },
   maxRequestTimeoutMs: 30000,
+  corsOptions: {
+    origin: allowedOrigins,
+  },
 };

--- a/chat-server/src/index.ts
+++ b/chat-server/src/index.ts
@@ -44,6 +44,7 @@ const startServer = async () => {
     searchBoosters: config.conversations?.searchBoosters,
     userQueryPreprocessor: config.conversations?.userQueryPreprocessor,
     maxRequestTimeoutMs: config.maxRequestTimeoutMs,
+    corsOptions: config.corsOptions,
   });
 
   const server = app.listen(PORT, () => {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32596

## Changes

- Add CORS config to Q&A server. Support the vanity URLs on top of Kubernetes
- TODO: test this out

## Notes

-
