### PR TITLE
Do not fail query on rephrase fail

### DIFF
--- a/chat-server/src/processors/MongoDbUserQueryPreprocessorResponse.d.ts
+++ b/chat-server/src/processors/MongoDbUserQueryPreprocessorResponse.d.ts
@@ -1,25 +1,41 @@
-/** You are an AI-powered API that helps developers find answers to their MongoDB questions.
- * You are a MongoDB expert.
- * Process the user query in the context of the conversation into the following data type.
+/**
+  You are an AI-powered API that helps developers find answers to their MongoDB
+  questions. You are a MongoDB expert. Process the user query in the context of
+  the conversation into the following data type.
  */
 export interface MongoDbUserQueryPreprocessorResponse {
-  /** One or more programming languages present in the content. Ordered by relevancy.
-    If no programming language is present and the user is asking for a code example, include "shell".
-    @example ["shell", "javascript", "typescript", "python", "java", "csharp", "cpp", "ruby", "kotlin", "c", "dart", "php", "rust", "scala", "swift" ...other popular programming languages ]
+  /**
+    One or more programming languages present in the content ordered by
+    relevancy. If no programming language is present and the user is asking for
+    a code example, include "shell".
+    @example ["shell", "javascript", "typescript", "python", "java", "csharp",
+    "cpp", "ruby", "kotlin", "c", "dart", "php", "rust", "scala", "swift"
+    ...other popular programming languages ]
   */
   programmingLanguages: string[];
-  /** One or more MongoDB products present in the content.
-    Which MongoDB products is the user interested in? Ordered by relevancy.
-    Include "Driver" if the user is asking about a programming language with a MongoDB driver.
-    @example ["MongoDB Atlas", "Atlas Charts", "Atlas Search", "Aggregation Framework", "MongoDB Server", "Compass", "MongoDB Connector for BI", "Realm SDK", "Driver", "Atlas App Services", ...other MongoDB products]
+
+  /**
+    One or more MongoDB products present in the content. Which MongoDB products
+    is the user interested in? Order by relevancy. Include "Driver" if the user
+    is asking about a programming language with a MongoDB driver.
+    @example ["MongoDB Atlas", "Atlas Charts", "Atlas Search", "Aggregation
+    Framework", "MongoDB Server", "Compass", "MongoDB Connector for BI", "Realm
+    SDK", "Driver", "Atlas App Services", ...other MongoDB products]
    */
   mongoDbProducts: string[];
-  /** Using your knowledge of MongoDB and the conversational context,
-    rephrase the latest user query to make it more meaningful.
-    Rephrase the query into a question if it's not already one.
-    The query generated here is passed to semantic search.
-    If you do not know how to rephrase the query, paste the original query verbatim.
-    If the query is negative toward MongoDB, respond "DO_NOT_ANSWER".
+
+  /**
+    Using your knowledge of MongoDB and the conversational context, rephrase the
+    latest user query to make it more meaningful. Rephrase the query into a
+    question if it's not already one. The query generated here is passed to
+    semantic search. If you do not know how to rephrase the query, leave this
+    field undefined.
   */
-  query: string;
+  query?: string;
+
+  /**
+    Set to true if and only if the query is hostile, offensive, or disparages
+    MongoDB or its products.
+   */
+  rejectQuery: boolean;
 }

