### PR TITLE
Allow users to override server URL via props

### DIFF
--- a/chat-ui/src/Chatbot.tsx
+++ b/chat-ui/src/Chatbot.tsx
@@ -170,8 +170,14 @@ function getAvatarVariantForRole(role: Role) {
   return avatarVariant;
 }
 
-export function Chatbot() {
-  const conversation = useConversation();
+export type ChatbotProps = {
+  serverBaseUrl?: string;
+};
+
+export function Chatbot(props: ChatbotProps) {
+  const conversation = useConversation({
+    serverBaseUrl: props.serverBaseUrl,
+  });
   const [initialInputFocused, setInitialInputFocused] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);

--- a/chat-ui/src/services/conversations.ts
+++ b/chat-ui/src/services/conversations.ts
@@ -59,7 +59,7 @@ export class TimeoutError<Data extends object = object> extends Error {
   }
 }
 
-export default class ConversationService {
+export class ConversationService {
   private serverUrl: string;
 
   constructor(config: ConversationServiceConfig) {
@@ -297,6 +297,3 @@ export default class ConversationService {
     });
   }
 }
-export const conversationService = new ConversationService({
-  serverUrl: import.meta.env.VITE_SERVER_BASE_URL,
-});


### PR DESCRIPTION
Small change here to remove the `conversationService` singleton in favor of a memoized conversation service that the user can configure.