### PR TITLE
(DOCSP-32936): Increase single IP rate limits to be more line w firewall rate limits

### DIFF
--- a/chat-server/src/routes/conversations/conversationsRouter.ts
+++ b/chat-server/src/routes/conversations/conversationsRouter.ts
@@ -72,8 +72,8 @@ export function makeConversationsRouter({
     Global rate limit the requests to the conversationsRouter.
    */
   const globalRateLimit = rateLimit({
-    windowMs: 60 * 1000,
-    max: 100,
+    windowMs: 5 * 60 * 1000,
+    max: 5000,
     standardHeaders: "draft-7", // draft-6: RateLimit-* headers; draft-7: combined RateLimit header
     legacyHeaders: true, // X-RateLimit-* headers
     message: rateLimitResponse,
@@ -108,8 +108,8 @@ export function makeConversationsRouter({
     Rate limit should be more restrictive than global rate limiter to limit expensive requests to the LLM.
    */
   const addMessageRateLimit = rateLimit({
-    windowMs: 60 * 1000,
-    max: 30,
+    windowMs: 5 * 60 * 1000,
+    max: 2500,
     standardHeaders: "draft-7", // draft-6: RateLimit-* headers; draft-7: combined RateLimit header
     legacyHeaders: true, // X-RateLimit-* headers
     message: rateLimitResponse,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32936

## Changes

- Increase single IP rate limits to be more line w firewall rate limits


## Notes

- see ticket for more context on this. came after discussion with infra team
