### PR TITLE
(EAI-232):  Scaffold eval package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -1001,7 +1000,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.23.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1009,7 +1007,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -1038,12 +1035,10 @@
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.23.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.23.6",
@@ -1079,7 +1074,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.23.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
@@ -1147,7 +1141,6 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1155,7 +1148,6 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.23.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -1167,7 +1159,6 @@
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.22.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -1199,7 +1190,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.23.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -1228,7 +1218,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1268,7 +1257,6 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.22.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -1290,7 +1278,6 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.22.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -1315,7 +1302,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.23.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1336,7 +1322,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.23.9",
@@ -1418,7 +1403,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1485,7 +1469,6 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1496,7 +1479,6 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1507,7 +1489,6 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1596,7 +1577,6 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1607,7 +1587,6 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1618,7 +1597,6 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.23.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1632,7 +1610,6 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1643,7 +1620,6 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1654,7 +1630,6 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1665,7 +1640,6 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1676,7 +1650,6 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1687,7 +1660,6 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1712,7 +1684,6 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1726,7 +1697,6 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.23.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -2842,7 +2812,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
@@ -2855,7 +2824,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
@@ -2892,7 +2860,6 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@cdxoo/dbscan": {
@@ -2910,7 +2877,7 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2921,7 +2888,7 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -3620,7 +3587,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -3635,7 +3601,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -3647,7 +3612,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -3658,7 +3622,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -3672,7 +3635,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -3683,7 +3645,6 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3691,7 +3652,6 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -3707,7 +3667,6 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -3753,7 +3712,6 @@
     },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3764,7 +3722,6 @@
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -3777,7 +3734,6 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -3791,7 +3747,6 @@
     },
     "node_modules/@jest/environment/node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -3804,7 +3759,6 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -3816,7 +3770,6 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -3827,7 +3780,6 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -3843,7 +3795,6 @@
     },
     "node_modules/@jest/fake-timers/node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -3856,7 +3807,6 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -3870,7 +3820,6 @@
     },
     "node_modules/@jest/globals/node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -3883,7 +3832,6 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -3925,7 +3873,6 @@
     },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3944,7 +3891,6 @@
     },
     "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
       "version": "6.0.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -3959,7 +3905,6 @@
     },
     "node_modules/@jest/reporters/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -3970,7 +3915,6 @@
     },
     "node_modules/@jest/reporters/node_modules/semver": {
       "version": "7.6.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3984,12 +3928,10 @@
     },
     "node_modules/@jest/reporters/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -4000,7 +3942,6 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -4013,7 +3954,6 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -4027,7 +3967,6 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -4041,7 +3980,6 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4066,12 +4004,10 @@
     },
     "node_modules/@jest/transform/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -4155,7 +4091,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -4168,7 +4103,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4176,7 +4110,6 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4184,12 +4117,10 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.22",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -8981,7 +8912,6 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -8996,7 +8926,6 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -9004,7 +8933,6 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -11845,22 +11773,22 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/aria-query": {
