### PR TITLE
Work around test that times out

### DIFF
--- a/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.test.ts
@@ -10,6 +10,7 @@ assert(process.env.MONGODB_DOT_COM_DB_NAME, "Missing MONGODB_DOT_COM_DB_NAME");
 const dotcomDataSource = makeMongoDbDotComDataSource({
   connectionUri: process.env.MONGODB_DOT_COM_CONNECTION_URI,
   dbName: process.env.MONGODB_DOT_COM_DB_NAME,
+  limit: 10,
 });
 describe("MongoDbDotComDataSource", () => {
   it("should fetch pages", async () => {

--- a/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.test.ts
@@ -10,7 +10,7 @@ assert(process.env.MONGODB_DOT_COM_DB_NAME, "Missing MONGODB_DOT_COM_DB_NAME");
 const dotcomDataSource = makeMongoDbDotComDataSource({
   connectionUri: process.env.MONGODB_DOT_COM_CONNECTION_URI,
   dbName: process.env.MONGODB_DOT_COM_DB_NAME,
-  limit: 10,
+  maxPages: 10,
 });
 describe("MongoDbDotComDataSource", () => {
   it("should fetch pages", async () => {

--- a/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.ts
@@ -11,16 +11,18 @@ import striptags from "striptags";
 export function makeMongoDbDotComDataSource({
   connectionUri,
   dbName,
+  limit,
 }: {
   connectionUri: string;
   dbName: string;
+  limit?: number; // for testing
 }): DataSource {
   return {
     name: "mongodb-dot-com",
     async fetchPages() {
       const mongodb = new MongoClient(connectionUri);
       try {
-        const customerPages = await mongodb
+        const query = mongodb
           .db(dbName)
           .collection<CustomerPage>("nodes")
           .find({
@@ -36,8 +38,11 @@ export function makeMongoDbDotComDataSource({
               },
               { components: { $exists: true, $ne: null } },
             ],
-          })
-          .toArray();
+          });
+        if (limit) {
+          query.limit(limit);
+        }
+        const customerPages = await query.toArray();
 
         const parsedCustomerPages = customerPages.map((customerPage) =>
           parseCustomerPage({

--- a/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/MongoDbDotComDataSource.ts
@@ -11,11 +11,11 @@ import striptags from "striptags";
 export function makeMongoDbDotComDataSource({
   connectionUri,
   dbName,
-  limit,
+  maxPages,
 }: {
   connectionUri: string;
   dbName: string;
-  limit?: number; // for testing
+  maxPages?: number; // for testing
 }): DataSource {
   return {
     name: "mongodb-dot-com",
@@ -39,8 +39,8 @@ export function makeMongoDbDotComDataSource({
               { components: { $exists: true, $ne: null } },
             ],
           });
-        if (limit) {
-          query.limit(limit);
+        if (maxPages) {
+          query.limit(maxPages);
         }
         const customerPages = await query.toArray();
 


### PR DESCRIPTION
```
FAIL  src/sources/MongoDbDotComDataSource.test.ts (26.539 s)
  ● MongoDbDotComDataSource › should fetch pages

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      13 | });
      14 | describe("MongoDbDotComDataSource", () => {
    > 15 |   it("should fetch pages", async () => {
         |   ^
      16 |     const pages = await dotcomDataSource.fetchPages();
      17 |     // writeFileSync('pages.json', JSON.stringify(pages, null, 2))
      18 |     expect(pages.length).toBeGreaterThan(0);

      at src/sources/MongoDbDotComDataSource.test.ts:15:3
      at Object.<anonymous> (src/sources/MongoDbDotComDataSource.test.ts:14:1)
```

## Changes

- Adds a `limit` arg to the MongoDbDotCom data source
- Sets the `limit` to 10 so the test doesn't time out
