### PR TITLE
(DOCSP-32914): Stop unindenting context

### DIFF
--- a/chat-server/src/config.ts
+++ b/chat-server/src/config.ts
@@ -92,16 +92,16 @@ export const config: AppConfig = {
     }) {
       const chunkSeparator = "~~~~~~";
       const context = chunks.join(`\n${chunkSeparator}\n`);
-      const content = stripIndents`Using the following information, answer the question.
-      Different pieces of information are separated by "${chunkSeparator}".
+      const content = `Using the following information, answer the question.
+Different pieces of information are separated by "${chunkSeparator}".
 
-      <Information>
-      ${context}
-      <End information>
+<Information>
+${context}
+<End information>
 
-      <Question>
-      ${question}
-      <End Question>`;
+<Question>
+${question}
+<End Question>`;
       return { role: "user", content };
     },
   },


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32914

## Changes

- remove `stripIndents` from the user message generation function b/c it's stripping indents on code examples, causing them to not be properly indented. 
-

## Notes

- seeing answers like this sometimes now:  
<img width="856" alt="Screenshot 2023-09-05 at 4 08 33 PM" src="https://github.com/mongodb/docs-chatbot/assets/90647379/b926991e-d2ba-4a9f-868c-7b9bfd18a77b">