@@ -11870,7 +11798,6 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -11882,7 +11809,6 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -11890,7 +11816,6 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -11899,7 +11824,6 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -12066,7 +11990,6 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -12102,12 +12025,10 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -12115,7 +12036,6 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -12352,7 +12272,6 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stream-chain": {
@@ -12426,7 +12345,6 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -12434,7 +12352,6 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -13240,7 +13157,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -13504,7 +13421,6 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -13524,7 +13440,6 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -13539,7 +13454,6 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -13602,7 +13516,6 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -13624,7 +13537,6 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -14017,7 +13929,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.22.3",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14059,7 +13970,6 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -14405,7 +14315,6 @@
       "version": "1.0.30001587",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
       "integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14455,7 +14364,6 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14589,7 +14497,6 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/classnames": {
@@ -14792,7 +14699,6 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -14801,7 +14707,6 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -15452,7 +15357,6 @@
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -15472,7 +15376,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/croner": {
@@ -16094,7 +15998,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16140,7 +16043,7 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -16152,7 +16055,6 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -16605,8 +16507,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.668",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.668.tgz",
-      "integrity": "sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ==",
-      "dev": true
+      "integrity": "sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -16636,7 +16537,6 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -17443,14 +17343,12 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -17716,7 +17614,6 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -17759,7 +17656,6 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -18350,7 +18246,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -18406,7 +18301,6 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -18719,7 +18613,6 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -19123,7 +19016,6 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-tags": {
@@ -19363,7 +19255,6 @@
     },
     "node_modules/import-local": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -19381,7 +19272,6 @@
     },
     "node_modules/import-local/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -19393,7 +19283,6 @@
     },
     "node_modules/import-local/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -19404,7 +19293,6 @@
     },
     "node_modules/import-local/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -19418,7 +19306,6 @@
     },
     "node_modules/import-local/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -19429,7 +19316,6 @@
     },
     "node_modules/import-local/node_modules/pkg-dir": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -19882,7 +19768,6 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20275,7 +20160,6 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -20283,7 +20167,6 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -20298,7 +20181,6 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -20311,7 +20193,6 @@
     },
     "node_modules/istanbul-lib-report/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -20322,7 +20203,6 @@
     },
     "node_modules/istanbul-lib-report/node_modules/make-dir": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -20336,7 +20216,6 @@
     },
     "node_modules/istanbul-lib-report/node_modules/semver": {
       "version": "7.6.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -20350,12 +20229,10 @@
     },
     "node_modules/istanbul-lib-report/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -20368,7 +20245,6 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20376,7 +20252,6 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.1.6",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -20439,8 +20314,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -20464,7 +20339,6 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -20477,7 +20351,6 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -20507,7 +20380,6 @@
     },
     "node_modules/jest-circus/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20520,7 +20392,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -20532,7 +20403,6 @@
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20545,7 +20415,6 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -20577,7 +20446,6 @@
     },
     "node_modules/jest-cli/node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -20590,12 +20458,10 @@
     },
     "node_modules/jest-cli/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-cli/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -20608,7 +20474,6 @@
     },
     "node_modules/jest-cli/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -20624,7 +20489,6 @@
     },
     "node_modules/jest-cli/node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -20641,7 +20505,6 @@
     },
     "node_modules/jest-cli/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -20649,7 +20512,6 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -20693,7 +20555,6 @@
     },
     "node_modules/jest-config/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20704,7 +20565,6 @@
     },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -20723,7 +20583,6 @@
     },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20736,7 +20595,6 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20750,7 +20608,6 @@
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20761,7 +20618,6 @@
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20774,7 +20630,6 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -20785,7 +20640,6 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -20800,7 +20654,6 @@
     },
     "node_modules/jest-each/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20811,7 +20664,6 @@
     },
     "node_modules/jest-each/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20824,7 +20676,6 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -20840,7 +20691,6 @@
     },
     "node_modules/jest-environment-node/node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -20853,7 +20703,6 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20861,7 +20710,6 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -20885,7 +20733,6 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -20897,7 +20744,6 @@
     },
     "node_modules/jest-leak-detector/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20908,7 +20754,6 @@
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20921,7 +20766,6 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20935,7 +20779,6 @@
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20946,7 +20789,6 @@
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -20959,7 +20801,6 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -20978,7 +20819,6 @@
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20989,7 +20829,6 @@
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -21037,7 +20876,6 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21053,7 +20891,6 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -21061,7 +20898,6 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21080,7 +20916,6 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -21092,7 +20927,6 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -21123,7 +20957,6 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -21155,7 +20988,6 @@
     },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -21174,7 +21006,6 @@
     },
     "node_modules/jest-runtime/node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -21187,7 +21018,6 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -21217,7 +21047,6 @@
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21228,7 +21057,6 @@
     },
     "node_modules/jest-snapshot/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -21239,7 +21067,6 @@
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -21252,7 +21079,6 @@
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.6.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -21266,12 +21092,10 @@
     },
     "node_modules/jest-snapshot/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -21287,7 +21111,6 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -21303,7 +21126,6 @@
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21314,7 +21136,6 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21325,7 +21146,6 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -21338,7 +21158,6 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -21356,7 +21175,6 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -21370,7 +21188,6 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21530,7 +21347,6 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -21578,7 +21394,6 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -21664,7 +21479,6 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21783,7 +21597,6 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22165,7 +21978,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -22221,7 +22033,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -22276,7 +22088,6 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -23509,6 +23320,10 @@
       "resolved": "packages/mongodb-atlas",
       "link": true
     },
+    "node_modules/mongodb-chatbot-eval": {
+      "resolved": "packages/mongodb-chatbot-eval",
+      "link": true
+    },
     "node_modules/mongodb-chatbot-server": {
       "resolved": "packages/mongodb-chatbot-server",
       "link": true
@@ -23712,7 +23527,6 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
@@ -23969,7 +23783,6 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-mocks-http": {
@@ -24004,7 +23817,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-stdlib-browser": {
@@ -25271,7 +25083,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -25923,7 +25734,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -25959,7 +25769,6 @@
     },
     "node_modules/pirates": {
       "version": "4.0.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -26480,7 +26289,6 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -26783,7 +26591,6 @@
     },
     "node_modules/pure-rand": {
       "version": "6.0.4",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -28576,7 +28383,6 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -28587,7 +28393,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -28595,7 +28400,6 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -28928,7 +28732,6 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -29250,12 +29053,10 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29334,7 +29135,6 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -29343,12 +29143,10 @@
     },
     "node_modules/source-map-support/node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -29484,7 +29282,6 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -29495,7 +29292,6 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29669,7 +29465,6 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -29810,7 +29605,6 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29846,7 +29640,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -30201,7 +29994,6 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -30214,7 +30006,6 @@
     },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -30337,7 +30128,6 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-fast-properties": {
