### PR TITLE
(EAI-343) [UI] Modal chat feed fills screen

### DIFF
--- a/packages/mongodb-chatbot-ui/src/ChatWindow.tsx
+++ b/packages/mongodb-chatbot-ui/src/ChatWindow.tsx
@@ -48,8 +48,11 @@ const styles = {
     border-radius: 24px;
   `,
   message_feed: css`
+    height: 100%;
+    max-height: 70vh;
     & > div {
       box-sizing: border-box;
+      max-height: 70vh;
     }
   `,
   verify_information: css`

--- a/packages/mongodb-chatbot-ui/src/ModalView.tsx
+++ b/packages/mongodb-chatbot-ui/src/ModalView.tsx
@@ -15,6 +15,10 @@ const styles = {
       box-sizing: border-box;
     }
 
+    > div {
+      padding: unset;
+    }
+
     & div[role="dialog"] {
       padding: 0;
       background: ${darkMode ? palette.black : palette.gray.light3};


### PR DESCRIPTION
Jira: (EAI-343) [UI] Modal chat feed fills screen

## Changes

- The modal will now take up to 70% of the user's viewport.
  - On my MBP, this gives 170px more height to the chat feed.
  - On my 4k 27" monitor this gives about 300px more height to the chat feed.

![taller-modal](https://github.com/mongodb/chatbot/assets/15657698/b206f23c-1f4d-4eba-82b0-40654f725367)
