### PR TITLE
(EAI-245): Create IDs for categories of questions to track FAQ across…

### DIFF
--- a/packages/scripts/src/findFaq.ts
+++ b/packages/scripts/src/findFaq.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "assert";
-import { Db, ObjectId } from "mongodb";
+import { Db, ObjectId, Collection, WithId } from "mongodb";
 
 import {
   Conversation,
@@ -7,6 +7,9 @@ import {
   AssistantMessage,
   FunctionMessage,
   UserMessage,
+  VectorStore,
+  FindNearestNeighborsOptions,
+  WithScore,
 } from "mongodb-chatbot-server";
 import { clusterize, DbscanOptions } from "./clusterize";
 import { findCentroid } from "./findCentroid";
@@ -50,6 +53,11 @@ export type FaqEntry = {
     (a cluster with more objects in it is a more frequently asked question).
    */
   faqScore: number;
+
+  /**
+    An id unique to this category of questions.
+   */
+  faqId?: string;
 };
 
 export const findFaq = async ({
@@ -165,4 +173,128 @@ export const findFaq = async ({
     .sort((a, b) => b.faqScore - a.faqScore);
 
   return faqEntries;
+};
+
+/**
+  Make a wrapper around the given collection that conforms to the VectorStore
+  interface.
+
+  Does not manage the collection - callers are still responsible for closing the
+  client.
+ */
+export const makeFaqVectorStoreCollectionWrapper = (
+  collection: Collection<WithId<FaqEntry & { created: Date; epsilon: number }>>
+): VectorStore<WithId<FaqEntry>> => {
+  return {
+    findNearestNeighbors(vector, options) {
+      const {
+        indexName,
+        path,
+        k,
+        minScore,
+        filter,
+        numCandidates,
+      }: Partial<FindNearestNeighborsOptions> = {
+        // Default options
+        indexName: "vector_index",
+        path: "embedding",
+        k: 10,
+        minScore: 0.95,
+        // User options override
+        ...(options ?? {}),
+      };
+      return collection
+        .aggregate<WithScore<WithId<FaqEntry>>>([
+          {
+            $vectorSearch: {
+              index: indexName,
+              queryVector: vector,
+              path,
+              limit: k,
+              numCandidates: numCandidates ?? k * 15,
+              filter,
+            },
+          },
+          {
+            $addFields: {
+              score: {
+                $meta: "vectorSearchScore",
+              },
+            },
+          },
+          {
+            $match: {
+              score: { $gte: minScore },
+            },
+          },
+        ])
+        .toArray();
+    },
+  };
+};
+
+/**
+  For each given question, finds if any similar messages already have a faqId.
+  If so, adopts the faqId. Otherwise, invents a new faqId for this category of
+  question.
+ */
+export const assignFaqIds = async ({
+  faq,
+  faqCollection,
+  backportNewIds,
+}: {
+  faq: FaqEntry[];
+  faqCollection: Collection<
+    WithId<FaqEntry & { created: Date; epsilon: number }>
+  >;
+
+  /**
+    If a new faqId is generated because existing entries did not have a faqId,
+    assigns the new faqId to the existing entries. 
+   */
+  backportNewIds?: boolean;
+}): Promise<(FaqEntry & { faqId: string })[]> => {
+  const store = makeFaqVectorStoreCollectionWrapper(faqCollection);
+
+  return await Promise.all(
+    faq.map(async (q) => {
+      // See if there already is an ID for this FAQ.
+      const previousFaqs = await store.findNearestNeighbors(q.embedding);
+      const previousFaqsWithFaqIds = previousFaqs.filter(
+        (q) => q.faqId !== undefined
+      );
+      previousFaqsWithFaqIds.sort((a, b) => b.score - a.score);
+
+      // Use the pre-existing faqId or generate a new one for this category
+      const faqId =
+        previousFaqsWithFaqIds[0]?.faqId ?? ObjectId.generate().toString("hex");
+      console.log(
+        `${
+          previousFaqsWithFaqIds[0]?.faqId === undefined
+            ? "Generated new"
+            : "Reused existing"
+        } faqId ${faqId} for question category "${q.question}"`
+      );
+
+      if (backportNewIds) {
+        const previousFaqsWithoutIds = previousFaqs.filter(
+          (q) => q.faqId === undefined
+        );
+        await Promise.all(
+          previousFaqsWithoutIds.map(async (q) => {
+            const updateResult = await faqCollection.updateOne(
+              {
+                _id: q._id,
+              },
+              { $set: { faqId } }
+            );
+            console.log(
+              `Backported new ID ${faqId} to ${q._id} (modified ${updateResult.modifiedCount})`
+            );
+          })
+        );
+      }
+      return { ...q, faqId };
+    })
+  );
 };

--- a/packages/scripts/src/main/findFaqMain.ts
+++ b/packages/scripts/src/main/findFaqMain.ts
@@ -1,6 +1,11 @@
 import { ObjectId, WithId, MongoClient } from "mongodb";
 import { assertEnvVars } from "mongodb-rag-core";
-import { findFaq, FaqEntry } from "../findFaq";
+import {
+  findFaq,
+  FaqEntry,
+  assignFaqIds,
+  makeFaqVectorStoreCollectionWrapper,
+} from "../findFaq";
 
 import "dotenv/config";
 
@@ -30,26 +35,43 @@ async function main() {
   const client = await MongoClient.connect(MONGODB_CONNECTION_URI);
   try {
     const db = client.db(MONGODB_DATABASE_NAME);
-    const faq = await findFaq({
-      db,
-      clusterizeOptions: {
-        epsilon,
-      },
-    });
     const faqCollection =
       db.collection<WithId<FaqEntry & { created: Date; epsilon: number }>>(
         "faq"
       );
     const created = new Date();
-    const insertResult = await faqCollection.insertMany(
-      faq.map((q) => ({
-        ...q,
+
+    // Associate each question with an ID to track questions across runs of
+    // findFaq
+    await findFaq({
+      db,
+      clusterizeOptions: {
         epsilon,
-        created,
-        _id: new ObjectId(),
-      }))
-    );
-    console.log(`Inserted ${insertResult.insertedCount} FAQ entries.`);
+      },
+    })
+      .then(async (faq) => {
+        // Associate each question with an ID to track questions across runs of
+        // findFaq
+        return assignFaqIds({
+          faq,
+          faqCollection,
+          backportNewIds: true,
+        });
+      })
+      .then(async (faq) => {
+        // Add info to prepare for database insert
+        return faq.map((q) => ({
+          ...q,
+          epsilon,
+          created,
+          _id: new ObjectId(),
+        }));
+      })
+      .then(async (faq) => {
+        // Insert into database
+        const insertResult = await faqCollection.insertMany(faq);
+        console.log(`Inserted ${insertResult.insertedCount} FAQ entries.`);
+      });
   } finally {
     await client.close();
   }


### PR DESCRIPTION
… days

Jira: https://jira.mongodb.org/browse/EAI-245

## Changes

- Updates the findFaq script to find a 'faqId' from a previous similar entry. If one can't be found, creates a new one.
- Optionally backports new IDs to previous entries.

## Notes

- This will enable us to bucket FAQ reports by faqId, which will provide more insight into frequently asked questions.
