### PR TITLE
Conversations refactor

### DIFF
--- a/chat-server/src/app.test.ts
+++ b/chat-server/src/app.test.ts
@@ -10,15 +10,6 @@ describe("App", () => {
     const { appConfig } = makeTestAppConfig();
     app = await makeApp({
       ...appConfig,
-      conversationsRouterConfig: {
-        ...appConfig.conversationsRouterConfig,
-        findNearestNeighborsOptions: {
-          indexName: "default",
-          path: "embedding",
-          k: 3,
-          minScore: 0.9,
-        },
-      },
       corsOptions: {
         origin: ["http://localhost:3000", "http://example.com"],
       },

--- a/chat-server/src/routes/conversations/FindContentFunc.ts
+++ b/chat-server/src/routes/conversations/FindContentFunc.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from "assert";
+import {
+  WithScore,
+  EmbeddedContent,
+  EmbedFunc,
+  EmbeddedContentStore,
+  FindNearestNeighborsOptions,
+} from "chat-core";
+import { SearchBooster } from "../../processors/SearchBooster";
+
+export type FindContentFunc = ({
+  query,
+  ipAddress,
+}: {
+  query: string;
+  ipAddress: string;
+}) => Promise<FindContentResult>;
+
+export type FindContentResult = {
+  queryEmbedding: number[];
+  content: WithScore<EmbeddedContent>[];
+};
+
+export type MakeDefaultFindContentFuncArgs = {
+  embed: EmbedFunc;
+  store: EmbeddedContentStore;
+  findNearestNeighborsOptions?: Partial<FindNearestNeighborsOptions>;
+  searchBoosters?: SearchBooster[];
+};
+
+/**
+  Basic implementation of FindContentFunc with search boosters.
+ */
+export const makeDefaultFindContentFunc = ({
+  embed,
+  store,
+  findNearestNeighborsOptions,
+  searchBoosters,
+}: MakeDefaultFindContentFuncArgs): FindContentFunc => {
+  return async ({ query, ipAddress }) => {
+    const { embedding } = await embed({
+      text: query,
+      userIp: ipAddress,
+    });
+
+    let content = await store.findNearestNeighbors(
+      embedding,
+      findNearestNeighborsOptions
+    );
+
+    for (const booster of searchBoosters ?? []) {
+      if (booster.shouldBoost({ text: query })) {
+        content = await booster.boost({
+          existingResults: content,
+          embedding,
+          store,
+        });
+      }
+    }
+    return { queryEmbedding: embedding, content };
+  };
+};

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -153,7 +153,7 @@ describe("POST /conversations/:conversationId/messages", () => {
         });
       expect(res.statusCode).toEqual(400);
       expect(res.body).toStrictEqual({
-        error: "Invalid conversation ID",
+        error: `Invalid ObjectId string: ${notAValidId}`,
       });
     });
 
@@ -186,9 +186,7 @@ describe("POST /conversations/:conversationId/messages", () => {
           message: "hello",
         });
       expect(res.statusCode).toEqual(404);
-      expect(res.body).toStrictEqual({
-        error: "Conversation not found",
-      });
+      expect(res.body?.error).toMatch(/^Conversation [a-f0-9]{24} not found$/);
     });
     test("Should return 400 if number of messages in conversation exceeds limit", async () => {
       const { _id } = await conversations.create({
@@ -247,7 +245,7 @@ describe("POST /conversations/:conversationId/messages", () => {
           throw new Error("mock error");
         },
         async findById() {
-          throw new Error("mock error");
+          throw new Error("Error finding conversation");
         },
         async rateMessage() {
           throw new Error("mock error");

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -4,10 +4,7 @@ import {
   MongoDB,
   assertEnvVars,
   CORE_ENV_VARS,
-  EmbeddedContentStore,
   EmbeddedContent,
-  EmbedFunc,
-  FindNearestNeighborsOptions,
 } from "chat-core";
 import {
   conversationConstants,
@@ -53,9 +50,6 @@ describe("POST /conversations/:conversationId/messages", () => {
   let mongodb: MongoDB;
   let ipAddress: string;
   let dataStreamer: ReturnType<typeof makeDataStreamer>;
-  let findNearestNeighborsOptions:
-    | Partial<FindNearestNeighborsOptions>
-    | undefined;
   let conversations: ConversationsService;
   let app: Express;
   let appConfig: AppConfig;
@@ -465,7 +459,6 @@ describe("POST /conversations/:conversationId/messages", () => {
       const findContent = makeDefaultFindContentFunc({
         embed,
         store,
-        findNearestNeighborsOptions,
       });
       test("Should return content for relevant text", async () => {
         const query = "MongoDB Atlas";

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -4,7 +4,10 @@ import {
   MongoDB,
   assertEnvVars,
   CORE_ENV_VARS,
+  EmbeddedContentStore,
   EmbeddedContent,
+  EmbedFunc,
+  FindNearestNeighborsOptions,
 } from "chat-core";
 import {
   conversationConstants,
@@ -50,6 +53,9 @@ describe("POST /conversations/:conversationId/messages", () => {
   let mongodb: MongoDB;
   let ipAddress: string;
   let dataStreamer: ReturnType<typeof makeDataStreamer>;
+  let findNearestNeighborsOptions:
+    | Partial<FindNearestNeighborsOptions>
+    | undefined;
   let conversations: ConversationsService;
   let app: Express;
   let appConfig: AppConfig;
@@ -459,6 +465,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const findContent = makeDefaultFindContentFunc({
         embed,
         store,
+        findNearestNeighborsOptions,
       });
       test("Should return content for relevant text", async () => {
         const query = "MongoDB Atlas";

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -526,7 +526,7 @@ const loadConversation = async ({
   conversationIdString: string;
   conversations: ConversationsService;
 }) => {
-  const conversationId = new ObjectId(conversationIdString);
+  const conversationId = toObjectId(conversationIdString);
   const conversation = await conversations.findById({
     _id: conversationId,
   });
@@ -537,4 +537,15 @@ const loadConversation = async ({
     });
   }
   return conversation;
+};
+
+const toObjectId = (id: string) => {
+  try {
+    return new ObjectId(id);
+  } catch (error) {
+    throw makeRequestError({
+      httpStatus: 400,
+      message: `Invalid ObjectId string: ${id}`,
+    });
+  }
 };

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -36,7 +36,6 @@ export const AddMessageRequestBody = z.object({
   message: z.string(),
 });
 
-export type AddMessageRequest = z.infer<typeof AddMessageRequest>;
 export const AddMessageRequest = SomeExpressRequest.merge(
   z.object({
     headers: z.object({
@@ -52,6 +51,8 @@ export const AddMessageRequest = SomeExpressRequest.merge(
     ip: z.string(),
   })
 );
+
+export type AddMessageRequest = z.infer<typeof AddMessageRequest>;
 
 export interface AddMessageToConversationRouteParams {
   conversations: ConversationsService;
@@ -89,7 +90,10 @@ export function makeAddMessageToConversationRoute({
   userQueryPreprocessor,
   maxChunkContextTokens = 1500,
 }: AddMessageToConversationRouteParams) {
-  return async (req: ExpressRequest, res: ExpressResponse<ApiMessage>) => {
+  return async (
+    req: ExpressRequest<AddMessageRequest["params"]>,
+    res: ExpressResponse<ApiMessage>
+  ) => {
     const reqId = getRequestId(req);
     try {
       const {
@@ -114,7 +118,7 @@ export function makeAddMessageToConversationRoute({
         });
       }
 
-      const latestMessageText = message as string;
+      const latestMessageText = message;
 
       if (latestMessageText.length > MAX_INPUT_LENGTH) {
         throw makeRequestError({

--- a/chat-server/src/routes/conversations/conversationsRouter.test.ts
+++ b/chat-server/src/routes/conversations/conversationsRouter.test.ts
@@ -61,6 +61,7 @@ describe("Conversations Router", () => {
       conversationId,
       "what is the current version of mongodb server?"
     );
+    expect(successRes.error).toBeFalsy();
     expect(successRes.status).toBe(200);
     expect(rateLimitedRes.status).toBe(429);
     expect(rateLimitedRes.body).toStrictEqual(rateLimitResponse);

--- a/chat-server/src/services/conversations.ts
+++ b/chat-server/src/services/conversations.ts
@@ -168,7 +168,7 @@ export function makeConversationsService(
         newMessage,
         preprocessedContent && { preprocessedContent },
         references && { references },
-        rejectQuery !== undefined ? { rejectQuery } : undefined
+        rejectQuery && { rejectQuery }
       );
 
       const updateResult = await conversationsCollection.updateOne(

--- a/chat-server/src/services/conversations.ts
+++ b/chat-server/src/services/conversations.ts
@@ -168,7 +168,7 @@ export function makeConversationsService(
         newMessage,
         preprocessedContent && { preprocessedContent },
         references && { references },
-        rejectQuery && { rejectQuery }
+        rejectQuery !== undefined ? { rejectQuery } : undefined
       );
 
       const updateResult = await conversationsCollection.updateOne(


### PR DESCRIPTION
Jira: none

## Changes

- Increases code readability and enable further refactors by refactoring makeAddMessageToConversationRoute to centralize error handling under one catch block
- Simplifies implementation and improves extensibility by baking sprawled dependencies into a single injected `findContent` function
- Defines `findContent` in configuration

## Notes

- TODO? Apply similar refactor principles to other paths