@@ -30582,7 +30372,7 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -30624,7 +30414,7 @@
     },
     "node_modules/ts-node/node_modules/acorn": {
       "version": "8.11.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -30635,7 +30425,7 @@
     },
     "node_modules/ts-node/node_modules/acorn-walk": {
       "version": "8.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -30742,7 +30532,6 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -31203,7 +30992,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -31533,12 +31321,11 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -31551,7 +31338,6 @@
     },
     "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -32277,7 +32063,6 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -32670,7 +32455,6 @@
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -32682,7 +32466,6 @@
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -32892,7 +32675,6 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -32996,7 +32778,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -33004,7 +32786,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -34131,6 +33912,24 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/mongodb-chatbot-eval": {
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jest": "^29.7.0",
+        "mongodb-rag-core": "*"
+      },
+      "bin": {
+        "eval": "build/main.js"
+      },
+      "devDependencies": {
+        "dotenv": "^16.4.4"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "packages/mongodb-chatbot-server": {

--- a/packages/mongodb-chatbot-eval/.eslintrc.js
+++ b/packages/mongodb-chatbot-eval/.eslintrc.js
@@ -1,0 +1,4 @@
+const baseConfig = require("../../.eslintrc.cjs");
+module.exports = {
+  ...baseConfig,
+};

--- a/packages/mongodb-chatbot-eval/.release-it.json
+++ b/packages/mongodb-chatbot-eval/.release-it.json
@@ -1,0 +1,28 @@
+{
+  "git": {
+    "commitArgs": ["-a"],
+    "commitMessage": "Release ${npm.name} v${version}",
+    "changelog": "git log --pretty=format:'* %s (%h)' ${latestTag}..HEAD -- .",
+    "tagMatch": "${npm.name}-*",
+    "getLatestTagFromAllRefs": true,
+    "tag": true,
+    "push": true,
+    "pushRepo": "upstream",
+    "tagName": "${npm.name}-v${version}"
+  },
+  "npm": {
+    "publish": false
+  },
+  "github": {
+    "releaseName": "${npm.name}-v${version}",
+    "draft": true,
+    "release": true
+  },
+  "hooks": {
+    "before:init": [
+      "pushd .. && npm i && npm run build && popd",
+      "npm run build",
+      "npm run lint"
+    ]
+  }
+}

--- a/packages/mongodb-chatbot-eval/README.md
+++ b/packages/mongodb-chatbot-eval/README.md
@@ -1,0 +1,3 @@
+# MongoDB Chatbot Evaluation CLI
+
+TODO

--- a/packages/mongodb-chatbot-eval/jest.config.json
+++ b/packages/mongodb-chatbot-eval/jest.config.json
@@ -1,0 +1,6 @@
+{
+  "preset": "ts-jest",
+  "setupFiles": ["<rootDir>/src/test/jestEnvSetUp.ts"],
+  "setupFilesAfterEnv": ["<rootDir>/src/test/jestSetUp.ts"],
+  "testPathIgnorePatterns": ["<rootDir>/build"]
+}

--- a/packages/mongodb-chatbot-eval/package.json
+++ b/packages/mongodb-chatbot-eval/package.json
@@ -36,9 +36,21 @@
     "eval": "./build/main.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc -b tsconfig.build.json",
+    "postbuild": "chmod +x build/main.js",
+    "watch": "tsc -b -w",
+    "lint": "eslint ./src --ext js,jsx,ts,tsx --report-unused-disable-directives",
+    "release": "release-it",
+    "test": "jest"
   },
   "bugs": {
     "url": "https://github.com/mongodb/chatbot/issues"
+  },
+  "dependencies": {
+    "jest": "^29.7.0",
+    "mongodb-rag-core": "*"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.4"
   }
 }

--- a/packages/mongodb-chatbot-eval/package.json
+++ b/packages/mongodb-chatbot-eval/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "mongodb-chatbot-eval",
+  "version": "0.0.0",
+  "description": "Evaluate responses from MongoDB chatbot server",
+  "license": "Apache-2.0",
+  "author": "MongoDB, Inc.",
+  "keywords": [
+    "retrieval-augmented-generation",
+    "rag",
+    "chatbot",
+    "mongodb",
+    "mongodb-chatbot-framework"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb/chatbot.git"
+  },
+  "homepage": "https://mongodb.github.io/chatbot/eval",
+  "main": "build/main.js",
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
+  "files": [
+    "build",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./build/index.js",
+    "./generate": "./build/generate/index.js",
+    "./evaluate": "./build/evaluate/index.js",
+    "./report": "./build/report/index.js",
+    "./core": "./build/core/index.js"
+  },
+  "bin": {
+    "eval": "./build/main.js"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/mongodb/chatbot/issues"
+  }
+}

