### PR TITLE
(EAI-44): Ingest Prisma docs

### DIFF
--- a/ingest-mongodb-public/package.json
+++ b/ingest-mongodb-public/package.json
@@ -14,7 +14,9 @@
     "build": "tsc -b",
     "watch": "tsc -b -w",
     "release": "release-it",
-    "ingest:all": "../node_modules/mongodb-rag-ingest/build/main.js all --config ./build/config.js"
+    "ingest:all": "ingest all --config ./build/config.js",
+    "ingest:pages": "ingest pages --config ./build/config.js",
+    "ingest:embed": "ingest embed --config ./build/config.js"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7",

--- a/ingest-mongodb-public/src/sources/index.ts
+++ b/ingest-mongodb-public/src/sources/index.ts
@@ -16,6 +16,8 @@ import {
   prepareSnootySources,
   LocallySpecifiedSnootyProjectConfig,
 } from "mongodb-rag-ingest/sources/snooty";
+import { prismaSourceConstructor } from "./prisma";
+// import { prismaSourceConstructor } from "./prisma";
 
 /**
   Async constructor for specific data sources -- parameters baked in.
@@ -555,6 +557,7 @@ export const sourceConstructors: SourceConstructor[] = [
   () => makeDevCenterDataSource(devCenterProjectConfig),
   pyMongoSourceConstructor,
   mongooseSourceConstructor,
+  prismaSourceConstructor,
   cppSourceConstructor,
   mongoDbCorpDataSource,
   practicalAggregationsDataSource,

--- a/ingest-mongodb-public/src/sources/prisma.ts
+++ b/ingest-mongodb-public/src/sources/prisma.ts
@@ -1,0 +1,72 @@
+import { makeMdOnGithubDataSource } from "mongodb-rag-ingest/sources";
+
+/**
+  This is necessary for the Prisma source because the Prisma docs
+  use a naming convention for their files that includes a number
+  at the beginning of the file name segments. This number is not included
+  in the URL for the page, so we need to remove it from the path.
+
+  @example
+  The docs source structure page names like:
+
+  ```txt
+  docs/content/300-guides/025-migrate/300-seed-database.mdx
+  ```
+
+  This function converts that to:
+
+  ```txt
+  docs/content/guides/migrate/seed-database.mdx
+  ```
+ */
+function removeNumbersFromPath(path: string) {
+  return path
+    .split("/")
+    .map((segment) => segment.replace(/^\d+-/, ""))
+    .join("/");
+}
+export const prismaSourceConstructor = async () => {
+  const repoUrl = "https://github.com/prisma/docs";
+  const repoLoaderOptions = {
+    branch: "main",
+    recursive: true,
+  };
+  return await makeMdOnGithubDataSource({
+    name: "prisma",
+    repoUrl,
+    repoLoaderOptions,
+    filter: (path: string) => path.includes("mongodb") && path.endsWith(".mdx"),
+    pathToPageUrl(path, frontMatter) {
+      console.log("path:", path);
+      const numberFreePath = removeNumbersFromPath(path);
+      let url = numberFreePath
+        .replace(/^\/content\//, "https://www.prisma.io/docs/")
+        .replace(/\.mdx$/, "");
+      if (frontMatter?.langSwitcher) {
+        const langSwitcher = frontMatter.langSwitcher as string[];
+        url += `-${langSwitcher[0]}`;
+      }
+      if (frontMatter?.dbSwitcher) {
+        url += "-mongodb";
+      }
+      return url;
+    },
+    extractTitle(_pageContent, frontMatter) {
+      // metaTitle is more descriptive
+      if (typeof frontMatter?.metaTitle === "string") {
+        return frontMatter.metaTitle;
+      }
+      // Fallback to title
+      if (typeof frontMatter?.title === "string") {
+        return frontMatter.title;
+      }
+    },
+    extractMetadata(_pageContent, frontMatter) {
+      if (typeof frontMatter?.metaDescription === "string") {
+        return {
+          description: frontMatter.metaDescription,
+        };
+      } else return {};
+    },
+  });
+};

--- a/ingest/src/sources/MdOnGithubDataSource.ts
+++ b/ingest/src/sources/MdOnGithubDataSource.ts
@@ -18,6 +18,8 @@ export type MakeMdOnGithubDataSourceParams = Omit<
     frontMatter?: Record<string, unknown>
   ) => string;
 
+  filter?: MakeGitHubDataSourceArgs["filter"];
+
   /**
     Metadata to include with all Pages in DB.
    */
@@ -72,6 +74,7 @@ export const makeMdOnGithubDataSource = async ({
   repoUrl,
   repoLoaderOptions,
   pathToPageUrl,
+  filter,
   metadata,
   frontMatter = { process: true, separator: "---", format: "yaml" },
   extractMetadata,
@@ -80,10 +83,11 @@ export const makeMdOnGithubDataSource = async ({
   return makeGitHubDataSource({
     name,
     repoUrl,
+    filter,
     repoLoaderOptions: {
       ...(repoLoaderOptions ?? {}),
       ignoreFiles: [
-        /^(?!.*\.md$).*/i, // Anything BUT .md extension
+        /^(?!.*\.(md|mdx)$).*/i, // Anything BUT .md OR .mdx extensions
         ...(repoLoaderOptions?.ignoreFiles ?? []),
       ],
     },


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-44

## Changes

- Add Prisma MongoDB docs data source
- Add functional filter to Github data source

## Notes

- We really should add some integration tests on `ingest-mongodb-public` and split up `sources/index.ts` into into separate files. Doing this as part of - https://jira.mongodb.org/browse/EAI-151
