### PR TITLE
(EAI-226) [UI] Change Conversations without Reload + [SERVER] get conversation route fix

### DIFF
--- a/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.ts
@@ -85,11 +85,13 @@ function convertDbConversationToApiConversation(conversation: Conversation) {
   return {
     _id: conversation._id.toHexString(),
     createdAt: conversation.createdAt.getTime(),
-    messages: conversation.messages.map((message) => ({
-      id: message.id.toHexString(),
-      role: message.role,
-      content: message.content,
-      createdAt: message.createdAt.getTime(),
-    })),
+    messages: conversation.messages
+      .filter((message) => message.role !== "system")
+      .map((message) => ({
+        id: message.id.toHexString(),
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt.getTime(),
+      })),
   } satisfies ApiConversation;
 }

--- a/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.ts
@@ -1,14 +1,16 @@
 import { ObjectId } from "mongodb-rag-core";
-import {
-  Conversation,
-  ConversationsService,
-} from "../../services/ConversationsService";
+import { ConversationsService } from "../../services/ConversationsService";
 import {
   Request as ExpressRequest,
   Response as ExpressResponse,
 } from "express";
 import { getRequestId, logRequest, sendErrorResponse } from "../../utils";
-import { ApiConversation, RequestError, makeRequestError } from "./utils";
+import {
+  ApiConversation,
+  RequestError,
+  convertConversationFromDbToApi,
+  makeRequestError,
+} from "./utils";
 import { z } from "zod";
 import { SomeExpressRequest } from "../../middleware/validateRequestSchema";
 
@@ -54,8 +56,7 @@ export function makeGetConversationRoute({
           httpStatus: 404,
         });
       }
-      const apiConversation =
-        convertDbConversationToApiConversation(conversationInDb);
+      const apiConversation = convertConversationFromDbToApi(conversationInDb);
       logRequest({
         reqId,
         message: `Successfully retrieved conversation: ${apiConversation}`,
@@ -79,19 +80,4 @@ export function makeGetConversationRoute({
       });
     }
   };
-}
-
-function convertDbConversationToApiConversation(conversation: Conversation) {
-  return {
-    _id: conversation._id.toHexString(),
-    createdAt: conversation.createdAt.getTime(),
-    messages: conversation.messages
-      .filter((message) => message.role !== "system")
-      .map((message) => ({
-        id: message.id.toHexString(),
-        role: message.role,
-        content: message.content,
-        createdAt: message.createdAt.getTime(),
-      })),
-  } satisfies ApiConversation;
 }