--- a/packages/mongodb-chatbot-eval/src/CommandMetadataStore.ts
+++ b/packages/mongodb-chatbot-eval/src/CommandMetadataStore.ts
@@ -1,0 +1,16 @@
+import { ObjectId } from "mongodb-rag-core";
+
+export interface CommandRunMetadata {
+  _id: ObjectId;
+  commandName: string;
+  startTime: Date;
+  endTime: Date;
+}
+export interface CommandMetadataStore {
+  insertOne(command: Omit<CommandRunMetadata, "_id">): Promise<boolean>;
+  findById(commandId: ObjectId): Promise<CommandRunMetadata | undefined>;
+}
+
+export function makeMongoDbCommandMetadataStore(): CommandMetadataStore {
+  return {};
+}

--- a/packages/mongodb-chatbot-eval/src/CommandMetadataStore.ts
+++ b/packages/mongodb-chatbot-eval/src/CommandMetadataStore.ts
@@ -11,6 +11,14 @@ export interface CommandMetadataStore {
   findById(commandId: ObjectId): Promise<CommandRunMetadata | undefined>;
 }
 
+// TODO: implement
 export function makeMongoDbCommandMetadataStore(): CommandMetadataStore {
-  return {};
+  return {
+    async insertOne(command) {
+      return true;
+    },
+    async findById(commandId) {
+      return undefined;
+    },
+  };
 }

--- a/packages/mongodb-chatbot-eval/src/EvalConfig.ts
+++ b/packages/mongodb-chatbot-eval/src/EvalConfig.ts
@@ -1,0 +1,39 @@
+import { CommandMetadataStore } from "./CommandMetadataStore";
+import { EvaluateQualityFunc } from "./evaluate/EvaluateQualityFunc";
+import { EvaluationStore } from "./evaluate/EvaluationStore";
+import { GenerateDataFunc } from "./generate/GenerateDataFunc";
+import { GeneratedDataStore } from "./generate/GeneratedDataStore";
+import { TestCase } from "./generate/TestCase";
+import { ReportEvalFunc } from "./report/ReportEvalFunc";
+import { ReportStore } from "./report/ReportStore";
+
+/**
+  Config
+ */
+export interface EvalConfig {
+  metadataStore: CommandMetadataStore;
+  generatedDataStore: GeneratedDataStore;
+  evaluationStore: EvaluationStore;
+  reportStore: ReportStore;
+  commands: {
+    generate?: {
+      [k: string]: {
+        type: string;
+        testCases: TestCase[];
+        generator: GenerateDataFunc;
+      };
+    };
+    eval?: {
+      [k: string]: {
+        evaluator: EvaluateQualityFunc;
+      };
+    };
+    report?: {
+      [k: string]: {
+        reporter: ReportEvalFunc;
+      };
+    };
+  };
+}
+
+export type ConfigConstructor = () => Promise<EvalConfig>;

--- a/packages/mongodb-chatbot-eval/src/commands/evaluate.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/evaluate.ts
@@ -1,0 +1,29 @@
+import { CommandModule } from "yargs";
+import {
+  ResolvedConfig,
+  LoadConfigArgs,
+  withConfig,
+  withConfigOptions,
+} from "../withConfig";
+
+const commandModule: CommandModule<unknown, LoadConfigArgs> = {
+  command: "evaluate",
+  builder(args) {
+    return withConfigOptions(args);
+  },
+  async handler(args) {
+    return withConfig(evaluateCommand, {
+      ...args,
+    });
+  },
+  describe: "Evaluate generated data.",
+};
+
+export default commandModule;
+
+export const evaluateCommand = async (
+  config: ResolvedConfig
+  // other args?
+) => {
+  // TODO: do stuff
+};

