### PR TITLE
(DOCSP-33030) [Q&A] Record request origin for usage tracking

### DIFF
--- a/chat-server/src/app.ts
+++ b/chat-server/src/app.ts
@@ -46,7 +46,7 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
   }
 };
 
-const reqHandler: RequestHandler = (req, _res, next) => {
+export const reqHandler: RequestHandler = (req, _res, next) => {
   const reqId = new ObjectId().toString();
   // Custom header specifically for a request ID. This ID will be used to track
   // logs related to the same request

--- a/chat-server/src/llmQualitativeTests/generateChatTranscript.ts
+++ b/chat-server/src/llmQualitativeTests/generateChatTranscript.ts
@@ -5,6 +5,8 @@ import { strict as assert } from "assert";
 import { stringifyConversation } from "./stringifyConversation";
 import { TestCaseMessage } from "./TestCase";
 
+const requestOrigin = "llmQualitativeTests";
+
 export async function generateTranscript({
   app,
   conversations,
@@ -24,11 +26,27 @@ export async function generateTranscript({
   const [setUpMessages, testMessage] = [messages.slice(0, -1), messages.pop()];
   const conversationId = conversation._id;
   for (const message of setUpMessages) {
-    await conversations.addConversationMessage({
-      conversationId,
-      role: message.role,
-      content: message.content,
-    });
+    switch(message.role) {
+      case "user": {
+        await conversations.addConversationMessage({
+          conversationId,
+          role: message.role,
+          content: message.content,
+          embedding: [],
+          requestOrigin,
+        });
+        break;
+      }
+      case "assistant": {
+        await conversations.addConversationMessage({
+          conversationId,
+          role: message.role,
+          content: message.content,
+          references: []
+        });
+        break;
+      }
+    }
   }
   // Add user message + service response to conversation in DB.
   await request(app)

--- a/chat-server/src/middleware/requestOrigin.test.ts
+++ b/chat-server/src/middleware/requestOrigin.test.ts
@@ -1,24 +1,52 @@
 import { requireRequestOrigin } from "./requestOrigin";
 import { createRequest, createResponse } from "node-mocks-http";
 
+const baseReq = {
+  body: { message: "Hello, world!" },
+  params: { conversationId: "conversation-1234" },
+  query: { stream: "true" },
+  headers: { "req-id": "request-1234" },
+  ip: "127.0.0.1",
+};
+
 describe("requireRequestOrigin", () => {
-  it("TODO - needs proper tests", () => {
-    // TODO
-    expect(true).toBe(true);
+  it("blocks any request where the Origin header is not set", async () => {
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
+
+    const middleware = requireRequestOrigin();
+    req.body = baseReq.body
+    req.params = baseReq.params
+    req.query = baseReq.query
+    req.headers = baseReq.headers
+    req.ip = baseReq.ip
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: "No Origin header",
+    });
   });
-  // it("accepts a Zod schema that describes Express requests", async () => {
-  //   const req = createRequest();
-  //   const res = createResponse();
-  //   const next = jest.fn();
+  it("allows any request where the Origin header is set", async () => {
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
 
-  //   const middleware = requireRequestOrigin();
-  //   req.body = { message: "Hello, world!" };
-  //   req.params = { conversationId: "conversation-1234" };
-  //   req.query = { stream: "true" };
-  //   req.headers = { "req-id": "request-1234" };
-  //   req.ip = "127.0.0.1";
+    const middleware = requireRequestOrigin();
+    req.body = baseReq.body;
+    req.params = baseReq.params;
+    req.query = baseReq.query;
+    req.headers = {
+      ...baseReq.headers,
+      origin: "http://localhost:5173",
+    };
+    req.ip = baseReq.ip;
 
-  //   await middleware(req, res, next);
-  //   expect(next).toHaveBeenCalledTimes(1);
-  // });
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
 });

--- a/chat-server/src/middleware/requestOrigin.test.ts
+++ b/chat-server/src/middleware/requestOrigin.test.ts
@@ -1,0 +1,24 @@
+import { requireRequestOrigin } from "./requestOrigin";
+import { createRequest, createResponse } from "node-mocks-http";
+
+describe("requireRequestOrigin", () => {
+  it("TODO - needs proper tests", () => {
+    // TODO
+    expect(true).toBe(true);
+  });
+  // it("accepts a Zod schema that describes Express requests", async () => {
+  //   const req = createRequest();
+  //   const res = createResponse();
+  //   const next = jest.fn();
+
+  //   const middleware = requireRequestOrigin();
+  //   req.body = { message: "Hello, world!" };
+  //   req.params = { conversationId: "conversation-1234" };
+  //   req.query = { stream: "true" };
+  //   req.headers = { "req-id": "request-1234" };
+  //   req.ip = "127.0.0.1";
+
+  //   await middleware(req, res, next);
+  //   expect(next).toHaveBeenCalledTimes(1);
+  // });
+});

--- a/chat-server/src/middleware/requestOrigin.ts
+++ b/chat-server/src/middleware/requestOrigin.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction } from "express";
+import { getRequestId, logRequest, sendErrorResponse } from "../utils";
+
+declare module "express-serve-static-core" {
+  interface Request {
+    origin: string;
+  }
+}
+
+export function requireRequestOrigin() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const reqId = getRequestId(req);
+    const { origin } = req.headers;
+    if (!origin) {
+      return sendErrorResponse({
+        reqId,
+        res,
+        httpStatus: 400,
+        errorMessage: "No Origin header",
+      });
+    }
+    logRequest({
+      reqId,
+      message: `Request origin ${origin} is allowed`,
+    });
+    req.origin = origin;
+    return next();
+  };
+}

--- a/chat-server/src/middleware/validateRequestSchema.ts
+++ b/chat-server/src/middleware/validateRequestSchema.ts
@@ -4,12 +4,11 @@ import { generateErrorMessage } from "zod-error";
 import { getRequestId, logRequest, sendErrorResponse } from "../utils";
 
 export const SomeExpressRequest = z.object({
-  ip: z.string(),
   headers: z.object({}).optional(),
   params: z.object({}).optional(),
   query: z.object({}).optional(),
   body: z.object({}).optional(),
-}).strict();
+});
 
 function generateZodErrorMessage(error: ZodError) {
   return generateErrorMessage(error.issues, {
@@ -23,10 +22,14 @@ export default function validateRequestSchema(schema: AnyZodObject) {
   schema = SomeExpressRequest.merge(schema);
   return async (req: Request, res: Response, next: NextFunction) => {
     const result = await schema.safeParseAsync(req);
+    const reqId = getRequestId(req);
+    logRequest({
+      reqId,
+      message: JSON.stringify(schema.shape),
+    });
     if (result.success) {
       return next();
     }
-    const reqId = getRequestId(req);
     const message = generateZodErrorMessage(result.error);
     logRequest({
       reqId,

--- a/chat-server/src/middleware/validateRequestSchema.ts
+++ b/chat-server/src/middleware/validateRequestSchema.ts
@@ -22,14 +22,10 @@ export default function validateRequestSchema(schema: AnyZodObject) {
   schema = SomeExpressRequest.merge(schema);
   return async (req: Request, res: Response, next: NextFunction) => {
     const result = await schema.safeParseAsync(req);
-    const reqId = getRequestId(req);
-    logRequest({
-      reqId,
-      message: JSON.stringify(schema.shape),
-    });
     if (result.success) {
       return next();
     }
+    const reqId = getRequestId(req);
     const message = generateZodErrorMessage(result.error);
     logRequest({
       reqId,

--- a/chat-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -49,13 +49,14 @@ jest.setTimeout(100000);
 describe("POST /conversations/:conversationId/messages", () => {
   let mongodb: MongoDB;
   let ipAddress: string;
+  let origin: string;
   let dataStreamer: ReturnType<typeof makeDataStreamer>;
   let conversations: ConversationsService;
   let app: Express;
   let appConfig: AppConfig;
 
   beforeAll(async () => {
-    ({ ipAddress, mongodb, app, appConfig } = await makeTestApp());
+    ({ ipAddress, origin, mongodb, app, appConfig } = await makeTestApp());
     ({
       conversationsRouterConfig: { dataStreamer, conversations },
     } = appConfig);
@@ -74,6 +75,7 @@ describe("POST /conversations/:conversationId/messages", () => {
     const createConversationRes = await request(app)
       .post(CONVERSATIONS_API_V1_PREFIX)
       .set("X-FORWARDED-FOR", ipAddress)
+      .set("Origin", origin)
       .send();
     const res: ApiConversation = createConversationRes.body;
     conversationId = res._id;
@@ -89,6 +91,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const res = await request(app)
         .post(testEndpointUrl)
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send(requestBody);
       const message: ApiMessage = res.body;
       expect(res.statusCode).toEqual(200);
@@ -102,6 +105,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       };
       const res2 = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
+        .set("Origin", origin)
         .send(request2Body);
       const message2: ApiMessage = res2.body;
       expect(res2.statusCode).toEqual(200);
@@ -127,6 +131,7 @@ describe("POST /conversations/:conversationId/messages", () => {
           endpointUrl.replace(":conversationId", conversationId) +
             "?stream=true"
         )
+        .set("Origin", origin)
         .send(requestBody);
       expect(res.statusCode).toEqual(200);
       expect(res.header["content-type"]).toBe("text/event-stream");
@@ -136,12 +141,13 @@ describe("POST /conversations/:conversationId/messages", () => {
     });
   });
 
-  describe("Error handing", () => {
+  describe("Error handling", () => {
     test("should respond 400 if invalid conversation ID", async () => {
       const notAValidId = "not-a-valid-id";
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", notAValidId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({
           message: "hello",
         });
@@ -151,9 +157,18 @@ describe("POST /conversations/:conversationId/messages", () => {
       });
     });
 
-    it("should return 400 for invalid request bodies", async () => {
+    it("should respond 400 if the Origin header is missing", async () => {
+      const res: request.Response = await request(app)
+        .post(endpointUrl.replace(":conversationId", conversationId))
+        .send({ message: "howdy there" });
+      expect(res.statusCode).toEqual(400);
+      expect(res.body).toEqual({ error: "No Origin header" });
+    });
+
+    it("should respond 400 for invalid request bodies", async () => {
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
+        .set("Origin", origin)
         .send({ msg: "howdy there" });
       expect(res.statusCode).toEqual(400);
     });
@@ -163,6 +178,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({
           message: tooLongMessage,
         });
@@ -176,29 +192,42 @@ describe("POST /conversations/:conversationId/messages", () => {
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", anotherObjectId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({
           message: "hello",
         });
       expect(res.statusCode).toEqual(404);
       expect(res.body?.error).toMatch(/^Conversation [a-f0-9]{24} not found$/);
     });
-    test("Should return 400 if number of messages in conversation exceeds limit", async () => {
+    test("Should respond 400 if number of messages in conversation exceeds limit", async () => {
       const { _id } = await conversations.create({
         ipAddress,
       });
       // Init conversation with max length
       for await (const i of Array(MAX_MESSAGES_IN_CONVERSATION - 1)) {
         const role = i % 2 === 0 ? "user" : "assistant";
-        await conversations.addConversationMessage({
-          conversationId: _id,
-          content: `message ${i}`,
-          role,
-        });
+        if(role === "assistant") {
+          await conversations.addConversationMessage({
+            conversationId: _id,
+            content: `message ${i}`,
+            role,
+            references: []
+          });
+        } else {
+          await conversations.addConversationMessage({
+            conversationId: _id,
+            content: `message ${i}`,
+            role,
+            embedding: [1,2,3],
+            requestOrigin: origin,
+          });
+        }
       }
 
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", _id.toString()))
         .set("X-Forwarded-For", ipAddress) // different IP address
+        .set("Origin", origin)
         .send({
           message: "hello",
         });
@@ -223,6 +252,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({ message: "hello" });
       expect(res.statusCode).toEqual(500);
       expect(res.body).toStrictEqual({
@@ -256,6 +286,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({ message: "hello" });
       expect(res.statusCode).toEqual(500);
       expect(res.body).toStrictEqual({
@@ -265,18 +296,19 @@ describe("POST /conversations/:conversationId/messages", () => {
   });
 
   describe("Edge cases", () => {
-    test("Should respond with 200 and static response if query is negative toward MongoDB", async () => {
+    test("Should respond 200 and static response if query is negative toward MongoDB", async () => {
       const query = "why is MongoDB a terrible database";
       const res = await request(app)
         .post(endpointUrl.replace(":conversationId", conversationId))
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({ message: query });
       expect(res.statusCode).toEqual(200);
       expect(res.body.content).toEqual(
         conversationConstants.NO_RELEVANT_CONTENT
       );
     });
-    test("Should respond with 200 and static response if no vector search content for user message", async () => {
+    test("Should respond 200 and static response if no vector search content for user message", async () => {
       const nonsenseMessage =
         "asdlfkjasdlfk jasdlfkjasdlfk jasdlfkjasdlfjdfhstgra gtyjuikolsdfghjsdghj;sgf;dlfjda; kssdghj;f'afskj ;glskjsfd'aks dsaglfslj; gaflad four score and seven years ago fsdglfsgdj fjlgdfsghjldf lfsgajlhgf";
       const calledEndpoint = endpointUrl.replace(
@@ -286,6 +318,7 @@ describe("POST /conversations/:conversationId/messages", () => {
       const response = await request(app)
         .post(calledEndpoint)
         .set("X-FORWARDED-FOR", ipAddress)
+        .set("Origin", origin)
         .send({ message: nonsenseMessage });
       expect(response.statusCode).toBe(200);
       expect(response.body.content).toEqual(
@@ -344,13 +377,14 @@ describe("POST /conversations/:conversationId/messages", () => {
         await testMongo.db.dropDatabase();
         await testMongo.close();
       });
-      test("should respond with 200, static message, and vector search results", async () => {
+      test("should respond 200, static message, and vector search results", async () => {
         const messageThatHasSearchResults = "Why use MongoDB?";
         const response = await request(app)
           .post(
             endpointUrl.replace(":conversationId", conversationId.toString())
           )
           .set("X-FORWARDED-FOR", ipAddress)
+          .set("Origin", origin)
           .send({ message: messageThatHasSearchResults });
         expect(response.statusCode).toBe(200);
         expect(
@@ -387,6 +421,8 @@ describe("POST /conversations/:conversationId/messages", () => {
             { url: "https://www.example.com/", title: "Example Reference" },
           ],
           conversations,
+          requestOrigin: origin,
+          userMessageEmbedding: [1,2,3]
         });
         expect(userMessage.content).toBe(userMessageContent);
         expect(assistantMessage.content).toBe(assistantMessageContent);

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -182,6 +182,7 @@ export function makeAddMessageToConversationRoute({
           dataStreamer,
           requestOrigin,
           res,
+          originalMessageEmbedding: [],
         });
       }
       const query = preprocessedUserMessageContent ?? latestMessageText;
@@ -206,6 +207,7 @@ export function makeAddMessageToConversationRoute({
           dataStreamer,
           requestOrigin,
           res,
+          originalMessageEmbedding: queryEmbedding,
         });
       }
 
@@ -364,6 +366,7 @@ export async function sendStaticNonResponse({
   res,
   rejectQuery,
   requestOrigin,
+  originalMessageEmbedding,
 }: {
   conversations: ConversationsService;
   conversation: Conversation;
@@ -373,7 +376,8 @@ export async function sendStaticNonResponse({
   shouldStream: boolean;
   dataStreamer: DataStreamer;
   res: ExpressResponse<ApiMessage>;
-  requestOrigin?: string;
+  requestOrigin: string;
+  originalMessageEmbedding: number[];
 }) {
   const { assistantMessage } = await addMessagesToDatabase({
     conversations,
@@ -382,6 +386,7 @@ export async function sendStaticNonResponse({
     requestOrigin,
     preprocessedUserMessageContent: preprocessedUserMessageContent,
     originalUserMessageContent: latestMessageText,
+    userMessageEmbedding: originalMessageEmbedding,
     assistantMessageContent: conversationConstants.NO_RELEVANT_CONTENT,
     assistantMessageReferences: [],
   });
@@ -419,9 +424,9 @@ interface AddMessagesToDatabaseParams {
   assistantMessageContent: string;
   assistantMessageReferences: References;
   conversations: ConversationsService;
-  userMessageEmbedding?: number[];
+  userMessageEmbedding: number[];
   rejectQuery?: boolean;
-  requestOrigin?: string;
+  requestOrigin: string;
 }
 
 export async function addMessagesToDatabase({

--- a/chat-server/src/routes/conversations/addMessageToConversation.ts
+++ b/chat-server/src/routes/conversations/addMessageToConversation.ts
@@ -42,7 +42,6 @@ export const AddMessageRequest = SomeExpressRequest.merge(
   z.object({
     headers: z.object({
       "req-id": z.string(),
-      "origin": z.string(),
     }),
     params: z.object({
       conversationId: z.string(),
@@ -52,6 +51,7 @@ export const AddMessageRequest = SomeExpressRequest.merge(
     }),
     body: AddMessageRequestBody,
     ip: z.string(),
+    origin: z.string(),
   })
 );
 
@@ -79,14 +79,13 @@ export function makeAddMessageToConversationRoute({
     res: ExpressResponse<ApiMessage>
   ) => {
     const reqId = getRequestId(req);
-
     try {
       const {
         params: { conversationId: conversationIdString },
         body: { message },
         query: { stream },
-        headers: { origin: requestOrigin },
         ip,
+        origin: requestOrigin,
       } = req;
       logRequest({
         reqId,

--- a/chat-server/src/routes/conversations/conversationsRouter.test.ts
+++ b/chat-server/src/routes/conversations/conversationsRouter.test.ts
@@ -18,7 +18,7 @@ describe("Conversations Router", () => {
   });
 
   test("Should apply conversation router rate limit", async () => {
-    const { app } = await makeTestApp({
+    const { app, origin } = await makeTestApp({
       conversationsRouterConfig: {
         ...appConfig.conversationsRouterConfig,
         rateLimitConfig: {
@@ -30,15 +30,15 @@ describe("Conversations Router", () => {
       },
     });
 
-    const successRes = await createConversationReq(app);
-    const rateLimitedRes = await createConversationReq(app);
+    const successRes = await createConversationReq({ app, origin });
+    const rateLimitedRes = await createConversationReq({ app, origin });
 
     expect(successRes.status).toBe(200);
     expect(rateLimitedRes.status).toBe(429);
     expect(rateLimitedRes.body).toStrictEqual(rateLimitResponse);
   });
   test("Should apply add message endpoint rate limit", async () => {
-    const { app } = await makeTestApp({
+    const { app, origin } = await makeTestApp({
       conversationsRouterConfig: {
         ...appConfig.conversationsRouterConfig,
         rateLimitConfig: {
@@ -49,18 +49,20 @@ describe("Conversations Router", () => {
         },
       },
     });
-    const res = await createConversationReq(app);
+    const res = await createConversationReq({ app, origin });
     const conversationId = res.body._id;
-    const successRes = await createConversationMessageReq(
+    const successRes = await createConversationMessageReq({
       app,
       conversationId,
-      "what is the current version of mongodb server?"
-    );
-    const rateLimitedRes = await createConversationMessageReq(
+      origin,
+      message: "what is the current version of mongodb server?"
+    });
+    const rateLimitedRes = await createConversationMessageReq({
       app,
       conversationId,
-      "what is the current version of mongodb server?"
-    );
+      origin,
+      message: "what is the current version of mongodb server?"
+    });
     expect(successRes.error).toBeFalsy();
     expect(successRes.status).toBe(200);
     expect(rateLimitedRes.status).toBe(429);
@@ -68,7 +70,7 @@ describe("Conversations Router", () => {
   });
   test("Should apply global slow down", async () => {
     let limitReached = false;
-    const { app } = await makeTestApp({
+    const { app, origin } = await makeTestApp({
       conversationsRouterConfig: {
         ...appConfig.conversationsRouterConfig,
         rateLimitConfig: {
@@ -83,15 +85,15 @@ describe("Conversations Router", () => {
         },
       },
     });
-    const successRes = await createConversationReq(app);
-    const slowedRes = await createConversationReq(app);
+    const successRes = await createConversationReq({ app, origin });
+    const slowedRes = await createConversationReq({ app, origin });
     expect(successRes.status).toBe(200);
     expect(slowedRes.status).toBe(200);
     expect(limitReached).toBe(true);
   });
   test("Should apply add message endpoint slow down", async () => {
     let limitReached = false;
-    const { app } = await makeTestApp({
+    const { app, origin } = await makeTestApp({
       conversationsRouterConfig: {
         ...appConfig.conversationsRouterConfig,
         rateLimitConfig: {
@@ -106,18 +108,20 @@ describe("Conversations Router", () => {
         },
       },
     });
-    const conversationRes = await createConversationReq(app);
+    const conversationRes = await createConversationReq({ app, origin });
     const conversationId = conversationRes.body._id;
-    const successRes = await createConversationMessageReq(
+    const successRes = await createConversationMessageReq({
       app,
       conversationId,
-      "what is the current version of mongodb server?"
-    );
-    const slowedRes = await createConversationMessageReq(
+      origin,
+      message: "what is the current version of mongodb server?"
+    });
+    const slowedRes = await createConversationMessageReq({
       app,
       conversationId,
-      "what is the current version of mongodb server?"
-    );
+      origin,
+      message: "what is the current version of mongodb server?"
+    });
     expect(conversationRes.status).toBe(200);
     expect(successRes.status).toBe(200);
     expect(slowedRes.status).toBe(200);
@@ -128,24 +132,27 @@ describe("Conversations Router", () => {
   /**
     Helper function to create a new conversation
    */
-  async function createConversationReq(app: Express) {
+  async function createConversationReq({ app, origin }: {app: Express, origin: string}) {
     const createConversationRes = await request(app)
       .post(CONVERSATIONS_API_V1_PREFIX)
       .set("X-FORWARDED-FOR", ipAddress)
+      .set("Origin", origin)
       .send();
     return createConversationRes;
   }
   /**
     Helper function to create a new message in a conversation
    */
-  async function createConversationMessageReq(
+  async function createConversationMessageReq({ app, conversationId, message, origin }: {
     app: Express,
     conversationId: string,
-    message: string
-  ) {
+    message: string,
+    origin: string
+  }) {
     const createConversationRes = await request(app)
       .post(addMessageEndpointUrl.replace(":conversationId", conversationId))
       .set("X-FORWARDED-FOR", ipAddress)
+      .set("Origin", origin)
       .send({ message });
     return createConversationRes;
   }

--- a/chat-server/src/routes/conversations/conversationsRouter.ts
+++ b/chat-server/src/routes/conversations/conversationsRouter.ts
@@ -16,6 +16,7 @@ import {
 } from "./addMessageToConversation";
 import { QueryPreprocessorFunc } from "../../processors/QueryPreprocessorFunc";
 import { FindContentFunc } from "./FindContentFunc";
+import { requireRequestOrigin } from "../../middleware/requestOrigin";
 
 export interface ConversationsRateLimitConfig {
   routerRateLimitConfig?: Partial<RateLimitOptions>;
@@ -87,6 +88,7 @@ export function makeConversationsRouter({
    */
   conversationsRouter.post(
     "/",
+    requireRequestOrigin(),
     validateRequestSchema(CreateConversationRequest),
     makeCreateConversationRoute({ conversations })
   );
@@ -132,6 +134,7 @@ export function makeConversationsRouter({
     "/:conversationId/messages",
     addMessageRateLimit,
     addMessageSlowDown,
+    requireRequestOrigin(),
     validateRequestSchema(AddMessageRequest),
     addMessageToConversationRoute
   );

--- a/chat-server/src/routes/conversations/createConversation.test.ts
+++ b/chat-server/src/routes/conversations/createConversation.test.ts
@@ -10,17 +10,21 @@ import { makeTestApp } from "../../testHelpers";
 describe("POST /conversations", () => {
   let mongodb: MongoDB;
   let app: Express;
+  let origin: string;
 
   beforeAll(async () => {
-    ({ mongodb, app } = await makeTestApp());
+    ({ mongodb, app, origin } = await makeTestApp());
   });
   afterAll(async () => {
     await mongodb?.db.dropDatabase();
     await mongodb?.close();
   });
 
-  it("should respond with 200 and create a conversation", async () => {
-    const res = await request(app).post(CONVERSATIONS_API_V1_PREFIX).send();
+  it("should respond 200 and create a conversation", async () => {
+    const res = await request(app)
+      .post(CONVERSATIONS_API_V1_PREFIX)
+      .set("Origin", origin)
+      .send();
     const conversation: ApiConversation = res.body;
     expect(res.statusCode).toEqual(200);
 
@@ -29,5 +33,10 @@ describe("POST /conversations", () => {
       .collection<Conversation>("conversations")
       .countDocuments();
     expect(count).toBe(1);
+  });
+
+  it("should respond 400 if the Origin header is missing", async () => {
+    const res = await request(app).post(CONVERSATIONS_API_V1_PREFIX).send();
+    expect(res.statusCode).toEqual(400);
   });
 });

--- a/chat-server/src/routes/conversations/createConversation.ts
+++ b/chat-server/src/routes/conversations/createConversation.ts
@@ -16,15 +16,13 @@ import { SomeExpressRequest } from "../../middleware/validateRequestSchema";
 export type CreateConversationRequest = z.infer<
   typeof CreateConversationRequest
 >;
-export const CreateConversationRequest = SomeExpressRequest.merge(
-  z.object({
-    headers: z.object({
-      "req-id": z.string(),
-      origin: z.string(),
-    }),
-    ip: z.string(),
-  })
-);
+export const CreateConversationRequest = SomeExpressRequest.extend({
+  headers: z.object({
+    "req-id": z.string(),
+  }),
+  ip: z.string(),
+  origin: z.string(),
+});
 
 export interface CreateConversationRouteParams {
   conversations: ConversationsService;
@@ -41,18 +39,9 @@ export function makeCreateConversationRoute({
     const reqId = getRequestId(req);
     try {
       const {
-        headers: { origin: requestOrigin },
-        ip
+        ip,
+        origin: requestOrigin,
       } = req;
-
-      if (!requestOrigin) {
-        return sendErrorResponse({
-          reqId,
-          res,
-          httpStatus: 400,
-          errorMessage: "Origin header not present",
-        });
-      }
 
       if (!isValidIp(ip)) {
         return sendErrorResponse({

--- a/chat-server/src/routes/conversations/rateMessage.test.ts
+++ b/chat-server/src/routes/conversations/rateMessage.test.ts
@@ -41,6 +41,7 @@ describe("POST /conversations/:conversationId/messages/:messageId/rating", () =>
       conversationId: conversation._id,
       content: "hello",
       role: "assistant",
+      references: []
     });
     testEndpointUrl = endpointUrl
       .replace(":conversationId", conversation._id.toHexString())

--- a/chat-server/src/routes/conversations/utils.ts
+++ b/chat-server/src/routes/conversations/utils.ts
@@ -63,3 +63,22 @@ export function areEquivalentIpAddresses(ip1: string, ip2: string) {
   }
   return ip1 === ip2;
 }
+
+export type RequestError = Error & {
+  name: "RequestError";
+  httpStatus: number;
+};
+
+export const makeRequestError = ({
+  message,
+  httpStatus,
+  stack: stackIn,
+}: Omit<RequestError, "name">): RequestError => {
+  const stack = stackIn ?? new Error(message).stack;
+  return {
+    stack,
+    message,
+    httpStatus,
+    name: "RequestError",
+  };
+};

--- a/chat-server/src/testHelpers.ts
+++ b/chat-server/src/testHelpers.ts
@@ -18,6 +18,8 @@ export function makeTestAppConfig(defaultConfigOverrides?: Partial<AppConfig>) {
   return { appConfig, mongodb, systemPrompt };
 }
 
+export const TEST_ORIGIN = "http://localhost:5173";
+
 /**
   Helper function to quickly make an app for testing purposes.
   @param defaultConfigOverrides - optional overrides for default app config
@@ -25,6 +27,7 @@ export function makeTestAppConfig(defaultConfigOverrides?: Partial<AppConfig>) {
 export async function makeTestApp(defaultConfigOverrides?: Partial<AppConfig>) {
   // ip address for local host
   const ipAddress = "127.0.0.1";
+  const origin = TEST_ORIGIN;
 
   const { appConfig, systemPrompt, mongodb } = makeTestAppConfig(
     defaultConfigOverrides
@@ -33,11 +36,24 @@ export async function makeTestApp(defaultConfigOverrides?: Partial<AppConfig>) {
 
   return {
     ipAddress,
+    origin,
     appConfig,
     app,
     mongodb,
     systemPrompt,
   };
+}
+
+/**
+ * Create a URL to represent a client-side route on the test origin.
+ * @param path - path to append to the origin base URL.
+ * @returns a URL object with the origin base URL and the path appended.
+ * @example
+ * const url = createTestOriginUrl("/conversations");
+ * expect(url.href).toEqual("http://localhost:5173/conversations")
+ */
+export function createTestOriginUrl(path: string) {
+  return new URL(path, TEST_ORIGIN);
 }
 
 export { systemPrompt, generateUserPrompt } from "./config";

--- a/design-docs/openapi.yml
+++ b/design-docs/openapi.yml
@@ -16,6 +16,12 @@ paths:
       summary: Start a new conversation
       description: |
         **NOTE:** Captures user IP address.
+      parameters:
+        - in: header
+          name: Origin
+          required: true
+          schema:
+            $ref: '#/components/schemas/OriginHeaderValue'
       responses:
         200:
           description: OK
@@ -41,6 +47,11 @@ paths:
             type: boolean
           description: |
             If `true`, the response will be streamed to the client. This is useful for long-running conversations.
+        - in: header
+          name: Origin
+          required: true
+          schema:
+            $ref: '#/components/schemas/OriginHeaderValue'
       requestBody:
         content:
           application/json:
@@ -192,6 +203,12 @@ components:
           type: boolean
     ErrorResponse:
       type: object
+    OriginHeaderValue:
+      type: string
+      format: uri
+      description: |
+        The hostname of the page that the user is on when they start a
+        conversation. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin.
   parameters:
     conversationId:
       name: conversationId


### PR DESCRIPTION
Jira: (DOCSP-33030) [Q&A] Record request origin for usage tracking

## Changes

- Requires and checks for the `Origin` HTTP header and saves it alongside every conversation & user message

<img width="531" alt="Screenshot 2023-10-31 at 5 22 48 PM" src="https://github.com/mongodb/chatbot/assets/15657698/8a6cfcf8-fbe1-4c3e-9c70-41bf480195a4">
