### PR TITLE
Replace GitHub data source

### DIFF
--- a/chat-server/.release-it.json
+++ b/chat-server/.release-it.json
@@ -1,6 +1,7 @@
 {
   "git": {
-    "add": "../",
+    "commitArgs": ["-a"],
+    "commitMessage": "Release chat-server v${version}",
     "tag": false,
     "push": true,
     "pushRepo": "upstream",

--- a/chat-ui/.release-it.json
+++ b/chat-ui/.release-it.json
@@ -1,7 +1,10 @@
 {
   "git": {
+    "commitArgs": ["-a"],
+    "commitMessage": "Release chat-ui v${version}",
     "tag": false,
     "push": true,
+    "pushRepo": "upstream",
     "tagName": "chat-ui-v${version}"
   },
   "npm": {
@@ -13,6 +16,10 @@
     "release": true
   },
   "hooks": {
-    "before:init": ["git pull", "npm run build", "npm run lint"]
+    "before:init": [
+      "pushd ../chat-core && npm i && npm run build && popd",
+      "npm run build",
+      "npm run lint"
+    ]
   }
 }

--- a/ingest/.release-it.json
+++ b/ingest/.release-it.json
@@ -1,7 +1,9 @@
 {
   "git": {
+    "add": "../",
     "tag": false,
     "push": true,
+    "pushRepo": "upstream",
     "tagName": "ingest-v${version}"
   },
   "npm": {
@@ -13,6 +15,11 @@
     "release": true
   },
   "hooks": {
-    "before:init": ["git pull", "npm run build", "npm run lint", "npm run test"]
+    "before:init": [
+      "pushd ../chat-core && npm i && npm run build && popd",
+      "npm run build",
+      "npm run lint",
+      "npm run test"
+    ]
   }
 }

--- a/ingest/.release-it.json
+++ b/ingest/.release-it.json
@@ -1,6 +1,7 @@
 {
   "git": {
-    "add": "../",
+    "commitArgs": ["-a"],
+    "commitMessage": "Release ingest v${version}",
     "tag": false,
     "push": true,
     "pushRepo": "upstream",

--- a/ingest/src/AcquitRequireMdOnGithubDataSource.test.ts
+++ b/ingest/src/AcquitRequireMdOnGithubDataSource.test.ts
@@ -12,13 +12,13 @@ const testFileLoaderOptions: Partial<GithubRepoLoaderParams> = {
   branch: "master",
   unknown: "warn",
   recursive: true,
-  ignoreFiles: [/^(?!test\/).+$/],
+  ignoreFiles: [/^(?!\/test\/).+$/, /^(?!.*\.js$).+$/],
 };
 const repoLoaderOptions: Partial<GithubRepoLoaderParams> = {
   branch: "master",
   unknown: "warn",
   recursive: true,
-  ignoreFiles: [/^(?!.*\.md$).*/i, /^(?!docs\/).+$/], // only load .md files in the /docs directory
+  ignoreFiles: [/^(?!.*\.md$).*/i, /^(?!\/docs\/).+$/], // only load .md files in the /docs directory
 };
 describe("AcquitRequireOnGithubDataSource", () => {
   it("should render a markdown file with code blocks from Acquit code blocks and markdown source", async () => {
@@ -45,6 +45,7 @@ describe("AcquitRequireOnGithubDataSource", () => {
       page.body.includes("```javascript\n")
     );
     assert(convertedPage);
+    expect(convertedPage?.metadata).toBeDefined();
     expect(convertedPage?.metadata?.arbitrary).toBe("data");
     expect(convertedPage.url.endsWith(".html")).toBe(true);
     expect(convertedPage.title).toBeTruthy();

--- a/ingest/src/GitDataSource.test.ts
+++ b/ingest/src/GitDataSource.test.ts
@@ -2,7 +2,7 @@ import { makeGitDataSource } from "./GitDataSource";
 jest.setTimeout(60000);
 describe("GitDataSource", () => {
   it("should load and process a real repo", async () => {
-    const dataSource = await makeGitDataSource({
+    const dataSource = makeGitDataSource({
       name: "sample",
       repoUri: "https://github.com/mongodb/mongo-java-driver.git",
       repoOptions: {
@@ -16,13 +16,11 @@ describe("GitDataSource", () => {
       metadata: {
         foo: "bar",
       },
-      handlePage: async (path, content, options) => [
+      handlePage: async (path) => [
         {
-          sourceName: options.sourceName,
           url: "https://example.com/" + path,
           title: "sample",
           body: "sample",
-          metadata: options.metadata,
           format: "md",
         },
       ],

--- a/ingest/src/GitHubDataSource.test.ts
+++ b/ingest/src/GitHubDataSource.test.ts
@@ -14,7 +14,7 @@ describe("makeGitHubDataSource", () => {
       repoUrl: "https://github.com/mongodb/mongo-python-driver",
       repoLoaderOptions: {
         branch: "4.5.0",
-        ignoreFiles: [/^(?!^doc\/).*/], // Everything BUT doc/
+        ignoreFiles: [/^(?!\/doc\/).*/], // Everything BUT /doc/
       },
       async handleDocumentInRepo(document) {
         numDocs++;
@@ -36,8 +36,8 @@ describe("makeGitHubDataSource", () => {
     const pages = await source.fetchPages();
 
     expect(pages.length).toBe(numDocs * 2);
-    expect(pages[0].url).toBe("doc/Makefile");
-    expect(pages[1].url).toBe("doc/Makefile-CLONE");
+    expect(pages[0].url).toBe("/doc/Makefile");
+    expect(pages[1].url).toBe("/doc/Makefile-CLONE");
 
     expect(pages[0].format).toBe("txt");
     expect(pages[0].sourceName).toBe("python-TEST");

--- a/ingest/src/MdOnGithubDataSource.test.ts
+++ b/ingest/src/MdOnGithubDataSource.test.ts
@@ -2,10 +2,8 @@ import {
   MakeMdOnGithubDataSourceParams,
   makeMdOnGithubDataSource,
 } from "./MdOnGithubDataSource";
-import { mongoDbCppDriverConfig } from "./projectSources";
 import "dotenv/config";
 import { strict as assert } from "assert";
-import { DataSource } from "./DataSource";
 import { Page } from "chat-core";
 
 jest.setTimeout(60000);
@@ -23,7 +21,7 @@ const sampleConf: MakeMdOnGithubDataSourceParams = {
   repoUrl: "https://github.com/mongodb/mongo-cxx-driver/",
   repoLoaderOptions: {
     branch: "master",
-    ignoreFiles: [/^(?!^docs\/content\/mongocxx-v3\/).*/],
+    ignoreFiles: [/^(?!^\/docs\/content\/mongocxx-v3\/).*/],
   },
   pathToPageUrl: samplePathToPage,
   metadata: {

--- a/ingest/src/RstOnGitHubDataSource.test.ts
+++ b/ingest/src/RstOnGitHubDataSource.test.ts
@@ -13,11 +13,11 @@ describe("makeRstOnGitHubDataSource", () => {
       repoUrl: "https://github.com/mongodb/mongo-python-driver",
       repoLoaderOptions: {
         branch: "4.5.0",
-        ignoreFiles: [/^(?!^doc\/).*/], // Everything BUT doc/
+        ignoreFiles: [/^(?!\/doc\/).*/], // Everything BUT doc/
       },
       pathToPageUrl(path) {
         return path
-          .replace(/^doc\//, "https://pymongo.readthedocs.io/en/4.5.0/")
+          .replace(/^\/doc\//, "https://pymongo.readthedocs.io/en/4.5.0/")
           .replace(/\.rst$/, ".html");
       },
       getMetadata({ url }) {
@@ -27,19 +27,23 @@ describe("makeRstOnGitHubDataSource", () => {
     const pages = await source.fetchPages();
     expect(pages.length).toBe(82);
     expect(pages[0].url).toBe(
-      "https://pymongo.readthedocs.io/en/4.5.0/atlas.html"
+      "https://pymongo.readthedocs.io/en/4.5.0/api/bson/binary.html"
     );
     expect(pages[0].format).toBe("md");
     expect(pages[0].sourceName).toBe("python-TEST");
-    expect(pages[0].body).toContain("Using PyMongo with MongoDB Atlas");
+    expect(pages[0].body).toContain(
+      "# :mod:`binary` -- Tools for representing binary data to be stored in MongoDB"
+    );
 
     // Fetches title
-    expect(pages[0].title).toBe("Using PyMongo with MongoDB Atlas");
+    expect(pages[0].title).toBe(
+      ":mod:`binary` -- Tools for representing binary data to be stored in MongoDB"
+    );
 
     // Adds metadata
     expect(pages[0].metadata).toStrictEqual({
       test: "It works!",
-      url: "https://pymongo.readthedocs.io/en/4.5.0/atlas.html",
+      url: "https://pymongo.readthedocs.io/en/4.5.0/api/bson/binary.html",
     });
   });
 });

--- a/ingest/src/SnootyProjectsInfo.test.ts
+++ b/ingest/src/SnootyProjectsInfo.test.ts
@@ -85,7 +85,7 @@ describe("SnootyProjectsInfo", () => {
     ).toBeUndefined();
 
     if (findBadBoolBranches(data) !== undefined) {
-      logger.info("Found bad bools in Snooty Data API response.");
+      console.log("Found bad bools in Snooty Data API response.");
     }
     expect(findBadBoolBranches(projectsInfo?._data)).toBeUndefined();
   });

--- a/ingest/src/SnootyProjectsInfo.test.ts
+++ b/ingest/src/SnootyProjectsInfo.test.ts
@@ -85,7 +85,7 @@ describe("SnootyProjectsInfo", () => {
     ).toBeUndefined();
 
     if (findBadBoolBranches(data) !== undefined) {
-      console.log("Found bad bools in Snooty Data API response.");
+      logger.info("Found bad bools in Snooty Data API response.");
     }
     expect(findBadBoolBranches(projectsInfo?._data)).toBeUndefined();
   });

--- a/ingest/src/handleHtmlDocument.test.ts
+++ b/ingest/src/handleHtmlDocument.test.ts
@@ -13,7 +13,6 @@ jest.setTimeout(600000);
 
 const javaVersion = "4.10";
 const options: HandleHtmlPageFuncOptions = {
-  sourceName: "sample",
   pathToPageUrl: (pathInRepo: string) =>
     `https://example.com/${pathInRepo}`.replace(/index\.html$/, "testing.html"),
   metadata: {
@@ -42,7 +41,7 @@ const options: HandleHtmlPageFuncOptions = {
 };
 
 describe("handleHtmlDocument()", () => {
-  let page: Page;
+  let page: Omit<Page, "sourceName">;
   beforeAll(async () => {
     const html = fs.readFileSync(
       Path.resolve(__dirname, "./test_data/sampleJava.html"),

--- a/ingest/src/handleHtmlDocument.ts
+++ b/ingest/src/handleHtmlDocument.ts
@@ -2,11 +2,10 @@ import { Page, PageMetadata, logger } from "chat-core";
 import TurndownService from "turndown";
 import * as turndownPluginGfm from "turndown-plugin-gfm";
 import { JSDOM } from "jsdom";
-import { HandlePageFuncOptions } from "./GitDataSource";
 import { removeMarkdownImagesAndLinks } from "./removeMarkdownImagesAndLinks";
 import fs from "fs";
 
-export type HandleHtmlPageFuncOptions = HandlePageFuncOptions & {
+export type HandleHtmlPageFuncOptions = {
   /** Returns an array of DOM elements to be removed from the parsed document. */
   removeElements: (domDoc: Document) => Element[];
 
@@ -41,7 +40,6 @@ export async function handleHtmlDocument(
     removeElements,
     metadata,
     pathToPageUrl,
-    sourceName,
     postProcessMarkdown,
   } = options;
 
@@ -83,8 +81,7 @@ export async function handleHtmlDocument(
 
   let body = turndownService.turndown(domDocument.body);
   body = postProcessMarkdown ? await postProcessMarkdown(body) : body;
-  const page: Page = {
-    sourceName,
+  const page: Omit<Page, "sourceName"> = {
     format: "md",
     title,
     body,

--- a/ingest/src/projectSources.ts
+++ b/ingest/src/projectSources.ts
@@ -300,11 +300,12 @@ export const javaReactiveStreamsSourceConstructor = async () => {
       path.includes(jvmDriversVersion) &&
       path.includes("driver-reactive") &&
       !path.includes("apidocs"),
-    handlePage: async (path, content, options) =>
-      await handleHtmlDocument(path, content, {
-        ...options,
-        ...javaReactiveStreamsHtmlParserOptions,
-      }),
+    handlePage: async (path, content) =>
+      await handleHtmlDocument(
+        path,
+        content,
+        javaReactiveStreamsHtmlParserOptions
+      ),
   });
 };
 
@@ -336,11 +337,8 @@ export const scalaSourceConstructor = async () => {
       path.includes(jvmDriversVersion) &&
       path.includes("driver-scala") &&
       !path.includes("apidocs"),
-    handlePage: async (path, content, options) =>
-      await handleHtmlDocument(path, content, {
-        ...options,
-        ...scalaHtmlParserOptions,
-      }),
+    handlePage: async (path, content) =>
+      await handleHtmlDocument(path, content, scalaHtmlParserOptions),
   });
 };
 
@@ -378,11 +376,8 @@ export const libmongocSourceConstructor = async () => {
       path.endsWith(".html") &&
       !path.includes("mongoc_") && // do not include the generated reference docs
       !path.includes("search.html"), // do not include the search page
-    handlePage: async (path, content, options) =>
-      await handleHtmlDocument(path, content, {
-        ...options,
-        ...libmongocHtmlParserOptions,
-      }),
+    handlePage: async (path, content) =>
+      await handleHtmlDocument(path, content, libmongocHtmlParserOptions),
   });
 };
 const mongooseSourceConstructor = async () => {

--- a/ingest/src/projectSources.ts
+++ b/ingest/src/projectSources.ts
@@ -390,7 +390,7 @@ const mongooseSourceConstructor = async () => {
   const testFileLoaderOptions = {
     branch: "master",
     recursive: true,
-    ignoreFiles: [/^(?!test\/).+$/],
+    ignoreFiles: [/^(?!\/test\/).+$/],
   };
   const repoLoaderOptions = {
     branch: "master",

--- a/scripts/.release-it.json
+++ b/scripts/.release-it.json
@@ -1,6 +1,7 @@
 {
   "git": {
-    "add": "../",
+    "commitArgs": ["-a"],
+    "commitMessage": "Release scripts v${version}",
     "tag": false,
     "push": true,
     "pushRepo": "upstream",


### PR DESCRIPTION
Jira: none

## Changes

- Uses makeGitDataSource as a drop-in replacement for GitHubRepoLoader.

## Notes

- Langchain's GitHubRepoLoader consumes a lot of API requests and quickly hits the limit. This disrupts our tests. It's particularly annoying given that we only load public repos.
- Will probably need special work to handle private repos.