--- a/packages/mongodb-chatbot-eval/src/commands/evaluate.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/evaluate.ts
@@ -9,7 +9,14 @@ import {
 const commandModule: CommandModule<unknown, LoadConfigArgs> = {
   command: "evaluate",
   builder(args) {
-    return withConfigOptions(args);
+    return withConfigOptions(args)
+      .string("name")
+      .option("generatedDataQuery", {
+        type: "string",
+        description: "Query to filter generated data.",
+      })
+      .demandOption("generatedDataQuery")
+      .demandOption("name");
   },
   async handler(args) {
     return withConfig(evaluateCommand, {

--- a/packages/mongodb-chatbot-eval/src/commands/generate.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/generate.ts
@@ -9,7 +9,7 @@ import {
 const commandModule: CommandModule<unknown, LoadConfigArgs> = {
   command: "generate",
   builder(args) {
-    return withConfigOptions(args);
+    return withConfigOptions(args).string("name").demandOption("name");
   },
   async handler(args) {
     return withConfig(generateCommand, {

--- a/packages/mongodb-chatbot-eval/src/commands/generate.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/generate.ts
@@ -1,0 +1,29 @@
+import { CommandModule } from "yargs";
+import {
+  ResolvedConfig,
+  LoadConfigArgs,
+  withConfig,
+  withConfigOptions,
+} from "../withConfig";
+
+const commandModule: CommandModule<unknown, LoadConfigArgs> = {
+  command: "generate",
+  builder(args) {
+    return withConfigOptions(args);
+  },
+  async handler(args) {
+    return withConfig(generateCommand, {
+      ...args,
+    });
+  },
+  describe: "Generate data for evaluation.",
+};
+
+export default commandModule;
+
+export const generateCommand = async (
+  config: ResolvedConfig
+  // other args?
+) => {
+  // TODO: do stuff
+};

--- a/packages/mongodb-chatbot-eval/src/commands/report.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/report.ts
@@ -9,7 +9,14 @@ import {
 const commandModule: CommandModule<unknown, LoadConfigArgs> = {
   command: "report",
   builder(args) {
-    return withConfigOptions(args);
+    return withConfigOptions(args)
+      .string("name")
+      .option("evalResultsQuery", {
+        type: "string",
+        description: "Query to filer evaluation results.",
+      })
+      .demandOption("evalResultsQuery")
+      .demandOption("name");
   },
   async handler(args) {
     return withConfig(reportCommand, {

--- a/packages/mongodb-chatbot-eval/src/commands/report.ts
+++ b/packages/mongodb-chatbot-eval/src/commands/report.ts
@@ -1,0 +1,29 @@
+import { CommandModule } from "yargs";
+import {
+  ResolvedConfig,
+  LoadConfigArgs,
+  withConfig,
+  withConfigOptions,
+} from "../withConfig";
+
+const commandModule: CommandModule<unknown, LoadConfigArgs> = {
+  command: "report",
+  builder(args) {
+    return withConfigOptions(args);
+  },
+  async handler(args) {
+    return withConfig(reportCommand, {
+      ...args,
+    });
+  },
+  describe: "Report generated data.",
+};
+
+export default commandModule;
+
+export const reportCommand = async (
+  config: ResolvedConfig
+  // other args?
+) => {
+  // TODO: do stuff
+};

--- a/packages/mongodb-chatbot-eval/src/core.ts
+++ b/packages/mongodb-chatbot-eval/src/core.ts
@@ -1,0 +1,7 @@
+/**
+  @fileoverview Re-export mongodb-rag-core library.
+  This is done to guarantee that all consumers of the ingest package
+  use the expected version of core. Plus, this serves as a convenience for
+  consumers of this package as all consumers also need to access the modules in core.
+ */
+export * from "mongodb-rag-core";

--- a/packages/mongodb-chatbot-eval/src/evaluate/EvaluateQualityFunc.ts
+++ b/packages/mongodb-chatbot-eval/src/evaluate/EvaluateQualityFunc.ts
@@ -1,0 +1,4 @@
+import { GeneratedData } from "../generate/GeneratedDataStore";
+import { EvalResult } from "./EvaluationStore";
+
+export type EvaluateQualityFunc = (data: GeneratedData) => Promise<EvalResult>;

--- a/packages/mongodb-chatbot-eval/src/evaluate/EvaluationStore.ts
+++ b/packages/mongodb-chatbot-eval/src/evaluate/EvaluationStore.ts
@@ -17,6 +17,14 @@ export interface EvaluationStore {
   find(filter: Record<string, unknown>): Promise<EvalResult[] | undefined>;
 }
 
+// TODO: implement
 export function makeMongoDbEvaluationStore(): EvaluationStore {
-  return {};
+  return {
+    async insertOne(evalResult) {
+      return true;
+    },
+    async find(filter) {
+      return undefined;
+    },
+  };
 }

--- a/packages/mongodb-chatbot-eval/src/evaluate/EvaluationStore.ts
+++ b/packages/mongodb-chatbot-eval/src/evaluate/EvaluationStore.ts
@@ -1,0 +1,22 @@
+import { ObjectId } from "../core";
+
+export interface EvalResult {
+  _id: ObjectId;
+  conversationId: ObjectId;
+  commandRunMetadataId: ObjectId;
+  evalName: string;
+  /**
+    Number between 0 and 1, inclusive.
+   */
+  result: number;
+  endTime: Date;
+}
+
+export interface EvaluationStore {
+  insertOne(evalResult: EvalResult): Promise<boolean>;
+  find(filter: Record<string, unknown>): Promise<EvalResult[] | undefined>;
+}
+
+export function makeMongoDbEvaluationStore(): EvaluationStore {
+  return {};
+}

--- a/packages/mongodb-chatbot-eval/src/generate/GenerateDataFunc.ts
+++ b/packages/mongodb-chatbot-eval/src/generate/GenerateDataFunc.ts
@@ -1,0 +1,3 @@
+import { GeneratedData } from "./GeneratedDataStore";
+
+export type GenerateDataFunc = () => Promise<GeneratedData[]>;

--- a/packages/mongodb-chatbot-eval/src/generate/GeneratedDataStore.ts
+++ b/packages/mongodb-chatbot-eval/src/generate/GeneratedDataStore.ts
@@ -14,6 +14,17 @@ export interface GeneratedDataStore {
   find(filter: Record<string, unknown>): Promise<GeneratedData[] | undefined>;
 }
 
+// TODO: implement
 export function makeMongoDbGeneratedDataStore(): GeneratedDataStore {
-  return {};
+  return {
+    async insertOne(generatedData) {
+      return true;
+    },
+    async findById(generatedDataId) {
+      return undefined;
+    },
+    async find(filter) {
+      return undefined;
+    },
+  };
 }

--- a/packages/mongodb-chatbot-eval/src/generate/GeneratedDataStore.ts
+++ b/packages/mongodb-chatbot-eval/src/generate/GeneratedDataStore.ts
@@ -1,0 +1,19 @@
+import { ObjectId } from "../core";
+
+export interface GeneratedData {
+  _id: ObjectId;
+  commandRunId: ObjectId;
+  type: string;
+  data: unknown;
+  evalData?: Record<string, unknown>;
+}
+
+export interface GeneratedDataStore {
+  insertOne(generatedData: Omit<GeneratedData, "_id">): Promise<boolean>;
+  findById(generatedDataId: ObjectId): Promise<GeneratedData | undefined>;
+  find(filter: Record<string, unknown>): Promise<GeneratedData[] | undefined>;
+}
+
+export function makeMongoDbGeneratedDataStore(): GeneratedDataStore {
+  return {};
+}

--- a/packages/mongodb-chatbot-eval/src/generate/TestCase.ts
+++ b/packages/mongodb-chatbot-eval/src/generate/TestCase.ts
@@ -1,0 +1,22 @@
+export interface TestCase {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+export interface ConversationTestCase extends TestCase {
+  name: "conversation";
+  data: ConversationTestCaseData;
+}
+
+export interface ConversationTestCaseData extends Record<string, unknown> {
+  name: string;
+  expectation: string;
+  messages: ConversationTestCaseMessage[];
+  tags?: string[];
+  skip?: boolean;
+}
+
+export interface ConversationTestCaseMessage {
+  role: "user" | "assistant";
+  content: string;
+}

--- a/packages/mongodb-chatbot-eval/src/index.ts
+++ b/packages/mongodb-chatbot-eval/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./EvalConfig";
+export * from "./CommandMetadataStore";
+export * from "./withConfig";

--- a/packages/mongodb-chatbot-eval/src/main.ts
+++ b/packages/mongodb-chatbot-eval/src/main.ts
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+import yargs from "yargs";
+
+import "dotenv/config";
+
+function commandDir<T>(
+  argv: yargs.Argv<T>,
+  directory: string,
+  options?: yargs.RequireDirectoryOptions
+): yargs.Argv<T> {
+  return argv.commandDir(directory, {
+    extensions: ["js"],
+    exclude: /^(?:index|.*\.test)\.js$/, // .map, .d.ts excluded by 'extensions' property
+    visit(commandModule) {
+      return commandModule.default;
+    },
+    ...options,
+  });
+}
+
+async function main() {
+  const argv = commandDir(yargs.help(), "commands").demandCommand();
+
+  // Accessing this property executes CLI
+  argv.argv;
+}
+
+main().catch(console.error);

--- a/packages/mongodb-chatbot-eval/src/report/ReportEvalFunc.ts
+++ b/packages/mongodb-chatbot-eval/src/report/ReportEvalFunc.ts
@@ -1,0 +1,3 @@
+import { EvalResult } from "../evaluate/EvaluationStore";
+
+export type ReportEvalFunc = (evalution: EvalResult) => Promise<Report>;

--- a/packages/mongodb-chatbot-eval/src/report/ReportStore.ts
+++ b/packages/mongodb-chatbot-eval/src/report/ReportStore.ts
@@ -1,0 +1,18 @@
+import { ObjectId } from "../core";
+import { EvalResult } from "../evaluate/EvaluationStore";
+
+export interface Report {
+  _id: ObjectId;
+  reportName: string;
+  data: Record<string, unknown>;
+  endTime: Date;
+}
+
+export interface ReportStore {
+  insertOne(evalResult: EvalResult): Promise<boolean>;
+  find(filter: Record<string, unknown>): Promise<Report[] | undefined>;
+}
+
+export function makeMongoDbReportStore(): ReportStore {
+  return {};
+}

--- a/packages/mongodb-chatbot-eval/src/report/ReportStore.ts
+++ b/packages/mongodb-chatbot-eval/src/report/ReportStore.ts
@@ -13,6 +13,14 @@ export interface ReportStore {
   find(filter: Record<string, unknown>): Promise<Report[] | undefined>;
 }
 
+// TODO: implement
 export function makeMongoDbReportStore(): ReportStore {
-  return {};
+  return {
+    async insertOne(evalResult) {
+      return true;
+    },
+    async find(filter) {
+      return undefined;
+    },
+  };
 }

--- a/packages/mongodb-chatbot-eval/src/test/jestEnvSetUp.ts
+++ b/packages/mongodb-chatbot-eval/src/test/jestEnvSetUp.ts
@@ -1,0 +1,1 @@
+import "dotenv/config";

--- a/packages/mongodb-chatbot-eval/src/test/jestSetUp.ts
+++ b/packages/mongodb-chatbot-eval/src/test/jestSetUp.ts
@@ -1,0 +1,3 @@
+import { logger } from "mongodb-rag-core";
+// silence logger for tests
+logger.transports.forEach((t) => (t.silent = true));

--- a/packages/mongodb-chatbot-eval/src/withConfig.test.ts
+++ b/packages/mongodb-chatbot-eval/src/withConfig.test.ts
@@ -1,0 +1,21 @@
+import Path from "path";
+import { withConfig } from "./withConfig";
+
+describe("withConfig", () => {
+  it("loads a config file", async () => {
+    await withConfig(
+      async (config) => {
+        expect(config.dataSources).toBeDefined();
+      },
+      {
+        config: Path.resolve(
+          __dirname,
+          "..",
+          "testData",
+          "config",
+          "configTest.cjs"
+        ),
+      }
+    );
+  });
+});

--- a/packages/mongodb-chatbot-eval/src/withConfig.test.ts
+++ b/packages/mongodb-chatbot-eval/src/withConfig.test.ts
@@ -5,7 +5,11 @@ describe("withConfig", () => {
   it("loads a config file", async () => {
     await withConfig(
       async (config) => {
-        expect(config.dataSources).toBeDefined();
+        expect(config.commands).toBeDefined();
+        expect(config.evaluationStore).toBeDefined();
+        expect(config.generatedDataStore).toBeDefined();
+        expect(config.metadataStore).toBeDefined();
+        expect(config.reportStore).toBeDefined();
       },
       {
         config: Path.resolve(

--- a/packages/mongodb-chatbot-eval/src/withConfig.ts
+++ b/packages/mongodb-chatbot-eval/src/withConfig.ts
@@ -91,7 +91,7 @@ export const withConfigOptions = <T>(
     description: "Path to config JS file.",
   });
 };
-
+// NOTE: consider moving the generic configurable CLI stuff to `mongodb-rag-core` or another independent library since we're using across multiple projects.
 /**
   Config with promises resolved.
  */

--- a/packages/mongodb-chatbot-eval/src/withConfig.ts
+++ b/packages/mongodb-chatbot-eval/src/withConfig.ts
@@ -1,0 +1,162 @@
+import yargs from "yargs";
+import Path from "path";
+import { logger } from "mongodb-rag-core";
+import { EvalConfig } from "./EvalConfig";
+
+export type LoadConfigArgs = {
+  config?: string;
+};
+
+export const loadConfig = async ({
+  config: configPathIn,
+}: LoadConfigArgs): Promise<EvalConfig> => {
+  const path = Path.resolve(
+    configPathIn === undefined ? "eval.config.cjs" : configPathIn
+  );
+
+  const partialConfigConstructor = (await import(path))
+    .default as () => Promise<Partial<EvalConfig>>;
+  const partialConfig = await partialConfigConstructor();
+
+  const missingProperties: string[] = [];
+  const config: EvalConfig = {
+    ...partialConfig,
+    metadataStore: checkRequiredProperty(
+      partialConfig,
+      "metadataStore",
+      missingProperties
+    ),
+    generatedDataStore: checkRequiredProperty(
+      partialConfig,
+      "generatedDataStore",
+      missingProperties
+    ),
+    evaluationStore: checkRequiredProperty(
+      partialConfig,
+      "evaluationStore",
+      missingProperties
+    ),
+    reportStore: checkRequiredProperty(
+      partialConfig,
+      "reportStore",
+      missingProperties
+    ),
+    commands: checkRequiredProperty(
+      partialConfig,
+      "commands",
+      missingProperties
+    ),
+  };
+
+  if (missingProperties.length !== 0) {
+    throw new Error(
+      `Config is missing the following properties: ${missingProperties.join(
+        ", "
+      )}`
+    );
+  }
+
+  return config;
+};
+
+export const withConfig = async <T>(
+  action: (config: ResolvedConfig, args: T) => Promise<void>,
+  args: LoadConfigArgs & T
+) => {
+  const config = await loadConfig(args);
+  const [resolvedConfig, cleanup] = await resolveConfig(config);
+  try {
+    return await action(resolvedConfig, args);
+  } finally {
+    await Promise.all(
+      cleanup.map(async (close) => {
+        try {
+          await close();
+        } catch (error) {
+          logger.error(`Cleanup failed: ${(error as Error).message}`);
+        }
+      })
+    );
+  }
+};
+
+/**
+  Apply config options to CLI command.
+ */
+export const withConfigOptions = <T>(
+  args: yargs.Argv<T>
+): yargs.Argv<T & LoadConfigArgs> => {
+  return args.option("config", {
+    string: true,
+    description: "Path to config JS file.",
+  });
+};
+
+/**
+  Config with promises resolved.
+ */
+export type ResolvedConfig = {
+  [K in keyof EvalConfig]: Constructed<EvalConfig[K]>;
+};
+
+type Constructed<T> = Awaited<T extends () => infer R ? R : T>;
+
+/**
+  Resolve any promises in the config object.
+ */
+const resolveConfig = async (
+  config: EvalConfig
+): Promise<[ResolvedConfig, CleanupFunc[]]> => {
+  const cleanup: CleanupFunc[] = [];
+  try {
+    return [
+      Object.fromEntries(
+        await Promise.all(
+          Object.entries(config).map(async ([k, v]) => {
+            const resolved = await resolve(v);
+            const closeable = resolved as unknown as Closeable;
+            if (closeable?.close !== undefined) {
+              // Save cleanup so that any constructed instances can be cleaned up
+              // if subsequent construction fails
+              cleanup.push(async () => {
+                closeable.close && (await closeable.close());
+              });
+            }
+            return [k, resolved];
+          })
+        )
+      ),
+      cleanup,
+    ];
+  } catch (error) {
+    await Promise.all(cleanup.map((close) => close()));
+    throw error;
+  }
+};
+
+const resolve = async <T>(v: T): Promise<Constructed<T>> =>
+  typeof v === "function" ? v() : v;
+
+/**
+  Asserts that the given property is defined in the given object and returns
+  that value as a definitely not undefined type.
+ */
+function checkRequiredProperty<T, K extends keyof T>(
+  object: T,
+  k: K,
+  missingProperties: string[]
+): Exclude<T[K], undefined> {
+  const value = object[k];
+  if (value === undefined) {
+    missingProperties.push(k.toString());
+    // Hack: this is an invalid value. The caller MUST check the errors
+    return undefined as Exclude<T[K], undefined>;
+  }
+  return value as Exclude<T[K], undefined>;
+}
+
+type Closeable = {
+  close?(): Promise<void>;
+};
+
+type CleanupFunc = () => Promise<void>;

--- a/packages/mongodb-chatbot-eval/testData/config/configTest.cjs
+++ b/packages/mongodb-chatbot-eval/testData/config/configTest.cjs
@@ -1,0 +1,7 @@
+module.exports = async () => ({
+  metadataStore: {},
+  generatedDataStore: {},
+  evaluationStore: {},
+  reportStore: {},
+  commands: [],
+});

--- a/packages/mongodb-chatbot-eval/tsconfig.build.json
+++ b/packages/mongodb-chatbot-eval/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "test/**/*.ts"]
+}

--- a/packages/mongodb-chatbot-eval/tsconfig.json
+++ b/packages/mongodb-chatbot-eval/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build"
+  },
+  "include": ["./src/**/*.ts"]
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-232

## Changes

Scaffold eval package with the following:

- [x] Project config, like TypeScript, eslint, jest, etc.
- [x] types/interfaces
- [x] Mock implementations of data stores
- [x] Mock implementations of commands

## Notes

- Heavily based on set up from the ingest CLI
- I suspect some aspects of this will change as the project develops, but think useful to have this scaffold to build based off of. 
