### PR TITLE
cronjob stop backoff after 3

### DIFF
--- a/packages/chatbot-eval-mongodb-public/environments/staging.yml
+++ b/packages/chatbot-eval-mongodb-public/environments/staging.yml
@@ -25,6 +25,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
   - name: faq-eval-quality
     schedule: "30 4 * * *" # every day at 4am UTC (11PM EST)
     command: ["npm", "run", "eval:faqConversationQualityCheckPipeline"]
@@ -47,6 +48,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
 # Alerts
 defaultAlerts:

--- a/packages/ingest-mongodb-public/environments/production.yml
+++ b/packages/ingest-mongodb-public/environments/production.yml
@@ -30,6 +30,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
 # Alerts
 defaultAlerts:

--- a/packages/ingest-mongodb-public/environments/staging.yml
+++ b/packages/ingest-mongodb-public/environments/staging.yml
@@ -30,6 +30,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
   - name: ingest-content-test
     schedule: "0 8 * * *" # every day at 8am UTC (3AM EST)
     command: ["npm", "run", "ingest:k8s"]
@@ -57,6 +58,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+      backoffLimit: 3
   - name: ingest-content-coach-gtm
     schedule: "0 4 * * *" # every day at 4am UTC (11PM EST)
     command: ["npm", "run", "ingest:k8s:coachGtmPages"]
@@ -87,6 +89,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
 # Alerts
 defaultAlerts:

--- a/packages/scripts/environments/production.yml
+++ b/packages/scripts/environments/production.yml
@@ -19,6 +19,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
   - name: analyze
     schedule: "0 7 * * *" # every day at 7am UTC
@@ -41,6 +42,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
   - name: find-faq
     schedule: "0 8 * * *" # every day at 8am UTC
@@ -61,6 +63,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
 # Alerts
 defaultAlerts:

--- a/packages/scripts/environments/staging.yml
+++ b/packages/scripts/environments/staging.yml
@@ -19,6 +19,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
   - name: analyze
     schedule: "0 7 * * *" # every day at 7am UTC
@@ -41,6 +42,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
   - name: clean-up-test-databases-dev
     schedule: 0 8 * * SUN
@@ -55,6 +57,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
   - name: clean-up-test-databases-test
     schedule: 0 9 * * SUN
@@ -69,6 +72,7 @@ cronJobs:
       limits:
         cpu: 500m
         memory: 5Gi
+    backoffLimit: 3
 
 # Alerts
 defaultAlerts:


### PR DESCRIPTION
Jira: n/a

## Changes

- Stop cronjob backoffs after 3 attempts

## Notes

- should limit the amount of crashloopbackoff emails we get 🎉 