--- a/packages/mongodb-chatbot-server/src/routes/conversations/utils.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/utils.test.ts
@@ -1,4 +1,11 @@
-import { areEquivalentIpAddresses, isValidIp } from "./utils";
+import { Conversation } from "../../services";
+import {
+  areEquivalentIpAddresses,
+  convertConversationFromDbToApi,
+  convertMessageFromDbToApi,
+  isValidIp,
+} from "./utils";
+import { ObjectId } from "mongodb-rag-core";
 
 describe("Conversation routes utils", () => {
   describe("isValidIp()", () => {
@@ -29,6 +36,140 @@ describe("Conversation routes utils", () => {
       const ipv6 = "::ffff:127.0.0.1";
       expect(areEquivalentIpAddresses(ipv4, ipv6)).toBe(true);
       expect(areEquivalentIpAddresses(ipv6, ipv4)).toBe(true);
+    });
+  });
+});
+
+const exampleConversationInDatabase: Conversation = {
+  _id: new ObjectId("65ca743910cae16a93ff3548"),
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  messages: [
+    {
+      id: new ObjectId("65ca766ab564b694eba8c330"),
+      role: "system",
+      content:
+        "You are an expert conversationalist! You can chat about anything with anyone.",
+      createdAt: new Date("2024-01-01T00:00:01Z"),
+    },
+    {
+      id: new ObjectId("65ca76775a57e51c3b4c286d"),
+      role: "user",
+      content:
+        "Hello! I'm looking for a new book to read. I like fantasy novels. Can you recommend one?",
+      createdAt: new Date("2024-01-01T00:00:42Z"),
+    },
+    {
+      id: new ObjectId("65ca767e30116ce068e17bb5"),
+      role: "assistant",
+      content: "",
+      functionCall: {
+        name: "getBookRecommendations",
+        arguments: JSON.stringify({ genre: ["fantasy"] }),
+      },
+      createdAt: new Date("2024-01-01T00:00:45Z"),
+    },
+    {
+      id: new ObjectId("65ca768341f9ea61d048aaa8"),
+      role: "function",
+      name: "getBookRecommendations",
+      content: JSON.stringify([
+        { title: "The Way of Kings", author: "Brandon Sanderson" },
+        { title: "The Name of the Wind", author: "Patrick Rothfuss" },
+        { title: "Uprooted", author: "Naomi Novik" },
+      ]),
+      createdAt: new Date("2024-01-01T00:00:47Z"),
+    },
+    {
+      id: new ObjectId("65ca76874e1df9cf2742bf86"),
+      role: "assistant",
+      content: `I recommend "The Way of Kings" by Brandon Sanderson. You may also enjoy "The Name of the Wind" by Patrick Rothfuss or "Uprooted" by Naomi Novik.`,
+      createdAt: new Date("2024-01-01T00:00:52Z"),
+    },
+  ],
+};
+
+describe.only("Data Conversion Functions", () => {
+  describe("convertMessageFromDbToApi", () => {
+    test("serializes values", () => {
+      const [
+        systemMessage,
+        userMessage,
+        functionCallMessage,
+        functionResultMessage,
+        assistantMessage,
+      ] = exampleConversationInDatabase.messages;
+
+      expect(convertMessageFromDbToApi(systemMessage)).toEqual({
+        id: "65ca766ab564b694eba8c330",
+        role: "system",
+        content:
+          "You are an expert conversationalist! You can chat about anything with anyone.",
+        createdAt: 1704067201000,
+      });
+
+      expect(convertMessageFromDbToApi(userMessage)).toEqual({
+        id: "65ca76775a57e51c3b4c286d",
+        role: "user",
+        content:
+          "Hello! I'm looking for a new book to read. I like fantasy novels. Can you recommend one?",
+        createdAt: 1704067242000,
+      });
+
+      expect(convertMessageFromDbToApi(functionCallMessage)).toEqual({
+        id: "65ca767e30116ce068e17bb5",
+        role: "assistant",
+        content: "",
+        createdAt: 1704067245000,
+      });
+
+      expect(convertMessageFromDbToApi(functionResultMessage)).toEqual({
+        id: "65ca768341f9ea61d048aaa8",
+        role: "function",
+        content: JSON.stringify([
+          { title: "The Way of Kings", author: "Brandon Sanderson" },
+          { title: "The Name of the Wind", author: "Patrick Rothfuss" },
+          { title: "Uprooted", author: "Naomi Novik" },
+        ]),
+        createdAt: 1704067247000,
+      });
+
+      expect(convertMessageFromDbToApi(assistantMessage)).toEqual({
+        id: "65ca76874e1df9cf2742bf86",
+        role: "assistant",
+        content: `I recommend "The Way of Kings" by Brandon Sanderson. You may also enjoy "The Name of the Wind" by Patrick Rothfuss or "Uprooted" by Naomi Novik.`,
+        createdAt: 1704067252000,
+        rating: undefined,
+        references: undefined,
+      });
+    });
+  });
+
+  describe("convertConversationFromDbToApi", () => {
+    test("serializes values & removes system, assistant:functionCall, and function messages", () => {
+      const apiConversation = convertConversationFromDbToApi(
+        exampleConversationInDatabase
+      );
+      expect(apiConversation).toEqual({
+        _id: "65ca743910cae16a93ff3548",
+        createdAt: 1704067200000,
+        messages: [
+          {
+            id: "65ca76775a57e51c3b4c286d",
+            role: "user",
+            content:
+              "Hello! I'm looking for a new book to read. I like fantasy novels. Can you recommend one?",
+            createdAt: 1704067242000,
+          },
+          {
+            id: "65ca76874e1df9cf2742bf86",
+            role: "assistant",
+            content: `I recommend "The Way of Kings" by Brandon Sanderson. You may also enjoy "The Name of the Wind" by Patrick Rothfuss or "Uprooted" by Naomi Novik.`,
+            createdAt: 1704067252000,
+            rating: undefined,
+            references: undefined,
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/mongodb-chatbot-server/src/routes/conversations/utils.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/utils.test.ts
@@ -88,7 +88,7 @@ const exampleConversationInDatabase: Conversation = {
   ],
 };
 
-describe.only("Data Conversion Functions", () => {
+describe("Data Conversion Functions", () => {
   describe("convertMessageFromDbToApi", () => {
     test("serializes values", () => {
       const [

--- a/packages/mongodb-chatbot-server/src/routes/conversations/utils.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/utils.ts
@@ -1,10 +1,6 @@
 import { isIP } from "net";
 import { Address6 } from "ip-address";
-import {
-  Conversation,
-  Message,
-  AssistantMessage,
-} from "../../services/ConversationsService";
+import { Conversation, Message } from "../../services/ConversationsService";
 import { References } from "mongodb-rag-core";
 import { z } from "zod";
 
@@ -33,7 +29,7 @@ export function convertMessageFromDbToApi(message: Message): ApiMessage {
     content,
     createdAt: createdAt.getTime(),
   };
-  if(role === "assistant") {
+  if (role === "assistant") {
     const { rating, references } = message;
     return {
       ...apiMessage,
@@ -48,7 +44,7 @@ function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }
 
-export function isMessageAllowedInApiResponse(message: Message) {
+function isMessageAllowedInApiResponse(message: Message) {
   // Only return user messages and assistant messages that are not function calls
   switch (message.role) {
     case "system":

--- a/packages/mongodb-chatbot-server/src/routes/conversations/utils.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/utils.ts
@@ -27,26 +27,54 @@ export const ApiConversation = z.object({
 
 export function convertMessageFromDbToApi(message: Message): ApiMessage {
   const { id, createdAt, role, content } = message;
-  const { rating, references } = message as Partial<AssistantMessage>;
-  return {
+  const apiMessage = {
     id: id.toString(),
     role,
     content,
     createdAt: createdAt.getTime(),
-    rating,
-    references,
   };
+  if(role === "assistant") {
+    const { rating, references } = message;
+    return {
+      ...apiMessage,
+      rating,
+      references,
+    };
+  }
+  return apiMessage;
 }
+
+function assertNever(x: never): never {
+  throw new Error("Unexpected object: " + x);
+}
+
+export function isMessageAllowedInApiResponse(message: Message) {
+  // Only return user messages and assistant messages that are not function calls
+  switch (message.role) {
+    case "system":
+      return false;
+    case "user":
+      return true;
+    case "assistant":
+      return message.functionCall === undefined;
+    case "function":
+      return false;
+    default:
+      // This should never happen - it means we missed a case in the switch.
+      // The assertNever function raises a type error if this happens.
+      return assertNever(message);
+  }
+}
+
 export function convertConversationFromDbToApi(
   conversation: Conversation
 ): ApiConversation {
-  const nonSystemMessages = conversation.messages.filter(
-    (msg) => msg.role !== "system"
-  );
   return {
-    _id: conversation._id.toString(),
-    messages: nonSystemMessages.map(convertMessageFromDbToApi),
+    _id: conversation._id.toHexString(),
     createdAt: conversation.createdAt.getTime(),
+    messages: conversation.messages
+      .filter(isMessageAllowedInApiResponse)
+      .map(convertMessageFromDbToApi),
   };
 }
 

--- a/packages/mongodb-chatbot-ui/src/ConversationProvider.tsx
+++ b/packages/mongodb-chatbot-ui/src/ConversationProvider.tsx
@@ -10,6 +10,9 @@ export const ConversationContext = createContext<Conversation>({
   createConversation: async () => {
     return;
   },
+  endConversationWithError: () => {
+    return;
+  },
   addMessage: async () => {
     return;
   },
@@ -25,7 +28,7 @@ export const ConversationContext = createContext<Conversation>({
   commentMessage: async () => {
     return;
   },
-  endConversationWithError: () => {
+  switchConversation: async () => {
     return;
   },
 });

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -125,6 +125,29 @@ export class ConversationService {
     };
   }
 
+  async getConversation(
+    conversationId: string
+  ): Promise<Required<ConversationState>> {
+    const path = `/conversations/${conversationId}`;
+    const resp = await fetch(this.getUrl(path), {
+      headers: {
+        "Content-Type": "application/json",
+        [CUSTOM_REQUEST_ORIGIN_HEADER]: getCustomRequestOrigin() ?? "",
+      },
+    });
+    const conversation = await resp.json();
+    if (resp.status === 404) {
+      throw new Error(`Conversation not found: ${conversationId}`);
+    }
+    if (resp.status !== 200) {
+      throw new Error(`Failed to fetch conversation: ${conversation.error}`);
+    }
+    return {
+      ...conversation,
+      conversationId: conversation._id,
+    };
+  }
+
   async addMessage({
     conversationId,
     message,

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -44,6 +44,7 @@ type ConversationActor = {
   deleteMessage: (messageId: string) => Promise<void>;
   rateMessage: (messageId: string, rating: boolean) => Promise<void>;
   commentMessage: (messageId: string, comment: string) => Promise<void>;
+  switchConversation: (conversationId: string) => Promise<void>;
 };
 
 export type Conversation = ConversationState & ConversationActor;
@@ -306,12 +307,6 @@ export function useConversation(params: UseConversationParams = {}) {
 
   const createConversation = async () => {
     try {
-      if (state.conversationId) {
-        console.error(
-          `Cannot createConversation when conversationId already exists`
-        );
-        return;
-      }
       const conversation = await conversationService.createConversation();
       setConversation({
         ...conversation,
@@ -502,6 +497,31 @@ export function useConversation(params: UseConversationParams = {}) {
     (m) => m.id === STREAMING_MESSAGE_ID
   );
 
+  /**
+   * Switch to a different, existing conversation.
+   */
+  const switchConversation = async (conversationId: string) => {
+    try {
+      const conversation = await conversationService.getConversation(
+        conversationId
+      );
+      setConversation({
+        ...conversation,
+        error: "",
+      });
+    } catch (error) {
+      const errorMessage =
+        typeof error === "string"
+          ? error
+          : error instanceof Error
+          ? error.message
+          : "Failed to switch conversation.";
+      console.error(errorMessage);
+      // Rethrow the error so that we can handle it in the UI
+      throw error;
+    }
+  };
+
   return {
     ...state,
     createConversation,
@@ -512,5 +532,6 @@ export function useConversation(params: UseConversationParams = {}) {
     deleteMessage,
     rateMessage,
     commentMessage,
+    switchConversation,
   } satisfies Conversation;
 }


### PR DESCRIPTION
Jira: (EAI-226) [UI] Change Conversations without Reload

## Changes

- UI
  - `ConversationService`
    - Adds support for the `getConversation` route
  - `useConversation()` hook
    - Adds a `switchConversation()` method to allow switching to a different, existing conversation by ID.
    - Removes a check in `createConversation()` to allow starting a new conversation while one already exists.
- Server
  - fix the get conversations routes so that it doesn't return the system message or non user/assistant response messages. 

## Notes

- This is tough to test because we currently disable the `getConversations` route in our MongoDB server implementation via the [blockGetRequests middleware](https://github.com/mongodb/chatbot/blob/main/packages/chatbot-server-mongodb-public/src/middleware/blockGetRequests.ts).
- To test, you can [comment out this middleware in the config](https://github.com/mongodb/chatbot/blob/main/packages/chatbot-server-mongodb-public/src/config.ts#L140) locally and then add a call to `conversation.switchConversation("65c68cc18726aed95fcf6d73")` somewhere in the code (I suggest adding it to the `shouldClose` handler in `ModalView`).
- Non-MongoDB implementations allow the `getConversations` route by default so this should be handy for them.
