### PR TITLE
`LangchainChatLlm` support for Anthropic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4177,6 +4177,76 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.1.9.tgz",
+      "integrity": "sha512-A2xir/F8xC8DFS2nKFKR//YB5XfnJCtWl0uncCZXMmZhfW7W44RhXC+tV+97afPzRK8lJSjCdOZvi673TbqeyQ==",
+      "dev": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.17.2",
+        "@langchain/core": "~0.1.44",
+        "fast-xml-parser": "^4.3.5",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/@anthropic-ai/sdk": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.17.2.tgz",
+      "integrity": "sha512-xDfL/OblarYcwTSN2xBhynXJTkaTaxr8/v1fRKdT3grOZ4TrzIdrFfaTM771proR4g3uLe76PFSF3+gPjI6Gpw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/@types/node": {
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/fast-xml-parser": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "dev": true
+    },
     "node_modules/@langchain/core": {
       "version": "0.1.48",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.48.tgz",
@@ -31518,8 +31588,8 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
@@ -35969,6 +36039,7 @@
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
+        "@langchain/anthropic": "^0.1.9",
         "@types/common-tags": "^1.8.1",
         "@types/connect-timeout": "^0.0.37",
         "@types/cors": "^2.8.13",

--- a/packages/mongodb-chatbot-server/package.json
+++ b/packages/mongodb-chatbot-server/package.json
@@ -62,6 +62,7 @@
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
+    "@langchain/anthropic": "^0.1.9",
     "@types/common-tags": "^1.8.1",
     "@types/connect-timeout": "^0.0.37",
     "@types/cors": "^2.8.13",


### PR DESCRIPTION
Jira: n/a

## Changes

- Modify langchain chatllm implementation to support Anthropic models

## Notes

- i believe this change is compensating for a bug on langchain's side, as we were already conforming to their interface
- skipping test for anthropic b/c MongoDB doesn't have an Anthropic subscription that we could use in the integration test here. 
  - You can sign up for free to anthropic and plug in your own API key (that's what i did)
- Thank you to @eric-gardyn for help with the solution implementation!

Resolves https://github.com/mongodb/chatbot/issues/382