### PR TITLE
Support LangChain `Embeddings` class

### DIFF
--- a/docs/docs/ingest/configuration-reference.md
+++ b/docs/docs/ingest/configuration-reference.md
@@ -104,7 +104,7 @@ To learn more about creating a `DataSource`, refer to the [Data Sources](./data-
 
 The [`Embedder`](../reference/core/modules.md#embedder) takes in a string and returns a vector embedding for that string.
 
-To create an `Embedder` that uses the [LangChain `Embeddings` class](foo),
+To create an `Embedder` that uses the [LangChain `Embeddings` class](https://js.langchain.com/docs/integrations/text_embedding),
 you can use the function [`makeLangChainEmbedder()`](../reference/core/modules.md#makelangchainembedder). To see the various embedding models supported by LangChain, refer to the [LangChain text embedding models](https://js.langchain.com/docs/integrations/text_embedding) documentation.
 
 ```ts

--- a/docs/docs/ingest/configuration-reference.md
+++ b/docs/docs/ingest/configuration-reference.md
@@ -104,7 +104,27 @@ To learn more about creating a `DataSource`, refer to the [Data Sources](./data-
 
 The [`Embedder`](../reference/core/modules.md#embedder) takes in a string and returns a vector embedding for that string.
 
-To create an `Embedder` that uses the [OpenAI Embeddings API](https://platform.openai.com/docs/guides/embeddings),
+To create an `Embedder` that uses the [LangChain `Embeddings` class](foo),
+you can use the function [`makeLangChainEmbedder()`](../reference/core/modules.md#makelangchainembedder). To see the various embedding models supported by LangChain, refer to the [LangChain text embedding models](https://js.langchain.com/docs/integrations/text_embedding) documentation.
+
+```ts
+import { makeLangChainEmbedder } from "mongodb-rag-core";
+import { OpenAIEmbeddings } from "@langchain/openai";
+
+const { OPENAI_API_KEY } = process.env;
+
+const langChainOpenAiEmbeddings = new OpenAIEmbeddings({
+  openAIApiKey: OPENAI_API_KEY,
+  modelName: "text-embedding-3-large",
+  dimensions: 1024,
+});
+
+const embedder = makeLangChainEmbedder({
+  langChainEmbeddings: langChainOpenAiEmbeddings,
+});
+```
+
+To create an `Embedder` that uses the [OpenAI Embeddings API](https://platform.openai.com/docs/guides/embeddings) directly,
 you can use the function [`makeOpenAiEmbedder()`](../reference/core/modules.md#makeopenaiembedder). This function uses the
 `@azure/openai` package to construct the OpenAI client, which supports
 both the Azure OpenAI Service and the Open API.

--- a/docs/docs/ingest/configuration-reference.md
+++ b/docs/docs/ingest/configuration-reference.md
@@ -104,7 +104,7 @@ To learn more about creating a `DataSource`, refer to the [Data Sources](./data-
 
 The [`Embedder`](../reference/core/modules.md#embedder) takes in a string and returns a vector embedding for that string.
 
-To create an `Embedder` that uses the [LangChain `Embeddings` class](https://js.langchain.com/docs/integrations/text_embedding),
+To create an `Embedder` that uses the LangChain `Embeddings` class,
 you can use the function [`makeLangChainEmbedder()`](../reference/core/modules.md#makelangchainembedder). To see the various embedding models supported by LangChain, refer to the [LangChain text embedding models](https://js.langchain.com/docs/integrations/text_embedding) documentation.
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -4177,10 +4177,34 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@langchain/azure-openai": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@langchain/azure-openai/-/azure-openai-0.0.6.tgz",
+      "integrity": "sha512-YhEpHANb/2vLL1m10NJ1998NxlDkGqxXzK9yyuwFQPGEfObd3N62P6ef+hjjG2RRCDP288wbhfs4T/OAdeIsIw==",
+      "dependencies": {
+        "@azure/core-auth": "^1.5.0",
+        "@azure/openai": "1.0.0-beta.11",
+        "@langchain/core": "~0.1.9",
+        "js-tiktoken": "^1.0.7",
+        "zod": "^3.22.3",
+        "zod-to-json-schema": "3.20.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/azure-openai/node_modules/zod-to-json-schema": {
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.20.3.tgz",
+      "integrity": "sha512-/Q3wnyxAfCt94ZcrGiXXoiAfRqasxl9CX64LZ9fj+4dKH68zulUtU0uk1WMxQPfAxQ0ZI70dKzcoW7hHj+DwSQ==",
+      "peerDependencies": {
+        "zod": "^3.20.0"
+      }
+    },
     "node_modules/@langchain/core": {
-      "version": "0.1.48",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.48.tgz",
-      "integrity": "sha512-kGggyDbaYzCIPGkzvMvm/v0+lcTy1jlX6QZ7PSzUQFYJg5JK399x3AOYIDkbbUVxBAyHRgrWlxVQXH0FW3N6Bg==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.53.tgz",
+      "integrity": "sha512-khfRTu2DSCNMPUmnKx7iH0TpEaunW/4BgR6STTteRRDd0NFtXGfAwUuY9sm0+EKi/XKhdAmpGnfLwSfNg5F0Qw==",
       "dependencies": {
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
@@ -37025,6 +37049,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.5",
+        "@langchain/azure-openai": "^0.0.6",
+        "@langchain/core": "^0.1.53",
         "common-tags": "^1",
         "dotenv": "^16.3.1",
         "exponential-backoff": "^3.1.1",

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -60,6 +60,8 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.5",
+    "@langchain/azure-openai": "^0.0.6",
+    "@langchain/core": "^0.1.53",
     "common-tags": "^1",
     "dotenv": "^16.3.1",
     "exponential-backoff": "^3.1.1",

--- a/packages/mongodb-rag-core/src/LangChainEmbedder.test.ts
+++ b/packages/mongodb-rag-core/src/LangChainEmbedder.test.ts
@@ -1,0 +1,41 @@
+import "dotenv/config";
+import { Embeddings } from "@langchain/core/embeddings";
+import { makeLangChainEmbedder } from "./LangChainEmbedder";
+import { AzureOpenAIEmbeddings } from "@langchain/azure-openai";
+import { CORE_ENV_VARS } from "./CoreEnvVars";
+import { assertEnvVars } from "./assertEnvVars";
+import { AzureKeyCredential } from "@azure/openai";
+
+const { OPENAI_ENDPOINT, OPENAI_API_KEY, OPENAI_EMBEDDING_DEPLOYMENT } =
+  assertEnvVars(CORE_ENV_VARS);
+
+jest.setTimeout(10000);
+describe("LangChainEmbedder", () => {
+  it("embeds text", async () => {
+    // how to mock the Embeddings class?
+    const langChainEmbeddings = {
+      embedQuery: jest.fn().mockResolvedValue([1, 2, 3]),
+    } as unknown as Embeddings;
+    const embedder = makeLangChainEmbedder({ langChainEmbeddings });
+    const result = await embedder.embed({ text: "hello" });
+    expect(result).toEqual({ embedding: [1, 2, 3] });
+  });
+  it("works with Azure OpenAI", async () => {
+    // how to mock the Embeddings class?
+    const azureEmbeddings = new AzureOpenAIEmbeddings({
+      azureOpenAIEndpoint: OPENAI_ENDPOINT,
+      azureOpenAIApiDeploymentName: OPENAI_EMBEDDING_DEPLOYMENT,
+      credentials: new AzureKeyCredential(OPENAI_API_KEY),
+      maxRetries: 0,
+    });
+
+    const embedder = makeLangChainEmbedder({
+      langChainEmbeddings: azureEmbeddings,
+    });
+
+    const result = await embedder.embed({ text: "hello" });
+    expect(result).toEqual({
+      embedding: expect.arrayContaining([expect.any(Number)]),
+    });
+  });
+});

--- a/packages/mongodb-rag-core/src/LangChainEmbedder.ts
+++ b/packages/mongodb-rag-core/src/LangChainEmbedder.ts
@@ -1,0 +1,23 @@
+import { Embedder } from "./Embedder";
+import { Embeddings } from "@langchain/core/embeddings";
+export type MakeLangChainEmbedderParams = {
+  /**
+    LangChain.js `Embeddings` instance.
+    You can configure things like caching and retry behavior in the `Embeddings` instance.
+   */
+  langChainEmbeddings: Embeddings;
+};
+
+/**
+  Constructor for implementation of the {@link Embedder} using a LangChain.js [`Embeddings`](https://js.langchain.com/docs/modules/data_connection/text_embedding/) class.
+ */
+export const makeLangChainEmbedder = ({
+  langChainEmbeddings,
+}: MakeLangChainEmbedderParams): Embedder => {
+  return {
+    async embed({ text }) {
+      const embedding = await langChainEmbeddings.embedQuery(text);
+      return { embedding };
+    },
+  };
+};

--- a/packages/mongodb-rag-core/src/index.ts
+++ b/packages/mongodb-rag-core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./CoreEnvVars";
 export * from "./DatabaseConnection";
 export * from "./EmbeddedContent";
 export * from "./Embedder";
+export * from "./LangChainEmbedder";
 export * from "./MongoDbEmbeddedContentStore";
 export * from "./MongoDbVerifiedAnswerStore";
 export * from "./MongoDbPageStore";


### PR DESCRIPTION
Jira: n/a

## Changes

- `makeLangChainEmbedder()` constructor of `Embedder` that wraps LangChain `Embeddings` class
- document `makeLangChainEmbedder()`

## Notes

- the langchain `Embeddings` class has some nice support for things like retry and caching. we might want to consider migrating to using this instead of Azure OpenAI directly. 
- I want to add this before a hackathon on saturday so folks can use our framework w/ whatever embedding model they choose.