--- a/chat-server/src/processors/MongoDbUserQueryPreprocessorResponse.d.ts
+++ b/chat-server/src/processors/MongoDbUserQueryPreprocessorResponse.d.ts
@@ -17,8 +17,8 @@ export interface MongoDbUserQueryPreprocessorResponse {
   /** Using your knowledge of MongoDB and the conversational context,
     rephrase the latest user query to make it more meaningful.
     Rephrase the query into a question if it's not already one.
-    The the query generated here is passed to semantic search.
-    If you do not know how to rephrase the query, respond "DO_NOT_ANSWER".
+    The query generated here is passed to semantic search.
+    If you do not know how to rephrase the query, paste the original query verbatim.
     If the query is negative toward MongoDB, respond "DO_NOT_ANSWER".
   */
   query: string;

--- a/chat-server/src/processors/QueryPreprocessorFunc.ts
+++ b/chat-server/src/processors/QueryPreprocessorFunc.ts
@@ -2,13 +2,27 @@ export interface QueryPreprocessorMessage {
   content: string;
   role: string;
 }
-/** Query preprocessors run on the raw user input. They must return a new query.
-  They can also optionally return additional data.
+
+/**
+  Query preprocessors transform an input query to a new query based on your
+  business logic.
+
+  If the preprocessor can't transform the query, it may return undefined. The
+  preprocessor may also suggest not answering with the rejectQuery field in the
+  return value (for example, if the query disparages your company, you might
+  want to send a canned response).
 */
-export type QueryPreprocessorFunc<T = unknown> = ({
+export type QueryPreprocessorFunc<
+  ReturnType extends QueryPreprocessorResult = QueryPreprocessorResult
+> = ({
   query,
   messages,
 }: {
-  query: string;
+  query?: string;
   messages: QueryPreprocessorMessage[];
-}) => Promise<T & { query: string; doNotAnswer?: boolean }>;
+}) => Promise<ReturnType>;
+
+export type QueryPreprocessorResult = {
+  query?: string;
+  rejectQuery: boolean;
+};

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -323,7 +323,9 @@ describe("POST /conversations/:conversationId/messages", () => {
         .set("X-FORWARDED-FOR", ipAddress)
         .send({ message: nonsenseMessage });
       expect(response.statusCode).toBe(200);
-
+      expect(response.body.content).toEqual(
+        conversationConstants.NO_RELEVANT_CONTENT
+      );
       expect(response.body.references).toStrictEqual([]);
     });
 

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -324,9 +324,7 @@ describe("POST /conversations/:conversationId/messages", () => {
         .send({ message: nonsenseMessage });
       expect(response.statusCode).toBe(200);
 
-      expect(response.body.content).toEqual(
-        conversationConstants.NO_RELEVANT_CONTENT
-      );
+      expect(response.body.references).toStrictEqual([]);
     });
 
     describe("LLM not available but vector search is", () => {

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -180,7 +180,7 @@ export function makeAddMessageToConversationRoute({
       // (likely due to LLM timeout), then we will just use the original message.
       if (userQueryPreprocessor) {
         try {
-          const { query, doNotAnswer } = await userQueryPreprocessor({
+          const { query, rejectQuery } = await userQueryPreprocessor({
             query: latestMessageText,
             messages: conversationInDb.messages,
           });
@@ -191,7 +191,7 @@ export function makeAddMessageToConversationRoute({
               Original query: ${latestMessageText}
               Preprocessed query: ${preprocessedUserMessageContent}`,
           });
-          if (doNotAnswer) {
+          if (rejectQuery) {
             return await sendStaticNonResponse({
               conversations,
               conversationId,
@@ -490,6 +490,7 @@ interface AddMessagesToDatabaseParams {
   assistantMessageReferences: References;
   conversations: ConversationsService;
   userMessageEmbedding?: number[];
+  rejectQuery?: boolean;
 }
 export async function addMessagesToDatabase({
   conversationId,
@@ -499,6 +500,7 @@ export async function addMessagesToDatabase({
   assistantMessageReferences,
   conversations,
   userMessageEmbedding,
+  rejectQuery,
 }: AddMessagesToDatabaseParams) {
   // TODO: consider refactoring addConversationMessage to take in an array of messages.
   // Would limit database calls.
@@ -508,6 +510,7 @@ export async function addMessagesToDatabase({
     preprocessedContent: preprocessedUserMessageContent,
     role: "user",
     embedding: userMessageEmbedding,
+    rejectQuery,
   });
   const assistantMessage = await conversations.addConversationMessage({
     conversationId,

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -195,6 +195,7 @@ export function makeAddMessageToConversationRoute({
             return await sendStaticNonResponse({
               conversations,
               conversationId,
+              rejectQuery,
               preprocessedUserMessageContent,
               latestMessageText,
               shouldStream,
@@ -419,9 +420,11 @@ export async function sendStaticNonResponse({
   shouldStream,
   dataStreamer,
   res,
+  rejectQuery,
 }: {
   conversations: ConversationsService;
   conversationId: ObjectId;
+  rejectQuery?: boolean;
   preprocessedUserMessageContent?: string;
   latestMessageText: string;
   shouldStream: boolean;
@@ -431,6 +434,7 @@ export async function sendStaticNonResponse({
   const { assistantMessage } = await addMessagesToDatabase({
     conversations,
     conversationId,
+    rejectQuery,
     preprocessedUserMessageContent: preprocessedUserMessageContent,
     originalUserMessageContent: latestMessageText,
     assistantMessageContent: conversationConstants.NO_RELEVANT_CONTENT,

--- a/chat-server/src/services/conversations.ts
+++ b/chat-server/src/services/conversations.ts
@@ -55,7 +55,7 @@ export type UserMessage = Message & {
   /**
     Whether preprocessor suggested DO_NOT_ANSWER based on the input.
    */
-  doNotAnswer?: boolean;
+  rejectQuery?: boolean;
 
   /**
     The vector representation of the message content.
@@ -90,7 +90,7 @@ export interface AddConversationMessageParams {
    */
   embedding?: number[];
 
-  doNotAnswer?: boolean;
+  rejectQuery?: boolean;
 }
 export interface FindByIdParams {
   _id: ObjectId;
@@ -157,7 +157,7 @@ export function makeConversationsService(
       preprocessedContent,
       references,
       embedding,
-      doNotAnswer,
+      rejectQuery,
     }: AddConversationMessageParams) {
       const newMessage = createMessageFromOpenAIChatMessage({
         role,
@@ -168,7 +168,7 @@ export function makeConversationsService(
         newMessage,
         preprocessedContent && { preprocessedContent },
         references && { references },
-        doNotAnswer && { doNotAnswer }
+        rejectQuery && { rejectQuery }
       );
 
       const updateResult = await conversationsCollection.updateOne(

--- a/chat-server/src/services/conversations.ts
+++ b/chat-server/src/services/conversations.ts
@@ -53,7 +53,7 @@ export type UserMessage = Message & {
   preprocessedContent?: string;
 
   /**
-    Whether preprocessor suggested DO_NOT_ANSWER based on the input.
+    Whether preprocessor suggested not to answer based on the input.
    */
   rejectQuery?: boolean;
 
@@ -168,7 +168,7 @@ export function makeConversationsService(
         newMessage,
         preprocessedContent && { preprocessedContent },
         references && { references },
-        rejectQuery && { rejectQuery }
+        rejectQuery !== undefined ? { rejectQuery } : undefined
       );
 
       const updateResult = await conversationsCollection.updateOne(

--- a/scripts/src/scrubMessages.ts
+++ b/scripts/src/scrubMessages.ts
@@ -67,7 +67,7 @@ const scrubMessages = async ({ db }: { db: Db }) => {
         embedding: "$messages.embedding",
         rating: "$messages.rating",
         references: "$messages.references",
-        doNotAnswer: "$messages.doNotAnswer",
+        rejectQuery: "$messages.rejectQuery",
       } satisfies Record<
         Exclude<
           // This protects against unknown entries in the $project stage and


### PR DESCRIPTION
Jira: none

## Changes

- Adds "rejectQuery" field to preprocessor in order to avoid needing the DO_NOT_ANSWER thing
- Stores "rejectQuery" field in the database for future analysis

## Notes

- The "rejectQuery" name was chosen over "doNotAnswer" to avoid confusion around double negatives
- Behavior change: previously, the bot would fail to answer if it couldn't rephrase. This would no longer be the case after this is merged. When a user pasted an error message, they got a DO_NOT_ANSWER because the bot couldn't rephrase it.