### PR TITLE
(DOCSP-32688) Stop dereferencing spec

### DIFF
--- a/ingest/src/chunkOpenApiSpecYaml.test.ts
+++ b/ingest/src/chunkOpenApiSpecYaml.test.ts
@@ -5,7 +5,7 @@ import { handlePage } from "./SnootyDataSource";
 import { chunkOpenApiSpecYaml } from "./chunkOpenApiSpecYaml";
 
 describe("chunkRedocOpenApiSpecYaml()", () => {
-  it("chunks a Redoc OpenAPI spec", async () => {
+  it("chunks a local Redoc OpenAPI spec", async () => {
     const apiSpecPage = JSON.parse(
       fs.readFileSync(
         Path.resolve(__dirname, "./test_data/localOpenApiSpecPage.json"),
@@ -22,7 +22,7 @@ describe("chunkRedocOpenApiSpecYaml()", () => {
       chunkOverlap: 0,
       tokenizer: new GPT3Tokenizer({ type: "gpt3" }),
     });
-    expect(chunks).toHaveLength(40);
+    expect(chunks).toHaveLength(24);
     const chunkTextExpected1 = `---
 resourceName: POST /action/findOne
 openApiSpec: true
@@ -38,5 +38,24 @@ baseUrls:
     description: Find a single document that matches a query.
     x-codeSamples:`;
     expect(chunks[0].text).toContain(chunkTextExpected2);
+  });
+  test("chunks a remote Redoc OpenAPI spec", async () => {
+    const apiSpecPage = JSON.parse(
+      fs.readFileSync(
+        Path.resolve(__dirname, "./test_data/remoteOpenApiSpecPage.json"),
+        "utf-8"
+      )
+    );
+    const result = await handlePage(apiSpecPage.data, {
+      sourceName: "sample-source",
+      baseUrl: "https://example.com",
+      tags: ["a"],
+    });
+    const chunks = await chunkOpenApiSpecYaml(result, {
+      chunkSize: 1250,
+      chunkOverlap: 0,
+      tokenizer: new GPT3Tokenizer({ type: "gpt3" }),
+    });
+    expect(chunks.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32688

## Changes

- No longer dereference the spec b/c it was causing the number of spec chunks to get so long that they could no longer be uploaded to MongoDB in a single transaction, causing the whole ingest service to crash
- Added a basic test for loading in remote specs

## Notes

- Note that this change could theoretically cause a performance regression in handling queries related to the OpenAI specs, as now the specs don't have the contents of their references inline. But I am comfortable with this regression as it's really in an edge case and fixes a bug that causes the whole ingest pipeline to fail.
- Created post-launch ticket for further enhancing spec parsing https://jira.mongodb.org/browse/DOCSP-32708
