### PR TITLE
(EAI-230): Search endpoint + service

### DIFF
--- a/packages/mongodb-chatbot-server/src/routes/index.ts
+++ b/packages/mongodb-chatbot-server/src/routes/index.ts
@@ -1,2 +1,3 @@
 export * from "./conversations";
 export * from "./staticSite";
+export * from "./search";

--- a/packages/mongodb-chatbot-server/src/routes/search/getContent.ts
+++ b/packages/mongodb-chatbot-server/src/routes/search/getContent.ts
@@ -1,0 +1,64 @@
+import { EmbeddedContent } from "mongodb-rag-core";
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+import { SomeExpressRequest } from "../../middleware";
+import { z } from "zod";
+import { strict as assert } from "assert";
+import { SearchFunc, SearchResult } from "../../services/Search";
+
+export interface GetContentParams {
+  maxLimit?: number;
+  defaultLimit?: number;
+  minLimit?: number;
+  maxOffset?: number;
+  search: SearchFunc;
+}
+
+export const AddMessageRequest = SomeExpressRequest.merge(
+  z.object({
+    headers: z.object({
+      "req-id": z.string(),
+    }),
+    query: z.object({
+      q: z.string(),
+      limit: z.string().optional(),
+      offset: z.string().optional(),
+    }),
+  })
+);
+
+export type AddMessageRequest = z.infer<typeof AddMessageRequest>;
+export interface GetContentResponse {
+  offset: number;
+  limit: number;
+  results: SearchResult[];
+}
+
+export type ConvertEmbeddedContentToSearchResults = (
+  content: EmbeddedContent[]
+) => Promise<SearchResult>;
+
+export function makeGetContentRoute({
+  maxLimit = 100,
+  defaultLimit = 5,
+  minLimit = 1,
+  maxOffset = 0,
+  search,
+}: GetContentParams) {
+  assert(minLimit >= 1, `minLimit must be >= 1. Got: ${minLimit}`);
+  return async (
+    req: ExpressRequest<AddMessageRequest["params"]>,
+    res: ExpressResponse<GetContentResponse[]>
+  ) => {
+    try {
+      // TODO: validate request. throw 400 if invalid
+      // take into account limit and offset in validations
+      // perform search
+      // return search results
+    } catch (err) {
+      // TODO: handle errs...borrow logic from conversations
+    }
+  };
+}

--- a/packages/mongodb-chatbot-server/src/routes/search/index.ts
+++ b/packages/mongodb-chatbot-server/src/routes/search/index.ts
@@ -1,0 +1,2 @@
+export * from "./searchRouter";
+export * from "./getContent";

--- a/packages/mongodb-chatbot-server/src/routes/search/searchRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/search/searchRouter.ts
@@ -1,0 +1,16 @@
+import { RequestHandler, Router } from "express";
+import { GetContentParams, makeGetContentRoute } from "./getContent";
+
+export interface SearchRouterParams {
+  getContentConfig: GetContentParams;
+  middleware?: RequestHandler[];
+}
+
+export function makeSearchRouter({
+  getContentConfig,
+  middleware = [],
+}: SearchRouterParams) {
+  const searchRouter = Router();
+  middleware.forEach((middleware) => searchRouter.use(middleware));
+  searchRouter.get("/", makeGetContentRoute(getContentConfig));
+}

--- a/packages/mongodb-chatbot-server/src/services/Search.ts
+++ b/packages/mongodb-chatbot-server/src/services/Search.ts
@@ -1,0 +1,15 @@
+export interface SearchResult<
+  T extends Record<string, unknown> | undefined = undefined
+> {
+  title?: string;
+  url: string;
+  text?: string;
+  customData?: T;
+}
+
+export interface SearchParams {
+  query: string;
+  limit: number;
+  offset: number;
+}
+export type SearchFunc = (params: SearchParams) => Promise<SearchResult[]>;

--- a/packages/mongodb-chatbot-server/src/services/index.ts
+++ b/packages/mongodb-chatbot-server/src/services/index.ts
@@ -3,3 +3,4 @@ export * from "./ConversationsService";
 export * from "./openAiChatLlm";
 export * from "./dataStreamer";
 export * from "./mongodbConversations";
+export * from "./Search";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-230

## Changes

- [ ] `GET /search` endpoint
- [x] `SearchFunc` type
- [ ] `preprocessedSearch` implementation of `SearchFunc`
- [ ] use a `SearchFunc` in our implementation, so we can use it in qualitative tests
- [ ] Document endpoint
  - [ ] Add new `/server/search` page
  - [ ] Update OpenAPI spec

## Notes

-
