### PR TITLE
fix: awaited, non-verified answers were not rendered

### DIFF
--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -494,15 +494,12 @@ export function useConversation(params: UseConversationParams = {}) {
           ? formatReferences(references)
           : "";
         dispatch({ type: "cancelStreamingResponse" });
-        const metadata = response.metadata;
-        if (metadata) {
-          dispatch({
-            type: "addMessage",
-            role: "assistant",
-            content: response.content + referencesContent,
-            metadata,
-          });
-        }
+        dispatch({
+          type: "addMessage",
+          role: "assistant",
+          content: response.content + referencesContent,
+          metadata: response.metadata,
+        });
       }
     } catch (error) {
       abortController.abort();


### PR DESCRIPTION
## Changes

- For non-streaming responses, we were only rendering if there was metadata (i.e. if it was a verified message). Now this is fixed and we render all awaited messages.
