### PR TITLE
(EAI-206): Add authorized user to conversation custom data if env != prod && authorized user cookie exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13181,6 +13181,15 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-KoooCrD56qlLskXPLGUiJxOMnv5l/8m7cQD2OxJ73NPMhuSz9PmvwRD6EpjDyKBVrdJDdQ4bQK7JFNHnNmax0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -17074,6 +17083,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -38301,6 +38330,7 @@
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.5",
         "common-tags": "^1.8.2",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -38324,6 +38354,7 @@
         "@release-it/bumper": "^5.1.0",
         "@types/common-tags": "^1.8.1",
         "@types/connect-timeout": "^0.0.37",
+        "@types/cookie-parser": "^1.4.6",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/express-slow-down": "^1.3.2",

--- a/packages/chatbot-server-mongodb-public/package.json
+++ b/packages/chatbot-server-mongodb-public/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.5",
     "common-tags": "^1.8.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
@@ -50,6 +51,7 @@
     "@release-it/bumper": "^5.1.0",
     "@types/common-tags": "^1.8.1",
     "@types/connect-timeout": "^0.0.37",
+    "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/express-slow-down": "^1.3.2",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-206

## Changes

- Add ability to get authorized user from the cookie that CorpSecure sets in lower level envs. 
- Explicitly add `requireRequestOrigin()` and `requireValidIpAddress()` middleware and logic to add these to the conversation custom data b/c the new functionality to get the auth user overrides the defaults which used these. 

## Notes

- To use this functionality, you **must** access the site behind CorpSecure, such as our staging URL http://chat-server.docs.staging.corp.mongodb.com/
  - However, the staging site that sits behind CDN + firewall will not work for this functionality (https://knowledge.staging.corp.mongodb.com/). This site isn't behind CorpSecure, just IP-restricted firewall. 
