### PR TITLE
(DOCSP-32930): Add pymongo metadata

### DIFF
--- a/ingest/src/RstOnGitHubDataSource.test.ts
+++ b/ingest/src/RstOnGitHubDataSource.test.ts
@@ -20,6 +20,9 @@ describe("makeRstOnGitHubDataSource", () => {
           .replace(/^doc\//, "https://pymongo.readthedocs.io/en/4.5.0/")
           .replace(/\.rst$/, ".html");
       },
+      getMetadata({ url }) {
+        return { test: "It works!", url };
+      },
     });
     const pages = await source.fetchPages();
     expect(pages.length).toBe(82);
@@ -29,5 +32,14 @@ describe("makeRstOnGitHubDataSource", () => {
     expect(pages[0].format).toBe("md");
     expect(pages[0].sourceName).toBe("python-TEST");
     expect(pages[0].body).toContain("Using PyMongo with MongoDB Atlas");
+
+    // Fetches title
+    expect(pages[0].title).toBe("Using PyMongo with MongoDB Atlas");
+
+    // Adds metadata
+    expect(pages[0].metadata).toStrictEqual({
+      test: "It works!",
+      url: "https://pymongo.readthedocs.io/en/4.5.0/atlas.html",
+    });
   });
 });

--- a/ingest/src/projectSources.ts
+++ b/ingest/src/projectSources.ts
@@ -243,6 +243,14 @@ export const pyMongoSourceConstructor = async () => {
         .replace(/^doc\//, "https://pymongo.readthedocs.io/en/stable/")
         .replace(/\.rst$/, ".html");
     },
+    getMetadata({ title }) {
+      return {
+        tags: ["docs", "python"],
+        productName: "PyMongo",
+        version: "4.5.0 (current)",
+        pageTitle: title,
+      };
+    },
   });
 };
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32930

## Changes

- Adds metadata getter to rstOnGitHubDataSource
- Adds pymongo metadata and titles

