### PR TITLE
adding a trailing slash to env variables expected to be URLs

### DIFF
--- a/chat-core/src/CoreEnvVars.ts
+++ b/chat-core/src/CoreEnvVars.ts
@@ -11,3 +11,5 @@ export const CORE_ENV_VARS = {
   VECTOR_SEARCH_INDEX_NAME: "",
   NODE_ENV: "",
 };
+
+export const URL_ENV_VARS = ["MONGODB_CONNECTION_URI", "OPENAI_ENDPOINT"]

--- a/chat-core/src/assertEnvVars.ts
+++ b/chat-core/src/assertEnvVars.ts
@@ -1,3 +1,6 @@
+import { URL_ENV_VARS } from "CoreEnvVars";
+
+
 export const assertEnvVars = <T extends Record<string, string>>(
   ENV_VARS: T
 ): T => {
@@ -6,6 +9,11 @@ export const assertEnvVars = <T extends Record<string, string>>(
     (anyVarMissing, currentVar) => {
       // Get this var value from process.env - either valid string or undefined
       vars[currentVar] = process.env[currentVar];
+
+      // if the var is a url, make sure it has a following slash
+      if (URL_ENV_VARS.includes(currentVar)) {
+        vars[currentVar] = ensure_url_slash_termination(vars[currentVar] as string);
+      }
 
       // Return true if any var was missing so far or if this var was not set
       return anyVarMissing || !vars[currentVar];
@@ -21,3 +29,5 @@ ${Object.entries(vars)
   }
   return vars as T;
 };
+
+const ensure_url_slash_termination = (url: string): string => url.endsWith("/") ? url : `${url}/`;


### PR DESCRIPTION
## Changes

- add a trailing `/` to urls

## Notes

- before, if you didn't have a trailing `/` to the url of, say, the OpenAI base path, it got concatenated to the deployment ID without having a separator 
