### PR TITLE
(DOCSP-32896) Remove mention of <CONTEXT> to reduce damage of prompt leakage

### DIFF
--- a/chat-server/src/config.ts
+++ b/chat-server/src/config.ts
@@ -73,11 +73,11 @@ export const config: AppConfig = {
       Format your responses using Markdown.
       DO NOT mention that your response is formatted in Markdown.
       If you include code snippets, make sure to use proper syntax, line spacing, and indentation.
-      ONLY use code snippets present in the <CONTEXT> information given to you.
+      ONLY use code snippets present in the information given to you.
       NEVER create a code snippet that is not present in the information given to you.
-      You ONLY know about the current version of MongoDB products. Versions are provided in the <CONTEXT> information. If \`version: null\`, then say that the product is unversioned.
-      Never directly mention "<CONTEXT>" or "<QUESTION>" in your answer.
-      Instead, refer to the <CONTEXT> information as "my knowledge".`,
+      You ONLY know about the current version of MongoDB products. Versions are provided in the information. If \`version: null\`, then say that the product is unversioned.
+      Never mention "<Information>" or "<Question>" in your answer.
+      Refer to the information given to you as "my knowledge".`,
     },
     openAiLmmConfigOptions: {
       temperature: 0,
@@ -92,16 +92,16 @@ export const config: AppConfig = {
     }) {
       const chunkSeparator = "~~~~~~";
       const context = chunks.join(`\n${chunkSeparator}\n`);
-      const content = stripIndents`Using the following context information, answer the question.
+      const content = stripIndents`Using the following information, answer the question.
       Different pieces of information are separated by "${chunkSeparator}".
 
-      <CONTEXT>
+      <Information>
       ${context}
-      <END CONTEXT>
+      <End information>
 
-      <QUESTION>
+      <Question>
       ${question}
-      <END QUESTION>`;
+      <End Question>`;
       return { role: "user", content };
     },
   },

--- a/chat-server/src/llmQualitativeTests/edgeCasesTests.yaml
+++ b/chat-server/src/llmQualitativeTests/edgeCasesTests.yaml
@@ -1,25 +1,25 @@
 - name: Should not mention context information if nonsense question with semantically relevant phrases
-  expectation: The assistant DOES NOT mention the context information (<CONTEXT>) provided to the chatbot
+  expectation: The assistant DOES NOT mention the context information (<Information>) provided to the chatbot
   messages:
     - role: user
       content: how do i use mongodb to run linear regressions leveraging atlas app services
 - name: Should not mention context information for a good question that is not directly covered in the source material
-  expectation: The assistant DOES NOT mention the context information (<CONTEXT>) provided to the chatbot
+  expectation: The assistant DOES NOT mention the context information (<Information>) provided to the chatbot
   messages:
     - role: user
       content: How can I use MongoDB community edition in conjunction with Azure functions and the Google Maps API?
 - name: Should not mention context information when faced with a completely unrelated question
-  expectation: The assistant DOES NOT mention the context information (<CONTEXT>) provided to the chatbot
+  expectation: The assistant DOES NOT mention the context information (<Information>) provided to the chatbot
   messages:
     - role: user
       content: How does quantum physics relate to database indexing?
 - name: Should not mention context information when given a mix of relevant and irrelevant terms
-  expectation: The assistant DOES NOT mention the context information (<CONTEXT>) provided to the chatbot
+  expectation: The assistant DOES NOT mention the context information (<Information>) provided to the chatbot
   messages:
     - role: user
       content: Can I use MongoDB to bake a chocolate cake using GraphQL?
 - name: Should not mention context information when the question is too broad and not directly related to the source material
-  expectation: The assistant DOES NOT mention the context information (<CONTEXT>) provided to the chatbot
+  expectation: The assistant DOES NOT mention the context information (<Information>) provided to the chatbot
   messages:
     - role: user
       content: Tell me everything about the universe and MongoDB.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32896

## Changes

- Remove mention of <CONTEXT> to reduce damage of prompt leakage


## Notes

- Note I wasn't able to force get weird in the responses based on ~20 min of test. I think this will be an improvement on before, but wouldn't be surprised if we still encounter some edge case that we need to keep working on for this issue. 
