### PR TITLE
Fix all lint warnings

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -15,7 +15,6 @@ import {
   CORE_ENV_VARS,
   assertEnvVars,
   makeDefaultFindContent,
-  SystemPrompt,
   requireValidIpAddress,
   requireRequestOrigin,
   AddCustomDataFunc,
@@ -23,7 +22,6 @@ import {
   makeVerifiedAnswerGenerateUserPrompt,
   makeDefaultFindVerifiedAnswer,
 } from "mongodb-chatbot-server";
-import { stripIndents } from "common-tags";
 import { AzureKeyCredential, OpenAIClient } from "@azure/openai";
 import cookieParser from "cookie-parser";
 import { makeStepBackRagGenerateUserPrompt } from "./processors/makeStepBackRagGenerateUserPrompt";

--- a/packages/chatbot-server-mongodb-public/src/index.ts
+++ b/packages/chatbot-server-mongodb-public/src/index.ts
@@ -36,7 +36,7 @@ const startServer = async () => {
     await mongodb.close();
     await embeddedContentStore.close();
     await new Promise<void>((resolve, reject) => {
-      server.close((error: any) => {
+      server.close((error: unknown) => {
         error ? reject(error) : resolve();
       });
     });

--- a/packages/chatbot-server-mongodb-public/src/middleware/blockGetRequests.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/middleware/blockGetRequests.test.ts
@@ -1,7 +1,7 @@
 import { blockGetRequests } from "./blockGetRequests";
 import { NextFunction } from "express";
 
-type FunctionArguments<T> = T extends (...args: infer U) => any ? U : never;
+type FunctionArguments<T> = T extends (...args: infer U) => unknown ? U : never;
 
 describe("blockGetRequests", () => {
   let req: FunctionArguments<typeof blockGetRequests>[0];

--- a/packages/chatbot-server-mongodb-public/src/processors/extractMetadataFromUserMessage.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/extractMetadataFromUserMessage.ts
@@ -5,7 +5,6 @@ import {
   ChatRequestMessage,
   FunctionDefinition,
 } from "@azure/openai";
-import { strict as assert } from "assert";
 
 const extractMetadataSystemPrompt = {
   role: "system",

--- a/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
@@ -181,7 +181,7 @@ function makeUserContentForLlm({
   userMessageText: string;
   stepBackUserQuery: string;
   messages: Message[];
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   content: EmbeddedContent[];
   maxContextTokenCount: number;
 }) {

--- a/packages/chatbot-server-mongodb-public/src/processors/makeStepBackUserQuery.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeStepBackUserQuery.ts
@@ -54,7 +54,7 @@ export interface MakeStepBackUserQueryParams {
   deploymentName: string;
   messages?: Message[];
   userMessageText: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -112,7 +112,7 @@ function generateStepBackUserMessage({
 }: {
   userMessageText: string;
   messages: Message[];
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   numPrecedingMessagesToInclude?: number;
 }) {
   return {

--- a/packages/mongodb-artifact-generator/src/commands/generateDocsPage.ts
+++ b/packages/mongodb-artifact-generator/src/commands/generateDocsPage.ts
@@ -57,10 +57,7 @@ export default createCommand<GenerateDocsPageCommandArgs>({
 });
 
 export const action = createConfiguredAction<GenerateDocsPageCommandArgs>(
-  async (
-    { embeddedContentStore, embedder, pageStore },
-    { targetDescription, template }
-  ) => {
+  async ({ pageStore }, { targetDescription, template }) => {
     logger.logInfo(`Setting up...`);
     const generate = makeGenerateChatCompletion();
     // const { findContent, cleanup: cleanupFindContent } = makeFindContent({

--- a/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
+++ b/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
@@ -5,13 +5,11 @@ import {
 } from "../withConfig";
 import { createCommand } from "../createCommand";
 import { makeRunLogger, type RunLogger } from "../runlogger";
-// import { parse as parseCsv } from "csv-parse";
 import { parse as parseCsv } from "papaparse";
 import { promises as fs } from "fs";
 import path from "path";
 
 import { action as translateCodeAction } from "./translateCode";
-// import { action as translateDocsPageAction } from "./translateDocsPage";
 import { ObjectId } from "mongodb";
 
 let logger: RunLogger;
@@ -143,10 +141,7 @@ export const action = createConfiguredAction<ParseDriversCsvCommandArgs>(
         }
       );
 
-      const {
-        Code: codeExampleAssets,
-        // Page: pageAssets
-      } = groupBy(
+      const { Code: codeExampleAssets } = groupBy(
         relevantAssetFieldsOnly.filter((r) => r !== undefined),
         (asset) => asset.assetType
       );

--- a/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
+++ b/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
@@ -11,7 +11,7 @@ import { promises as fs } from "fs";
 import path from "path";
 
 import { action as translateCodeAction } from "./translateCode";
-import { action as translateDocsPageAction } from "./translateDocsPage";
+// import { action as translateDocsPageAction } from "./translateDocsPage";
 import { ObjectId } from "mongodb";
 
 let logger: RunLogger;
@@ -143,7 +143,10 @@ export const action = createConfiguredAction<ParseDriversCsvCommandArgs>(
         }
       );
 
-      const { Code: codeExampleAssets, Page: pageAssets } = groupBy(
+      const {
+        Code: codeExampleAssets,
+        // Page: pageAssets
+      } = groupBy(
         relevantAssetFieldsOnly.filter((r) => r !== undefined),
         (asset) => asset.assetType
       );
@@ -182,7 +185,7 @@ export const action = createConfiguredAction<ParseDriversCsvCommandArgs>(
   }
 );
 
-function groupBy<T, K extends keyof any>(
+function groupBy<T, K extends string | number>(
   array: T[],
   getKey: (item: T) => K
 ): Record<K, T[]> {

--- a/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
+++ b/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
@@ -172,7 +172,6 @@ export const action = createConfiguredAction<ParseDriversCsvCommandArgs>(
           outputFilename: codeExampleAsset.fileRename,
         });
       }
-
       console.log("done!");
     } finally {
       // await cleanupFindContent();

--- a/packages/mongodb-chatbot-evaluation/src/Pipeline.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/Pipeline.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from "mongodb-rag-core";
 import { EvalConfig } from "./EvalConfig";
-import { Pipeline, runPipeline } from "./Pipeline";
+import { runPipeline } from "./Pipeline";
 import { mockEvaluateConversation } from "./test/mockEvaluateConversation";
 import { makeMockEvaluationStore } from "./test/mockEvaluationStore";
 import { mockGenerateDataFunc } from "./test/mockGenerateDataFunc";
@@ -21,6 +21,7 @@ describe("runPipeline", () => {
     evaluationStore,
     reportStore,
   ];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mockExit = jest.fn() as any;
   beforeEach(() => {
     for (const store of stores) {

--- a/packages/mongodb-chatbot-evaluation/src/Pipeline.ts
+++ b/packages/mongodb-chatbot-evaluation/src/Pipeline.ts
@@ -1,6 +1,6 @@
 import { ObjectId, logger } from "mongodb-rag-core";
 import { CommandRunMetadata } from "./CommandMetadataStore";
-import { ConfigConstructor, EvalConfig } from "./EvalConfig";
+import { ConfigConstructor } from "./EvalConfig";
 import { strict as assert } from "assert";
 import { generateDataAndMetadata } from "./generate";
 import { generateEvalsAndMetadata } from "./evaluate/generateEvalsAndMetadata";

--- a/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationAverageRetrievalScore.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationAverageRetrievalScore.test.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { ObjectId } from "mongodb-rag-core";
-import { ConversationGeneratedData } from "../generate";
 import { Message } from "mongodb-chatbot-server";
 import { evaluateConversationAverageRetrievalScore } from "./evaluateConversationAverageRetrievalScore";
 import { mockConversationGeneratedDataFromMessages } from "../test/mockConversationGeneratedDataFromMessages";

--- a/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationFaithfulness.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationFaithfulness.test.ts
@@ -62,7 +62,8 @@ describe("makeEvaluateConversationFaithfulness", () => {
       createdAt: expect.any(Date),
       commandRunMetadataId: runId,
       metadata: {
-        contextContent: messages[0]!.contextContent!.map(({ text }) => text),
+        contextContent:
+          messages[0]?.contextContent?.map(({ text }) => text) ?? "",
         userQueryContent: messages[0].content,
         assistantResponseContent: messages[1].content,
         name: expect.any(String),
@@ -107,7 +108,8 @@ describe("makeEvaluateConversationFaithfulness", () => {
       createdAt: expect.any(Date),
       commandRunMetadataId: runId,
       metadata: {
-        contextContent: messages[0]!.contextContent!.map(({ text }) => text),
+        contextContent:
+          messages[0]?.contextContent?.map(({ text }) => text) ?? "",
         userQueryContent: messages[0].content,
         assistantResponseContent: messages[1].content,
       },

--- a/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationRelevancy.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationRelevancy.test.ts
@@ -54,6 +54,7 @@ describe("makeEvaluateConversationRelevancy", () => {
       runId,
       generatedData: faithfulGeneratedData,
     });
+
     expect(evalResult).toMatchObject({
       generatedDataId: faithfulGeneratedData._id,
       result: 1,
@@ -62,7 +63,8 @@ describe("makeEvaluateConversationRelevancy", () => {
       createdAt: expect.any(Date),
       commandRunMetadataId: runId,
       metadata: {
-        contextContent: messages[0]!.contextContent!.map(({ text }) => text),
+        contextContent:
+          messages[0]?.contextContent?.map(({ text }) => text) ?? "",
         userQueryContent: messages[0].content,
         assistantResponseContent: messages[1].content,
       },
@@ -106,7 +108,8 @@ describe("makeEvaluateConversationRelevancy", () => {
       createdAt: expect.any(Date),
       commandRunMetadataId: runId,
       metadata: {
-        contextContent: messages[0]!.contextContent!.map(({ text }) => text),
+        contextContent:
+          messages[0]?.contextContent?.map(({ text }) => text) ?? "",
         userQueryContent: messages[0].content,
         assistantResponseContent: messages[1].content,
       },

--- a/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateExpectedLinks.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateExpectedLinks.test.ts
@@ -124,14 +124,14 @@ describe("evaluateExpectedLinks", () => {
 
   it('should throw an error if generatedData is not of type "conversation"', async () => {
     const generatedConversationData = generateConversationData([]);
-    (generateConversationData as any).type = "not conversation";
+    (generatedConversationData as { type: string }).type = "not conversation";
     const runId = new ObjectId();
     await expect(
       evaluateExpectedLinks({
         generatedData: generatedConversationData,
         runId,
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow("Invalid data type. Expected 'conversation' data.");
   });
 
   it("should throw an error if no expectedLinks are provided in the test case", async () => {

--- a/packages/mongodb-chatbot-evaluation/src/report/generateReportAndMetadata.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/report/generateReportAndMetadata.test.ts
@@ -6,7 +6,6 @@ import { makeMockReportStore } from "../test/mockReportStore";
 import { generateReportAndMetadata } from "./generateReportAndMetadata";
 import { EvalResult } from "../evaluate/EvaluationStore";
 import { CommandRunMetadata } from "../CommandMetadataStore";
-import e from "express";
 import { Report } from "./ReportStore";
 
 describe("generateReportAndMetadata", () => {

--- a/packages/mongodb-chatbot-evaluation/src/test/mockConversations.ts
+++ b/packages/mongodb-chatbot-evaluation/src/test/mockConversations.ts
@@ -1,11 +1,8 @@
 import {
-  AssistantMessage,
   Conversation,
   ConversationsService,
   Message,
   MessageBase,
-  SystemMessage,
-  UserMessage,
 } from "mongodb-chatbot-server";
 import { ObjectId } from "mongodb-rag-core";
 

--- a/packages/mongodb-chatbot-evaluation/src/test/mockReportFunc.ts
+++ b/packages/mongodb-chatbot-evaluation/src/test/mockReportFunc.ts
@@ -11,7 +11,6 @@ export const mockReportEvalFunc: ReportEvalFunc = async ({
   evaluationRunId,
   evaluationStore,
   runId,
-  reportName,
 }) => {
   const filter: MockFindFilter<EvalResult> = (evalRes) =>
     evalRes.commandRunMetadataId.equals(evaluationRunId);

--- a/packages/mongodb-chatbot-evaluation/src/withConfig.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/withConfig.test.ts
@@ -3,6 +3,7 @@ import { withConfig } from "./withConfig";
 
 describe("withConfig", () => {
   it("loads a config file", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockExit = jest.fn() as any;
     process.exit = mockExit;
     await withConfig(

--- a/packages/mongodb-chatbot-evaluation/src/withConfig.ts
+++ b/packages/mongodb-chatbot-evaluation/src/withConfig.ts
@@ -111,9 +111,3 @@ function checkRequiredProperty<T, K extends keyof T>(
   }
   return value as Exclude<T[K], undefined>;
 }
-
-type Closeable = {
-  close?(): Promise<void>;
-};
-
-type CleanupFunc = () => Promise<void>;

--- a/packages/mongodb-chatbot-server/src/routes/conversations/commentMessage.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/commentMessage.test.ts
@@ -8,7 +8,7 @@ import {
   ConversationsService,
 } from "../../services/ConversationsService";
 import { Express } from "express";
-import { Db, ObjectId } from "mongodb-rag-core";
+import { ObjectId } from "mongodb-rag-core";
 import { DEFAULT_API_PREFIX } from "../../app";
 import { makeTestApp } from "../../test/testHelpers";
 import { AppConfig } from "../../app";

--- a/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.test.ts
@@ -1,4 +1,4 @@
-import { Db, ObjectId } from "mongodb-rag-core";
+import { ObjectId } from "mongodb-rag-core";
 import { ConversationsService } from "../../services";
 import { makeTestApp, makeTestAppConfig } from "../../test/testHelpers";
 import request from "supertest";

--- a/packages/mongodb-chatbot-server/src/routes/conversations/rateMessage.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/rateMessage.test.ts
@@ -8,7 +8,7 @@ import {
   ConversationsService,
 } from "../../services/ConversationsService";
 import { Express } from "express";
-import { Db, MongoClient, ObjectId } from "mongodb-rag-core";
+import { ObjectId } from "mongodb-rag-core";
 import { makeRateMessageRoute } from "./rateMessage";
 import { DEFAULT_API_PREFIX } from "../../app";
 import { makeTestApp, systemPrompt } from "../../test/testHelpers";
@@ -25,13 +25,12 @@ describe("POST /conversations/:conversationId/messages/:messageId/rating", () =>
   let conversation: Conversation;
   let testMsg: Message;
   let testEndpointUrl: string;
-  let mongodb: Db;
   let ipAddress: string;
   let appConfig: AppConfig;
   let origin: string;
 
   beforeAll(async () => {
-    ({ mongodb, app, ipAddress, appConfig, origin } = await makeTestApp());
+    ({ app, ipAddress, appConfig, origin } = await makeTestApp());
     conversations = appConfig.conversationsRouterConfig.conversations;
 
     app

--- a/packages/mongodb-chatbot-server/src/services/mongodbConversations.ts
+++ b/packages/mongodb-chatbot-server/src/services/mongodbConversations.ts
@@ -1,4 +1,3 @@
-import { SystemPrompt } from "./ChatLlm";
 import { ObjectId, Db } from "mongodb-rag-core";
 import {
   ConversationConstants,

--- a/packages/mongodb-chatbot-server/src/services/openAiChatLlm.ts
+++ b/packages/mongodb-chatbot-server/src/services/openAiChatLlm.ts
@@ -1,18 +1,11 @@
 import {
   ChatRequestAssistantMessage,
-  ChatResponseMessage,
   GetChatCompletionsOptions,
 } from "@azure/openai";
 import "dotenv/config";
 import { OpenAIClient } from "@azure/openai";
 import { strict as assert } from "assert";
-import {
-  ChatLlm,
-  LlmAnswerQuestionParams,
-  OpenAiChatMessage,
-  Tool,
-} from "./ChatLlm";
-import { Conversation } from "./ConversationsService";
+import { ChatLlm, LlmAnswerQuestionParams, Tool } from "./ChatLlm";
 
 /**
   Configuration for the {@link makeOpenAiChatLlm} function.

--- a/packages/mongodb-rag-core/src/PageFormat.ts
+++ b/packages/mongodb-rag-core/src/PageFormat.ts
@@ -1,5 +1,3 @@
-import { logger } from "./services/logger";
-
 /**
   This is the definition of the canonical file formats that we support
   for pages. If something is not in this list, we treat it as a "txt"

--- a/packages/mongodb-rag-ingest/src/embed/chunkOpenApiSpecYaml.ts
+++ b/packages/mongodb-rag-ingest/src/embed/chunkOpenApiSpecYaml.ts
@@ -46,7 +46,6 @@ export const chunkOpenApiSpecYaml: ChunkFunc = async function (
   const { paths } = spec;
   if (paths !== undefined) {
     for (const path of Object.keys(paths)) {
-      // const actions = paths[path] as { [key: string]: any };
       const actions = paths[path];
       if (actions === undefined) {
         continue;

--- a/packages/mongodb-rag-ingest/src/sources/LangchainDocumentLoaderDataSource.ts
+++ b/packages/mongodb-rag-ingest/src/sources/LangchainDocumentLoaderDataSource.ts
@@ -1,7 +1,7 @@
 import { DocumentLoader } from "langchain/document_loaders/base";
 import { Document as LangchainDocument } from "langchain/document";
 import { DataSource } from "./DataSource";
-import { Page, PageMetadata, PageStore } from "mongodb-rag-core";
+import { Page, PageMetadata } from "mongodb-rag-core";
 
 export interface MakeLangChainDocumentLoaderDataSourceParams {
   /**

--- a/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataApiClient.ts
+++ b/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataApiClient.ts
@@ -29,7 +29,7 @@ export interface TiCatalogItem {
    */
   associated_labs: string[];
   // TODO: is this always null?
-  associated_content: null | any;
+  associated_content: null | unknown;
   /**
     Whether or not the catalog item is in development.
    */
@@ -107,12 +107,12 @@ interface VideoCaption {
 
 interface ResponseMetadata {
   count: number;
-  extra: null | any;
+  extra: null | unknown;
   total_count: number;
   has_more: boolean;
   limit: number;
   offset: number;
-  filter: null | any;
+  filter: null | unknown;
 }
 
 interface GetAllCatalogItemsResponseData {

--- a/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataSource.ts
+++ b/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataSource.ts
@@ -1,4 +1,4 @@
-import { Page, PageMetadata } from "mongodb-rag-core";
+import { PageMetadata } from "mongodb-rag-core";
 import { DataSource } from "../DataSource";
 import { makeUniversityPages } from "./makeUniversityPages";
 import {

--- a/packages/mongodb-rag-ingest/src/sources/snooty/SnootyDataSource.test.ts
+++ b/packages/mongodb-rag-ingest/src/sources/snooty/SnootyDataSource.test.ts
@@ -60,7 +60,6 @@ describe("SnootyDataSource", () => {
       const astPages = JSONL.parse<{ type: string; data: { ast: SnootyNode } }>(
         fs.readFileSync(sampleDataPath, "utf8")
       );
-      const baseUrl = "https://mongodb.com/docs/v6.0";
       const pageAst = astPages.filter(
         (entry: { type: string }) => entry.type === "page"
       )[1]?.data.ast;

--- a/packages/scripts/src/createAug2023QualityTestsYaml.ts
+++ b/packages/scripts/src/createAug2023QualityTestsYaml.ts
@@ -40,7 +40,7 @@ interface TestCase {
   expectation: string;
 }
 
-function parseCsvToObject(csvFilePath: string) {
+function parseCsvToObject() {
   const input = readFileSync(generalTestsFilePath, "utf8");
   const records: TestCsvRow[] = parse(input, {
     columns: true,
@@ -99,7 +99,7 @@ function writeYamlToFile(yamlString: string, filePath: string) {
 }
 
 async function convertCsvToYamlAndWriteToFile(csvFilePath: string, db: Db) {
-  const csvObjects = parseCsvToObject(csvFilePath);
+  const csvObjects = parseCsvToObject();
   const testCases: TestCase[] = [];
   for (const csvObject of csvObjects) {
     const messages = await getMessagesForTest(

--- a/packages/scripts/src/main/upgradeFaqEntriesMain.ts
+++ b/packages/scripts/src/main/upgradeFaqEntriesMain.ts
@@ -2,7 +2,6 @@ import { MongoClient, WithId, AnyBulkWriteOperation } from "mongodb";
 import { assertEnvVars } from "mongodb-rag-core";
 import { upgradeFaqEntry, FaqEntry, FaqEntryV0 } from "../upgradeFaqEntries";
 import { ScrubbedMessage } from "../ScrubbedMessage";
-import { promises as fs } from "fs";
 import "dotenv/config";
 
 const {


### PR DESCRIPTION
```
> mongodb-rag-core

/drone/src/packages/mongodb-rag-core/src/PageFormat.ts
  1:10  warning  'logger' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

> mongodb-artifact-generator

/drone/src/packages/mongodb-artifact-generator/src/commands/generateDocsPage.ts
  61:7   warning  'embeddedContentStore' is defined but never used  @typescript-eslint/no-unused-vars
  61:29  warning  'embedder' is defined but never used              @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
   14:20  warning  'translateDocsPageAction' is defined but never used  @typescript-eslint/no-unused-vars
  146:46  warning  'pageAssets' is assigned a value but never used      @typescript-eslint/no-unused-vars
  185:37  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

> mongodb-rag-ingest

/drone/src/packages/mongodb-rag-ingest/src/embed/chunkOpenApiSpecYaml.ts
  49:55  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  98:55  warning  Forbidden non-null assertion              @typescript-eslint/no-non-null-assertion

/drone/src/packages/mongodb-rag-ingest/src/sources/LangchainDocumentLoaderDataSource.ts
  4:30  warning  'PageStore' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataApiClient.ts
   32:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  110:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  115:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/mongodb-rag-ingest/src/sources/mongodb-university/MongoDbUniversityDataSource.ts
  1:10  warning  'Page' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-rag-ingest/src/sources/snooty/SnootyDataSource.test.ts
  63:13  warning  'baseUrl' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

> mongodb-chatbot-server

/drone/src/packages/mongodb-chatbot-server/src/routes/conversations/commentMessage.test.ts
  11:10  warning  'Db' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-server/src/routes/conversations/getConversation.test.ts
  1:10  warning  'Db' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-server/src/routes/conversations/rateMessage.test.ts
  11:14  warning  'MongoClient' is defined but never used. Allowed unused vars must match /^_/u       @typescript-eslint/no-unused-vars
  28:7   warning  'mongodb' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-server/src/services/mongodbConversations.ts
  1:10  warning  'SystemPrompt' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-server/src/services/openAiChatLlm.ts
   3:3   warning  'ChatResponseMessage' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  12:3   warning  'OpenAiChatMessage' is defined but never used. Allowed unused vars must match /^_/u    @typescript-eslint/no-unused-vars
  15:10  warning  'Conversation' is defined but never used. Allowed unused vars must match /^_/u         @typescript-eslint/no-unused-vars

> chatbot-server-mongodb-public

/drone/src/packages/chatbot-server-mongodb-public/src/config.ts
  18:3   warning  'SystemPrompt' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  26:10  warning  'stripIndents' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/chatbot-server-mongodb-public/src/index.ts
  39:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/chatbot-server-mongodb-public/src/middleware/blockGetRequests.test.ts
  4:61  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/chatbot-server-mongodb-public/src/processors/extractMetadataFromUserMessage.ts
  8:20  warning  'assert' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
  184:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/chatbot-server-mongodb-public/src/processors/makeStepBackUserQuery.ts
   57:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  115:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

> scripts

/drone/src/packages/scripts/src/createAug2023QualityTestsYaml.ts
  43:27  warning  'csvFilePath' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/scripts/src/main/upgradeFaqEntriesMain.ts
  5:22  warning  'fs' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

> mongodb-chatbot-evaluation

/drone/src/packages/mongodb-chatbot-evaluation/src/Pipeline.test.ts
   3:10  warning  'Pipeline' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  24:33  warning  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any

/drone/src/packages/mongodb-chatbot-evaluation/src/Pipeline.ts
  3:29  warning  'EvalConfig' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationAverageRetrievalScore.test.ts
  3:10  warning  'ConversationGeneratedData' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationFaithfulness.test.ts
   65:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
   65:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  110:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  110:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/drone/src/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateConversationRelevancy.test.ts
   65:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
   65:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  109:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  109:25  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/drone/src/packages/mongodb-chatbot-evaluation/src/evaluate/evaluateExpectedLinks.test.ts
  127:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/mongodb-chatbot-evaluation/src/report/generateReportAndMetadata.test.ts
  9:8  warning  'e' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-evaluation/src/test/mockConversations.ts
  2:3  warning  'AssistantMessage' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  7:3  warning  'SystemMessage' is defined but never used. Allowed unused vars must match /^_/u     @typescript-eslint/no-unused-vars
  8:3  warning  'UserMessage' is defined but never used. Allowed unused vars must match /^_/u       @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-evaluation/src/test/mockReportFunc.ts
  14:3  warning  'reportName' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/drone/src/packages/mongodb-chatbot-evaluation/src/withConfig.test.ts
  6:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/drone/src/packages/mongodb-chatbot-evaluation/src/withConfig.ts
  115:6  warning  'Closeable' is defined but never used. Allowed unused vars must match /^_/u    @typescript-eslint/no-unused-vars
  119:6  warning  'CleanupFunc' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

```