### PR TITLE
(EAI-33): Move cleanup to testHelpers

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/llmQualitativeTests/generateChatTranscript.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/llmQualitativeTests/generateChatTranscript.test.ts
@@ -3,15 +3,11 @@ import {
   ConversationsService,
   AppConfig,
   DEFAULT_API_PREFIX,
-  Db,
-  MongoClient,
 } from "mongodb-chatbot-server";
 import { makeTestApp } from "../test/testHelpers";
 import { generateTranscript } from "./generateChatTranscript";
 import { stripIndents } from "common-tags";
 
-let db: Db;
-let mongoClient: MongoClient;
 let app: Express;
 let conversations: ConversationsService;
 let ipAddress: string;
@@ -22,12 +18,8 @@ const addMessageEndpoint =
 
 jest.setTimeout(20000);
 beforeAll(async () => {
-  ({ db, mongoClient, app, appConfig, ipAddress } = await makeTestApp());
+  ({ app, appConfig, ipAddress } = await makeTestApp());
   conversations = appConfig.conversationsRouterConfig.conversations;
-});
-afterAll(async () => {
-  await db.dropDatabase();
-  await mongoClient?.close();
 });
 describe("generateChatTranscript()", () => {
   test("Should generate a transcript when 1 message", async () => {

--- a/packages/chatbot-server-mongodb-public/src/test/testHelpers.ts
+++ b/packages/chatbot-server-mongodb-public/src/test/testHelpers.ts
@@ -1,16 +1,33 @@
+import { strict as assert } from "assert";
 import {
   MongoClient,
+  Db,
   AppConfig,
   makeApp,
   makeMongoDbConversationsService,
 } from "mongodb-chatbot-server";
 import { MONGODB_CONNECTION_URI, config, systemPrompt } from "../config";
 
+let mongoClient: MongoClient | undefined;
+let mongodb: Db | undefined;
+let testDbName: string | undefined;
+
+beforeAll(async () => {
+  testDbName = `conversations-test-${Date.now()}`;
+  mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
+  mongodb = mongoClient.db(testDbName);
+});
+
+afterAll(async () => {
+  await mongodb?.dropDatabase();
+  await mongoClient?.close();
+});
+
 export function makeTestAppConfig(defaultConfigOverrides?: Partial<AppConfig>) {
-  const testDbName = `conversations-test-${Date.now()}`;
-  const mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
-  const db = mongoClient.db(testDbName);
-  const conversations = makeMongoDbConversationsService(db, systemPrompt);
+  assert(mongodb !== undefined);
+  assert(mongoClient !== undefined);
+
+  const conversations = makeMongoDbConversationsService(mongodb, systemPrompt);
   const appConfig: AppConfig = {
     ...config,
     conversationsRouterConfig: {
@@ -19,7 +36,7 @@ export function makeTestAppConfig(defaultConfigOverrides?: Partial<AppConfig>) {
     },
     ...(defaultConfigOverrides ?? {}),
   };
-  return { appConfig, db, conversations, systemPrompt, mongoClient };
+  return { appConfig, mongodb, conversations, systemPrompt };
 }
 
 /**
@@ -30,8 +47,9 @@ export async function makeTestApp(defaultConfigOverrides?: Partial<AppConfig>) {
   // ip address for local host
   const ipAddress = "127.0.0.1";
 
-  const { appConfig, systemPrompt, db, mongoClient, conversations } =
-    makeTestAppConfig(defaultConfigOverrides);
+  const { appConfig, systemPrompt, mongodb, conversations } = makeTestAppConfig(
+    defaultConfigOverrides
+  );
   const app = await makeApp(appConfig);
 
   return {
@@ -39,8 +57,7 @@ export async function makeTestApp(defaultConfigOverrides?: Partial<AppConfig>) {
     appConfig,
     conversations,
     ipAddress,
-    mongoClient,
-    db,
+    mongodb,
     systemPrompt,
   };
 }

--- a/packages/mongodb-chatbot-server/src/app.test.ts
+++ b/packages/mongodb-chatbot-server/src/app.test.ts
@@ -6,18 +6,14 @@ import { makeTestAppConfig } from "./test/testHelpers";
 
 describe("App", () => {
   let app: Express;
-  const { appConfig, mongodb, mongoClient } = makeTestAppConfig();
   beforeAll(async () => {
+    const { appConfig } = makeTestAppConfig();
     app = await makeApp({
       ...appConfig,
       corsOptions: {
         origin: ["http://localhost:3000", "http://example.com"],
       },
     });
-  });
-  afterAll(async () => {
-    await mongodb.dropDatabase();
-    await mongoClient.close();
   });
   test("should server static files", async () => {
     const { appConfig } = makeTestAppConfig();

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -34,7 +34,6 @@ const { OPENAI_CHAT_COMPLETION_DEPLOYMENT, OPENAI_ENDPOINT } =
 jest.setTimeout(100000);
 describe("POST /conversations/:conversationId/messages", () => {
   let mongodb: Db;
-  let mongoClient: MongoClient;
   let ipAddress: string;
   let origin: string;
   let conversations: ConversationsService;
@@ -42,16 +41,10 @@ describe("POST /conversations/:conversationId/messages", () => {
   let appConfig: AppConfig;
 
   beforeAll(async () => {
-    ({ ipAddress, origin, mongodb, app, appConfig, mongoClient } =
-      await makeTestApp());
+    ({ ipAddress, origin, mongodb, app, appConfig } = await makeTestApp());
     ({
       conversationsRouterConfig: { conversations },
     } = appConfig);
-  });
-
-  afterAll(async () => {
-    await mongodb.dropDatabase();
-    await mongoClient.close();
   });
 
   let conversationId: string;
@@ -355,11 +348,9 @@ describe("POST /conversations/:conversationId/messages", () => {
         conversations: ConversationsService,
         app: Express;
       let testMongo: Db;
-      let testMongoClient: MongoClient;
       beforeEach(async () => {
-        const { mongodb, mongoClient, appConfig } = makeTestAppConfig();
+        const { mongodb, appConfig } = makeTestAppConfig();
         testMongo = mongodb;
-        testMongoClient = mongoClient;
         ({ app } = await makeTestApp({
           ...appConfig,
           conversationsRouterConfig: {
@@ -374,10 +365,6 @@ describe("POST /conversations/:conversationId/messages", () => {
         );
         const { _id } = await conversations.create();
         conversationId = _id;
-      });
-      afterEach(async () => {
-        await testMongo.dropDatabase();
-        await testMongoClient.close();
       });
       test("should respond 200, static message, and vector search results", async () => {
         const messageThatHasSearchResults = "Why use MongoDB?";

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import { Express } from "express";
+import { AppConfig } from "../../app";
 import {
   ConversationsMiddleware,
   rateLimitResponse,
@@ -14,13 +15,11 @@ describe("Conversations Router", () => {
   const ipAddress = "127.0.0.1";
   const addMessageEndpointUrl =
     DEFAULT_API_PREFIX + "/conversations/:conversationId/messages";
-  const { mongodb, appConfig, mongoClient } = makeTestAppConfig();
-  afterAll(async () => {
-    // clean up
-    await mongodb.dropDatabase();
-    await mongoClient.close();
-  });
 
+  let appConfig: AppConfig;
+  beforeAll(() => {
+    ({ appConfig } = makeTestAppConfig());
+  });
   test("Should apply conversation router rate limit", async () => {
     const { app, origin } = await makeTestApp({
       conversationsRouterConfig: {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/createConversation.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/createConversation.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import "dotenv/config";
-import { ObjectId } from "mongodb-rag-core";
+import { AppConfig } from "../../app";
+import { Db, ObjectId } from "mongodb-rag-core";
 import { Conversation } from "../../services/ConversationsService";
 import { ApiConversation } from "./utils";
 import { DEFAULT_API_PREFIX } from "../../app";
@@ -8,11 +9,10 @@ import { makeTestApp, makeTestAppConfig } from "../../test/testHelpers";
 
 const CONVERSATIONS_API_V1_PREFIX = DEFAULT_API_PREFIX + "/conversations";
 describe("POST /conversations", () => {
-  const { mongodb, appConfig, mongoClient } = makeTestAppConfig();
-
-  afterAll(async () => {
-    await mongodb.dropDatabase();
-    await mongoClient.close();
+  let appConfig: AppConfig;
+  let mongodb: Db;
+  beforeAll(() => {
+    ({ appConfig, mongodb } = makeTestAppConfig());
   });
 
   it("should respond 200 and create a conversation", async () => {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.test.ts
@@ -1,16 +1,15 @@
-import { ObjectId } from "mongodb";
+import { Db, ObjectId } from "mongodb-rag-core";
+import { ConversationsService } from "../../services";
 import { makeTestApp, makeTestAppConfig } from "../../test/testHelpers";
 import request from "supertest";
-import { DEFAULT_API_PREFIX } from "../../app";
+import { AppConfig, DEFAULT_API_PREFIX } from "../../app";
 const CONVERSATIONS_API_V1_PREFIX = DEFAULT_API_PREFIX + "/conversations";
 
 describe("GET /conversations/:conversationId", () => {
-  const { mongodb, appConfig, mongoClient, conversations } =
-    makeTestAppConfig();
-
-  afterAll(async () => {
-    await mongodb.dropDatabase();
-    await mongoClient.close();
+  let appConfig: AppConfig;
+  let conversations: ConversationsService;
+  beforeAll(() => {
+    ({ appConfig, conversations } = makeTestAppConfig());
   });
 
   it("should return 400 when the conversation ID is invalid", async () => {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/rateMessage.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/rateMessage.test.ts
@@ -26,14 +26,12 @@ describe("POST /conversations/:conversationId/messages/:messageId/rating", () =>
   let testMsg: Message;
   let testEndpointUrl: string;
   let mongodb: Db;
-  let mongoClient: MongoClient;
   let ipAddress: string;
   let appConfig: AppConfig;
   let origin: string;
 
   beforeAll(async () => {
-    ({ mongodb, mongoClient, app, ipAddress, appConfig, origin } =
-      await makeTestApp());
+    ({ mongodb, app, ipAddress, appConfig, origin } = await makeTestApp());
     conversations = appConfig.conversationsRouterConfig.conversations;
 
     app
@@ -52,11 +50,6 @@ describe("POST /conversations/:conversationId/messages/:messageId/rating", () =>
     testEndpointUrl = endpointUrl
       .replace(":conversationId", conversation._id.toHexString())
       .replace(":messageId", String(testMsg.id));
-  });
-
-  afterAll(async () => {
-    await mongodb.dropDatabase();
-    await mongoClient.close();
   });
 
   test("Should return 204 for valid rating", async () => {

--- a/packages/mongodb-chatbot-server/src/services/openAiChatLlm.test.ts
+++ b/packages/mongodb-chatbot-server/src/services/openAiChatLlm.test.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { AzureKeyCredential, OpenAIClient } from "@azure/openai";
-import { OpenAiChatMessage, Tool } from "./ChatLlm";
+import { ChatLlm, OpenAiChatMessage, Tool } from "./ChatLlm";
 import { makeTestAppConfig, systemPrompt } from "../test/testHelpers";
 import { makeOpenAiChatLlm } from "./openAiChatLlm";
 import { assertEnvVars, CORE_ENV_VARS } from "mongodb-rag-core";
@@ -70,10 +70,13 @@ const toolOpenAiLlm = makeOpenAiChatLlm({
   tools: testTools,
 });
 
-const { appConfig: config } = makeTestAppConfig();
-
 describe("OpenAiLlm", () => {
-  const openAiLlmService = config.conversationsRouterConfig.llm;
+  let openAiLlmService: ChatLlm;
+  beforeAll(() => {
+    const { appConfig: config } = makeTestAppConfig();
+    openAiLlmService = config.conversationsRouterConfig.llm;
+  });
+
   test("should answer question in conversation - awaited", async () => {
     const response = await openAiLlmService.answerQuestionAwaited({
       messages: conversation,

--- a/packages/scripts/environments/staging.yml
+++ b/packages/scripts/environments/staging.yml
@@ -64,6 +64,34 @@ cronJobs:
         cpu: 500m
         memory: 5Gi
 
+  - name: clean-up-test-databases-dev
+    schedule: 0 8 * * SUN
+    command: ["npm", "run", "scripts:removeTestDatabases"]
+    envSecrets:
+      # dev cluster
+      MONGODB_CONNECTION_URI: docs-chatbot-scripts-admin-dev
+    resources:
+      requests:
+        cpu: 100m
+        memory: 2Gi
+      limits:
+        cpu: 500m
+        memory: 5Gi
+
+  - name: clean-up-test-databases-test
+    schedule: 0 9 * * SUN
+    command: ["npm", "run", "scripts:removeTestDatabases"]
+    envSecrets:
+      # test cluster
+      MONGODB_CONNECTION_URI: docs-chatbot-scripts-admin-test
+    resources:
+      requests:
+        cpu: 100m
+        memory: 2Gi
+      limits:
+        cpu: 500m
+        memory: 5Gi
+
 # Alerts
 defaultAlerts:
   enabled: true


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-33

## Changes

- Moves test database creation and cleanup to beforeAll/afterAll hooks within the actual test helpers function
- Removes need for callers to drop database or close MongoClient

## Notes

- This still won't clean up in the event of an aborted test run, so we should periodically run the cleanup script
