### PR TITLE
(EAI-265) Add Vector Search to chatbot disclaimer text

### DIFF
--- a/packages/mongodb-chatbot-ui/src/DevCenterChatbot.tsx
+++ b/packages/mongodb-chatbot-ui/src/DevCenterChatbot.tsx
@@ -7,6 +7,8 @@ import {
 import { ModalView, ModalViewProps } from "./ModalView";
 import { MongoDbLegalDisclosure } from "./MongoDbLegal";
 import { mongoDbVerifyInformationMessage } from "./ui-text";
+import { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch";
+import { css } from "@emotion/css";
 
 export type DevCenterChatbotProps = DarkModeProps & {
   initialMessageText?: string;
@@ -24,7 +26,17 @@ export function DevCenterChatbot(props: DevCenterChatbotProps) {
       props.initialMessageText ??
       "Hi! I'm the MongoDB AI. What can I help you with today?",
     initialMessageSuggestedPrompts: props.initialMessageSuggestedPrompts ?? [],
-    disclaimer: <MongoDbLegalDisclosure />,
+    disclaimer: (
+      <>
+        <MongoDbLegalDisclosure />
+        <PoweredByAtlasVectorSearch
+          className={css`
+            margin-top: 8px;
+          `}
+          linkStyle="text"
+        />
+      </>
+    ),
     inputBottomText: mongoDbVerifyInformationMessage,
   } satisfies ModalViewProps;
 

--- a/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/css";
 import { useDarkMode } from "@leafygreen-ui/leafygreen-provider";
-import { Body, Error as ErrorText, Link } from "@leafygreen-ui/typography";
+import { Error as ErrorText } from "@leafygreen-ui/typography";
 import {
   InputBar,
   MongoDbInputBarPlaceholder,
@@ -8,12 +8,11 @@ import {
   SuggestedPrompts,
 } from "./InputBar";
 import { defaultChatbotFatalErrorMessage } from "./ui-text";
-import { useLinkData } from "./useLinkData";
-import { addQueryParams } from "./utils";
 import { useState } from "react";
 import { ChatbotTriggerProps } from "./ChatbotTrigger";
 import { useChatbotContext } from "./useChatbotContext";
 import classNames from "classnames";
+import { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch";
 
 const styles = {
   info_box: css`
@@ -160,18 +159,5 @@ export function InputBarTrigger(props: InputBarTriggerProps) {
         </div>
       </div>
     </div>
-  );
-}
-
-function PoweredByAtlasVectorSearch() {
-  const { tck } = useLinkData();
-  const url = "https://www.mongodb.com/products/platform/atlas-vector-search";
-  return (
-    <Body>
-      Powered by Atlas Vector Search.{" "}
-      <Link href={addQueryParams(url, { tck })} hideExternalIcon>
-        Learn More.
-      </Link>
-    </Body>
   );
 }

--- a/packages/mongodb-chatbot-ui/src/MongoDbLegal.tsx
+++ b/packages/mongodb-chatbot-ui/src/MongoDbLegal.tsx
@@ -2,7 +2,7 @@ import { useLinkData } from "./useLinkData";
 import { addQueryParams } from "./utils";
 import { Body, Link } from "@leafygreen-ui/typography";
 
-export function MongoDbLegalDisclosure() {
+export function MongoDbLegalDisclosureText() {
   const { tck } = useLinkData();
   const TermsOfUse = () => (
     <Link
@@ -27,9 +27,17 @@ export function MongoDbLegalDisclosure() {
   );
 
   return (
-    <Body>
+    <>
       This is a generative AI chatbot. By interacting with it, you agree to
       MongoDB's <TermsOfUse /> and <AcceptableUsePolicy />.
+    </>
+  );
+}
+
+export function MongoDbLegalDisclosure() {
+  return (
+    <Body>
+      <MongoDbLegalDisclosureText />
     </Body>
   );
 }

--- a/packages/mongodb-chatbot-ui/src/PoweredByAtlasVectorSearch.tsx
+++ b/packages/mongodb-chatbot-ui/src/PoweredByAtlasVectorSearch.tsx
@@ -1,0 +1,45 @@
+import { Body, Link } from "@leafygreen-ui/typography";
+import { useLinkData } from "./useLinkData";
+import { addQueryParams } from "./utils";
+
+export type PoweredByAtlasVectorSearchProps = {
+  className?: string;
+  linkStyle?: "learnMore" | "text";
+};
+
+export function PoweredByAtlasVectorSearch({
+  className,
+  linkStyle = "learnMore",
+}: PoweredByAtlasVectorSearchProps) {
+  const { tck } = useLinkData();
+  const url = "https://www.mongodb.com/products/platform/atlas-vector-search";
+  const VectorSearchLink = (props: { children: string }) => (
+    <Link href={addQueryParams(url, { tck })} hideExternalIcon>
+      {props.children}
+    </Link>
+  );
+
+  const Text = () => {
+    switch (linkStyle) {
+      case "learnMore":
+        return (
+          <>
+            Powered by Atlas Vector Search.{" "}
+            <VectorSearchLink>Learn More.</VectorSearchLink>
+          </>
+        );
+      case "text":
+        return (
+          <>
+            Powered by <VectorSearchLink>Atlas Vector Search</VectorSearchLink>
+          </>
+        );
+    }
+  }
+
+  return (
+    <Body className={className}>
+      <Text />
+    </Body>
+  );
+}

--- a/packages/mongodb-chatbot-ui/src/index.tsx
+++ b/packages/mongodb-chatbot-ui/src/index.tsx
@@ -33,3 +33,4 @@ export {
   mongoDbVerifyInformationMessage,
   defaultChatbotFatalErrorMessage,
 } from "./ui-text.ts";
+export { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch.tsx";


### PR DESCRIPTION
Jira: (EAI-265) Add Vector Search to chatbot disclaimer text

## Changes

- Adds an export and additional rendering style for `PoweredByAtlasVectorSearch` text component

## Notes

- Snooty PR implementing the same thing https://github.com/mongodb/snooty/pull/1040
