### PR TITLE
(EAI-348) Summarize Release Artifacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8372,6 +8372,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/@postman/form-data": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.1.tgz",
+      "integrity": "sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@postman/tough-cookie": {
+      "version": "4.1.3-postman.1",
+      "resolved": "https://registry.npmjs.org/@postman/tough-cookie/-/tough-cookie-4.1.3-postman.1.tgz",
+      "integrity": "sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@postman/tough-cookie/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@postman/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@postman/tunnel-agent": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.3.tgz",
+      "integrity": "sha512-k57fzmAZ2PJGxfOA4SGR05ejorHbVAa/84Hxh/2nAztjNXc4ZjOm9NUIk6/Z6LCrBvJZqjRZbN8e/nROVUPVdg==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -16741,6 +16795,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
+    },
     "node_modules/@types/chai": {
       "version": "4.3.11",
       "dev": true,
@@ -16996,6 +17055,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/jira-client": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/jira-client/-/jira-client-7.1.9.tgz",
+      "integrity": "sha512-THFFlN8cwCotwHhRJGvjXKdv2AR7WFVsBOkr4tVB+PAY5T4kpAsj1dkwdOEAyyVrRKPM5x+Q4TuO/Xl6e57VQw==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/request": "*"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.6",
       "dev": true,
@@ -17176,6 +17244,30 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/request": {
+      "version": "2.48.12",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.6",
       "dev": true,
@@ -17255,7 +17347,6 @@
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -17965,7 +18056,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18251,6 +18341,14 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "dev": true,
@@ -18288,6 +18386,14 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/assertion-error": {
@@ -18380,6 +18486,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
       "version": "1.6.7",
@@ -18605,6 +18724,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/before-after-hook": {
@@ -18854,6 +18981,14 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
     },
     "node_modules/browser-assert": {
       "version": "1.2.1",
@@ -19361,6 +19496,11 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -20647,6 +20787,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -21674,6 +21825,20 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "license": "MIT"
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecc-jsbn/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -22767,6 +22932,14 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/facepaint": {
       "version": "1.2.1",
       "license": "MIT"
@@ -23233,6 +23406,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "license": "MIT",
@@ -23654,6 +23835,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/giget": {
       "version": "1.2.1",
       "dev": true,
@@ -24071,6 +24260,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "dev": true,
@@ -24374,6 +24584,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/http2-wrapper": {
@@ -25430,6 +25653,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
     "node_modules/issue-parser": {
       "version": "6.0.0",
       "license": "MIT",
@@ -26485,6 +26713,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jira-client": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/jira-client/-/jira-client-8.2.2.tgz",
+      "integrity": "sha512-zs4BKJQYcdCoXi3G0JI9NFqkt7olUNQZ6bzZwUmZ+at3rjjmiBPVNYQHBgkBEOpX8iN5dppU0oYRVtCYRjSwXQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.0",
+        "postman-request": "^2.88.1-postman.30"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "dev": true,
@@ -26659,11 +26896,15 @@
       "version": "2.3.1",
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -26680,7 +26921,6 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -26742,6 +26982,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
       }
     },
     "node_modules/jszip": {
@@ -30643,6 +30897,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -31618,6 +31880,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "node_modules/performance-tests": {
       "resolved": "packages/performance-tests",
       "link": true
@@ -32111,6 +32378,54 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="
+    },
+    "node_modules/postman-request": {
+      "version": "2.88.1-postman.33",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.33.tgz",
+      "integrity": "sha512-uL9sCML4gPH6Z4hreDWbeinKU0p0Ke261nU7OvII95NU22HN6Dk7T/SaVPaj6T4TsQqGKIFw6/woLZnH7ugFNA==",
+      "dependencies": {
+        "@postman/form-data": "~3.1.1",
+        "@postman/tough-cookie": "~4.1.3-postman.1",
+        "@postman/tunnel-agent": "^0.6.3",
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.12.0",
+        "brotli": "^1.3.3",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.3.1",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "^2.1.35",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.3",
+        "safe-buffer": "^5.1.2",
+        "stream-length": "^1.0.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postman-request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/postman-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/power-assert": {
       "version": "1.6.1",
@@ -35771,6 +36086,35 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "dev": true,
@@ -35965,6 +36309,19 @@
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
+    },
+    "node_modules/stream-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+      "integrity": "sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==",
+      "dependencies": {
+        "bluebird": "^2.6.2"
+      }
+    },
+    "node_modules/stream-length/node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
@@ -37146,6 +37503,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/twostep": {
       "version": "0.4.2",
       "license": "MIT"
@@ -38017,6 +38379,24 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/vfile": {
       "version": "5.3.7",
@@ -39601,10 +39981,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.6",
+        "@octokit/rest": "^20.1.0",
+        "@types/jira-client": "^7.1.9",
         "common-tags": "^1.8.2",
         "dotenv": "^16",
         "front-matter": "^4.0.2",
-        "mongodb": "^5.9.2",
+        "jira-client": "^8.2.2",
         "mongodb-rag-core": "^0.1.0",
         "papaparse": "^5.4.1",
         "yaml": "^2.3.1",
@@ -39639,6 +40021,175 @@
       "engines": {
         "node": ">=18",
         "npm": ">=8"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/endpoint": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/graphql": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "dependencies": {
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/request-error": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/rest": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.0.tgz",
+      "integrity": "sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "^9.1.5",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/mongodb-artifact-generator/node_modules/@octokit/types": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "packages/mongodb-artifact-generator/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16670,6 +16670,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/@supercharge/promise-pool": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-3.2.0.tgz",
+      "integrity": "sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "license": "MIT",
@@ -39982,6 +39990,7 @@
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.6",
         "@octokit/rest": "^20.1.0",
+        "@supercharge/promise-pool": "^3.2.0",
         "@types/jira-client": "^7.1.9",
         "common-tags": "^1.8.2",
         "dotenv": "^16",

--- a/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-description.md
+++ b/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-description.md
@@ -1,0 +1,26 @@
+The MongoDB Atlas CLI (Command Line Interface) is a powerful tool designed to
+manage MongoDB Atlas resources directly from the command line. MongoDB Atlas is
+a fully-managed cloud database service that offers MongoDB databases in the
+cloud, ensuring scalable and flexible management of databases without the need
+for manual intervention in terms of hardware and infrastructure management.
+
+The Atlas CLI is particularly useful for developers and system administrators
+who prefer working within a terminal environment or require automation
+capabilities. It allows users to perform a variety of tasks that would typically
+be managed through the Atlas UI, such as creating and managing database
+clusters, configuring network access, managing backups, and scaling resources
+according to demand.
+
+With the Atlas CLI, users can also automate repetitive tasks through scripting.
+This is especially beneficial in a DevOps context, where operations like
+provisioning new databases or updating existing configurations can be integrated
+into continuous deployment pipelines. The CLI supports multiple commands that
+mirror the functionality available in the Atlas GUI, ensuring that any task that
+can be performed in the interface can also be executed from the command line.
+
+Moreover, the Atlas CLI is part of MongoDB's suite of integration tools, which
+also includes APIs and other utility tools. It is designed to be intuitive for
+those familiar with command line operations, providing a seamless experience for
+managing MongoDB deployments. This tool is essential for those looking to
+leverage MongoDB Atlas's powerful features in a programmatic way that integrates
+with existing workflows and systems.

--- a/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-description.md
+++ b/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-description.md
@@ -1,8 +1,8 @@
-The MongoDB Atlas CLI (Command Line Interface) is a powerful tool designed to
-manage MongoDB Atlas resources directly from the command line. MongoDB Atlas is
-a fully-managed cloud database service that offers MongoDB databases in the
-cloud, ensuring scalable and flexible management of databases without the need
-for manual intervention in terms of hardware and infrastructure management.
+The MongoDB Atlas CLI (Command Line Interface) allows you to manage MongoDB
+Atlas resources directly from the command line. MongoDB Atlas is a fully-managed
+cloud database service that offers MongoDB databases in the cloud, ensuring
+scalable and flexible management of databases without the need for manual
+intervention in terms of hardware and infrastructure management.
 
 The Atlas CLI is particularly useful for developers and system administrators
 who prefer working within a terminal environment or require automation

--- a/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-releaseInfo.yaml
+++ b/packages/mongodb-artifact-generator/context/release-notes/atlas-cli-releaseInfo.yaml
@@ -1,0 +1,35 @@
+github:
+  owner: "mongodb"
+  repo: "mongodb-atlas-cli"
+  version: "atlascli/v1.22.0"
+  previousVersion: "atlascli/v1.21.0"
+jira:
+  project: "CLOUDP"
+  version: "atlascli-1.22.0"
+projectDescription: >-
+  The MongoDB Atlas CLI (Command Line Interface) allows you to manage MongoDB
+  Atlas resources directly from the command line. MongoDB Atlas is a fully-managed
+  cloud database service that offers MongoDB databases in the cloud, ensuring
+  scalable and flexible management of databases without the need for manual
+  intervention in terms of hardware and infrastructure management.
+
+  The Atlas CLI is particularly useful for developers and system administrators
+  who prefer working within a terminal environment or require automation
+  capabilities. It allows users to perform a variety of tasks that would typically
+  be managed through the Atlas UI, such as creating and managing database
+  clusters, configuring network access, managing backups, and scaling resources
+  according to demand.
+
+  With the Atlas CLI, users can also automate repetitive tasks through scripting.
+  This is especially beneficial in a DevOps context, where operations like
+  provisioning new databases or updating existing configurations can be integrated
+  into continuous deployment pipelines. The CLI supports multiple commands that
+  mirror the functionality available in the Atlas GUI, ensuring that any task that
+  can be performed in the interface can also be executed from the command line.
+
+  Moreover, the Atlas CLI is part of MongoDB's suite of integration tools, which
+  also includes APIs and other utility tools. It is designed to be intuitive for
+  those familiar with command line operations, providing a seamless experience for
+  managing MongoDB deployments. This tool is essential for those looking to
+  leverage MongoDB Atlas's powerful features in a programmatic way that integrates
+  with existing workflows and systems.

--- a/packages/mongodb-artifact-generator/package.json
+++ b/packages/mongodb-artifact-generator/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.6",
     "@octokit/rest": "^20.1.0",
+    "@supercharge/promise-pool": "^3.2.0",
     "@types/jira-client": "^7.1.9",
     "common-tags": "^1.8.2",
     "dotenv": "^16",

--- a/packages/mongodb-artifact-generator/package.json
+++ b/packages/mongodb-artifact-generator/package.json
@@ -50,10 +50,12 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.6",
+    "@octokit/rest": "^20.1.0",
+    "@types/jira-client": "^7.1.9",
     "common-tags": "^1.8.2",
     "dotenv": "^16",
     "front-matter": "^4.0.2",
-    "mongodb": "^5.9.2",
+    "jira-client": "^8.2.2",
     "mongodb-rag-core": "^0.1.0",
     "papaparse": "^5.4.1",
     "yaml": "^2.3.1",

--- a/packages/mongodb-artifact-generator/src/ArtifactGeneratorEnvVars.ts
+++ b/packages/mongodb-artifact-generator/src/ArtifactGeneratorEnvVars.ts
@@ -2,4 +2,7 @@ import { CORE_ENV_VARS } from "mongodb-rag-core";
 
 export const ArtifactGeneratorEnvVars = {
   ...CORE_ENV_VARS,
+  GITHUB_ACCESS_TOKEN: "",
+  JIRA_USERNAME: "",
+  JIRA_PASSWORD: "",
 };

--- a/packages/mongodb-artifact-generator/src/Config.ts
+++ b/packages/mongodb-artifact-generator/src/Config.ts
@@ -1,3 +1,5 @@
+import { Octokit } from "@octokit/rest";
+import JiraApi from "jira-client";
 import { Embedder, PageStore, EmbeddedContentStore } from "mongodb-rag-core";
 
 /**
@@ -25,6 +27,16 @@ export type Config = {
     The store that holds the embedded content and vector embeddings for later vector search.
    */
   embeddedContentStore: Constructor<EmbeddedContentStore>;
+
+  /**
+    The Jira API client.
+   */
+  jiraApi?: Constructor<JiraApi>;
+
+  /**
+    The GitHub API client.
+   */
+  githubApi?: Constructor<Octokit>;
 };
 
 export type Constructor<T> = (() => T) | (() => Promise<T>);

--- a/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
+++ b/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
@@ -61,14 +61,19 @@ export default createCommand<GenerateReleaseNotesCommandArgs>({
 export const action = createConfiguredAction<GenerateReleaseNotesCommandArgs>(
   async (
     //
-    { githubApi },
+    { githubApi, jiraApi },
     { projectDescription }
   ) => {
     logger.logInfo(`Setting up...`);
 
     if (!githubApi) {
       throw new Error(
-        "GitHub API is required. Make sure to define it in the config."
+        "githubApi is required. Make sure to define it in the config."
+      );
+    }
+    if (!jiraApi) {
+      throw new Error(
+        "jiraApi is required. Make sure to define it in the config."
       );
     }
 
@@ -83,6 +88,11 @@ export const action = createConfiguredAction<GenerateReleaseNotesCommandArgs>(
         // repo: "chatbot",
         // version: "mongodb-chatbot-ui-v0.7.2",
         // previousVersion: "mongodb-chatbot-ui-v0.7.1",
+      },
+      jira: {
+        jiraApi,
+        // project: "CLOUDP",
+        version: "atlascli-1.22.0",
       },
     });
 

--- a/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
+++ b/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
@@ -1,0 +1,88 @@
+import {
+  createConfiguredAction,
+  withConfig,
+  withConfigOptions,
+} from "../withConfig";
+import { createCommand } from "../createCommand";
+import { makeGenerateChatCompletion } from "../chat";
+import { makeRunLogger, type RunLogger } from "../runlogger";
+
+let logger: RunLogger;
+
+type GenerateReleaseNotesCommandArgs = {
+  runId?: string;
+  projectDescription: string;
+};
+
+export default createCommand<GenerateReleaseNotesCommandArgs>({
+  command: "generateReleaseNotes",
+  builder(args) {
+    return withConfigOptions(args)
+      .option("runId", {
+        type: "string",
+        demandOption: false,
+        description: "A (hopefully unique) name for the run.",
+      })
+      .option("projectDescription", {
+        type: "string",
+        demandOption: true,
+        description:
+          "A text description of the project. This helps contextualize the release notes.",
+      });
+    // .option("releaseVersion", {
+    //   type: "string",
+    //   demandOption: true,
+    //   description: "The release to generate release notes for.",
+    // })
+    // .option("previousReleaseVersion", {
+    //   type: "string",
+    //   demandOption: true,
+    //   description:
+    //     "The last release before this release. Sets a lower bound on context for the release notes.",
+    // });
+  },
+  async handler(args) {
+    logger = makeRunLogger({
+      topic: "GenerateReleaseNotes",
+      runId: args.runId,
+    });
+    logger.logInfo(`Running command with args: ${JSON.stringify(args)}`);
+    const result = await withConfig(action, args);
+    logger.logInfo(`Success`);
+    await logger.flushArtifacts();
+    await logger.flushLogs();
+    return result;
+  },
+  describe: "TODO",
+});
+
+export const action = createConfiguredAction<GenerateReleaseNotesCommandArgs>(
+  async (
+    //
+    { jiraApi, githubApi },
+    { projectDescription }
+  ) => {
+    logger.logInfo(`Setting up...`);
+    // const generate = makeGenerateChatCompletion();
+
+    const data = await jiraApi?.getIssue("EAI-123");
+    console.log("data", data);
+
+    const gh = await githubApi?.pulls.get({
+      owner: "mongodb",
+      repo: "chatbot",
+      pull_number: 405,
+    });
+    console.log("gh", Object.keys(gh as any));
+
+    const gh_diff = await githubApi?.pulls.get({
+      owner: "mongodb",
+      repo: "chatbot",
+      pull_number: 405,
+      mediaType: {
+        format: "diff",
+      },
+    });
+    console.log("gh_diff", Object.keys(gh_diff as any));
+  }
+);

--- a/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
+++ b/packages/mongodb-artifact-generator/src/commands/generateReleaseNotes.ts
@@ -6,6 +6,8 @@ import {
 import { createCommand } from "../createCommand";
 import { makeGenerateChatCompletion } from "../chat";
 import { makeRunLogger, type RunLogger } from "../runlogger";
+import { getReleaseArtifacts } from "../release-notes/getReleaseArtifacts";
+import { promises as fs } from "fs";
 
 let logger: RunLogger;
 
@@ -59,30 +61,47 @@ export default createCommand<GenerateReleaseNotesCommandArgs>({
 export const action = createConfiguredAction<GenerateReleaseNotesCommandArgs>(
   async (
     //
-    { jiraApi, githubApi },
+    { githubApi },
     { projectDescription }
   ) => {
     logger.logInfo(`Setting up...`);
-    // const generate = makeGenerateChatCompletion();
 
-    const data = await jiraApi?.getIssue("EAI-123");
-    console.log("data", data);
+    if (!githubApi) {
+      throw new Error(
+        "GitHub API is required. Make sure to define it in the config."
+      );
+    }
 
-    const gh = await githubApi?.pulls.get({
-      owner: "mongodb",
-      repo: "chatbot",
-      pull_number: 405,
-    });
-    console.log("gh", Object.keys(gh as any));
-
-    const gh_diff = await githubApi?.pulls.get({
-      owner: "mongodb",
-      repo: "chatbot",
-      pull_number: 405,
-      mediaType: {
-        format: "diff",
+    const releaseArtifacts = await getReleaseArtifacts({
+      github: {
+        githubApi,
+        owner: "mongodb",
+        repo: "mongodb-atlas-cli",
+        version: "atlascli/v1.22.0",
+        previousVersion: "atlascli/v1.21.0",
+        // owner: "mongodb",
+        // repo: "chatbot",
+        // version: "mongodb-chatbot-ui-v0.7.2",
+        // previousVersion: "mongodb-chatbot-ui-v0.7.1",
       },
     });
-    console.log("gh_diff", Object.keys(gh_diff as any));
+
+    logger.appendArtifact(
+      "releaseArtifacts.json",
+      JSON.stringify(releaseArtifacts)
+    );
+
+    // const data = await jiraApi?.getIssue("EAI-123");
+    // console.log("data", data);
+
+    // const gh_diff = await githubApi?.pulls.get({
+    //   owner: "mongodb",
+    //   repo: "chatbot",
+    //   pull_number: 405,
+    //   mediaType: {
+    //     format: "diff",
+    //   },
+    // });
+    // console.log("gh_diff", Object.keys(gh_diff as any));
   }
 );

--- a/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
+++ b/packages/mongodb-artifact-generator/src/commands/parseDriversCsv.ts
@@ -10,7 +10,7 @@ import { promises as fs } from "fs";
 import path from "path";
 
 import { action as translateCodeAction } from "./translateCode";
-import { ObjectId } from "mongodb";
+import { ObjectId } from "mongodb-rag-core";
 
 let logger: RunLogger;
 

--- a/packages/mongodb-artifact-generator/src/commands/translateCode.ts
+++ b/packages/mongodb-artifact-generator/src/commands/translateCode.ts
@@ -12,7 +12,7 @@ import { summarize, translate } from "../operations";
 import { makeRunLogger, type RunLogger } from "../runlogger";
 import { stringifyVectorSearchChunks } from "../prompt";
 import path from "path";
-import { ObjectId } from "mongodb";
+import { ObjectId } from "mongodb-rag-core";
 
 let logger: RunLogger;
 

--- a/packages/mongodb-artifact-generator/src/core.ts
+++ b/packages/mongodb-artifact-generator/src/core.ts
@@ -1,7 +1,0 @@
-/**
-  @fileoverview Re-export mongodb-rag-core library.
-  This is done to guarantee that all consumers of the ingest package
-  use the expected version of core. Plus, this serves as a convenience for
-  consumers of this package as all consumers also need to access the modules in core.
- */
-export * from "mongodb-rag-core";

--- a/packages/mongodb-artifact-generator/src/release-notes/ReleaseInfo.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/ReleaseInfo.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { GitHubReleaseInfo } from "./github";
+import { JiraReleaseInfo } from "./jira";
+import { stripIndents } from "common-tags";
+
+export const ReleaseInfo = z.object({
+  github: GitHubReleaseInfo,
+  jira: JiraReleaseInfo,
+  projectDescription: z.string().describe(stripIndents`
+    A contextual description of the software project. This should
+    describe the purpose, use cases, and goals of the project. In
+    particular, it should describe the project's users and the
+    way they interact with the project.
+  `),
+});
+
+export type ReleaseInfo = z.infer<typeof ReleaseInfo>;

--- a/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
@@ -19,25 +19,25 @@ export async function getReleaseArtifacts({
 }: GetReleaseArtifactsArgs): Promise<ReleaseArtifact[]> {
   const artifacts: ReleaseArtifact[] = [];
 
-  // if (github) {
-  //   const { version, previousVersion, githubApi, owner, repo } = github;
+  if (github) {
+    const { version, previousVersion, githubApi, owner, repo } = github;
 
-  //   const githubReleaseArtifacts = makeGitHubReleaseArtifacts({
-  //     githubApi,
-  //     owner,
-  //     repo,
-  //     version,
-  //     previousVersion,
-  //   });
+    const githubReleaseArtifacts = makeGitHubReleaseArtifacts({
+      githubApi,
+      owner,
+      repo,
+      version,
+      previousVersion,
+    });
 
-  //   const [releaseCommits] = await Promise.all([
-  //     githubReleaseArtifacts.getCommits(),
-  //   ]);
+    const [releaseCommits] = await Promise.all([
+      githubReleaseArtifacts.getCommits(),
+    ]);
 
-  //   console.log(`Found ${releaseCommits.length} commits`);
+    console.log(`Found ${releaseCommits.length} GitHub commits`);
 
-  //   artifacts.push(...releaseCommits);
-  // }
+    artifacts.push(...releaseCommits);
+  }
 
   if (jira) {
     const { version, jiraApi, project } = jira;
@@ -52,7 +52,7 @@ export async function getReleaseArtifacts({
       jiraReleaseArtifacts.getIssues(),
     ]);
 
-    console.log(`Found ${releaseIssues.length} issues`);
+    console.log(`Found ${releaseIssues.length} Jira issues`);
 
     artifacts.push(...releaseIssues);
   }

--- a/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
@@ -1,36 +1,60 @@
 import { ReleaseArtifact } from "./projects";
 import {
-  MakeGitHubReleaseArtifactsArgs,
+  type MakeGitHubReleaseArtifactsArgs,
   makeGitHubReleaseArtifacts,
 } from "./github";
+import {
+  type MakeJiraReleaseArtifactsArgs,
+  makeJiraReleaseArtifacts,
+} from "./jira";
 
 export type GetReleaseArtifactsArgs = {
   github?: MakeGitHubReleaseArtifactsArgs;
+  jira?: MakeJiraReleaseArtifactsArgs;
 };
 
 export async function getReleaseArtifacts({
   github,
+  jira,
 }: GetReleaseArtifactsArgs): Promise<ReleaseArtifact[]> {
   const artifacts: ReleaseArtifact[] = [];
 
-  if (github) {
-    const { version, previousVersion, githubApi, owner, repo } = github;
+  // if (github) {
+  //   const { version, previousVersion, githubApi, owner, repo } = github;
 
-    const githubReleaseArtifacts = makeGitHubReleaseArtifacts({
-      githubApi,
-      owner,
-      repo,
+  //   const githubReleaseArtifacts = makeGitHubReleaseArtifacts({
+  //     githubApi,
+  //     owner,
+  //     repo,
+  //     version,
+  //     previousVersion,
+  //   });
+
+  //   const [releaseCommits] = await Promise.all([
+  //     githubReleaseArtifacts.getCommits(),
+  //   ]);
+
+  //   console.log(`Found ${releaseCommits.length} commits`);
+
+  //   artifacts.push(...releaseCommits);
+  // }
+
+  if (jira) {
+    const { version, jiraApi, project } = jira;
+
+    const jiraReleaseArtifacts = makeJiraReleaseArtifacts({
+      jiraApi,
+      project,
       version,
-      previousVersion,
     });
 
-    const [releaseCommits] = await Promise.all([
-      githubReleaseArtifacts.getCommits(),
+    const [releaseIssues] = await Promise.all([
+      jiraReleaseArtifacts.getIssues(),
     ]);
 
-    console.log(`Found ${releaseCommits.length} commits`);
+    console.log(`Found ${releaseIssues.length} issues`);
 
-    artifacts.push(...releaseCommits);
+    artifacts.push(...releaseIssues);
   }
 
   return artifacts;

--- a/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/getReleaseArtifacts.ts
@@ -1,0 +1,37 @@
+import { ReleaseArtifact } from "./projects";
+import {
+  MakeGitHubReleaseArtifactsArgs,
+  makeGitHubReleaseArtifacts,
+} from "./github";
+
+export type GetReleaseArtifactsArgs = {
+  github?: MakeGitHubReleaseArtifactsArgs;
+};
+
+export async function getReleaseArtifacts({
+  github,
+}: GetReleaseArtifactsArgs): Promise<ReleaseArtifact[]> {
+  const artifacts: ReleaseArtifact[] = [];
+
+  if (github) {
+    const { version, previousVersion, githubApi, owner, repo } = github;
+
+    const githubReleaseArtifacts = makeGitHubReleaseArtifacts({
+      githubApi,
+      owner,
+      repo,
+      version,
+      previousVersion,
+    });
+
+    const [releaseCommits] = await Promise.all([
+      githubReleaseArtifacts.getCommits(),
+    ]);
+
+    console.log(`Found ${releaseCommits.length} commits`);
+
+    artifacts.push(...releaseCommits);
+  }
+
+  return artifacts;
+}

--- a/packages/mongodb-artifact-generator/src/release-notes/github.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/github.ts
@@ -1,0 +1,128 @@
+// An interface that lets you connect to GitHub and fetch artifacts
+
+import { Octokit } from "@octokit/rest";
+import { GitCommitArtifact, GitDiffArtifact } from "./projects";
+import { splitDiff } from "./splitDiff";
+
+// relevant to a given release.
+export type GitHubReleaseArtifacts = {
+  /**
+   Fetches the commits between the previous version and the current version.
+   */
+  getCommits(): Promise<GitCommitArtifact[]>;
+
+  /**
+   Fetches the diffs between the previous version and the current version.
+   */
+  getDiffs(): Promise<GitDiffArtifact[]>;
+};
+
+export type MakeGitHubReleaseArtifactsArgs = {
+  /**
+   A GitHub API client from Octokit
+   */
+  githubApi: Octokit;
+
+  /**
+   The owner of the repository
+   */
+  owner: string;
+
+  /**
+   The repository name
+   */
+  repo: string;
+
+  /**
+   The version of the release. This (naïvely) corresponds to a git tag.
+   */
+  version: string;
+
+  /**
+   The previous version of the release. This (naïvely) corresponds to a git tag.
+   */
+  previousVersion: string;
+};
+
+export function makeGitHubReleaseArtifacts(
+  args: MakeGitHubReleaseArtifactsArgs
+): GitHubReleaseArtifacts {
+  return {
+    getCommits: async () => {
+      // Fetch the commits between the previous version and the current version
+      const { data } = await args.githubApi.repos.compareCommitsWithBasehead({
+        owner: args.owner,
+        repo: args.repo,
+        basehead: `${args.previousVersion}...${args.version}`,
+      });
+
+      // Get details for each commit
+      const commits = await Promise.all(
+        data.commits.map(async (commit) => {
+          const { data } = await args.githubApi.repos.getCommit({
+            owner: args.owner,
+            repo: args.repo,
+            ref: commit.sha,
+          });
+
+          return data;
+        })
+      );
+
+      console.log("commits[0]", commits[0]);
+      console.log("commits.length", commits.length);
+
+      // Convert the commits into artifacts
+      return commits.map((commit) => ({
+        type: "git-commit",
+        data: {
+          hash: commit.sha,
+          message: commit.commit.message,
+          files:
+            commit.files?.map((file) => {
+              return {
+                fileName: file.filename,
+                additions: file.additions,
+                deletions: file.deletions,
+                changes: file.changes,
+                hash: file.sha,
+                status: file.status,
+                patch: file.patch,
+              };
+            }) ?? [],
+        },
+      }));
+    },
+    getDiffs: async () => {
+      // Fetch the diffs between the previous version and the current version
+      const { data } = await args.githubApi.repos.compareCommitsWithBasehead({
+        owner: args.owner,
+        repo: args.repo,
+        basehead: `${args.previousVersion}...${args.version}`,
+        headers: {
+          accept: "application/vnd.github.v3.diff",
+        },
+      });
+
+      // Octokit doesn't have typings for the diff response. When you
+      // pass the diff header, the response body is a string (i.e. the
+      // diff) not a structured object.
+      const fullDiff = data as unknown as string;
+
+      const artifacts = splitDiff(fullDiff).map(
+        ({ fileName, diff }) =>
+          ({
+            type: "git-diff",
+            data: {
+              oldHash: args.previousVersion,
+              newHash: args.version,
+              fileName,
+              diff,
+            },
+          } satisfies GitDiffArtifact)
+      );
+
+      return artifacts;
+    },
+  };
+}

--- a/packages/mongodb-artifact-generator/src/release-notes/github.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/github.ts
@@ -3,6 +3,7 @@
 import { Octokit } from "@octokit/rest";
 import { GitCommitArtifact, GitDiffArtifact } from "./projects";
 import { splitDiff } from "./splitDiff";
+import { z } from "zod";
 
 // relevant to a given release.
 export type GitHubReleaseArtifacts = {
@@ -17,31 +18,28 @@ export type GitHubReleaseArtifacts = {
   getDiffs(): Promise<GitDiffArtifact[]>;
 };
 
-export type MakeGitHubReleaseArtifactsArgs = {
+export const GitHubReleaseInfo = z.object({
+  owner: z.string().describe("The owner of the repository."),
+  repo: z.string().describe("The repository name."),
+  version: z
+    .string()
+    .describe(
+      "The version of the release. This (naïvely) corresponds to a git tag."
+    ),
+  previousVersion: z
+    .string()
+    .describe(
+      "The previous version of the release. This (naïvely) corresponds to a git tag."
+    ),
+});
+
+export type GitHubReleaseInfo = z.infer<typeof GitHubReleaseInfo>;
+
+export type MakeGitHubReleaseArtifactsArgs = GitHubReleaseInfo & {
   /**
    A GitHub API client from Octokit
    */
   githubApi: Octokit;
-
-  /**
-   The owner of the repository
-   */
-  owner: string;
-
-  /**
-   The repository name
-   */
-  repo: string;
-
-  /**
-   The version of the release. This (naïvely) corresponds to a git tag.
-   */
-  version: string;
-
-  /**
-   The previous version of the release. This (naïvely) corresponds to a git tag.
-   */
-  previousVersion: string;
 };
 
 export function makeGitHubReleaseArtifacts(
@@ -68,9 +66,6 @@ export function makeGitHubReleaseArtifacts(
           return data;
         })
       );
-
-      console.log("commits[0]", commits[0]);
-      console.log("commits.length", commits.length);
 
       // Convert the commits into artifacts
       return commits.map((commit) => ({

--- a/packages/mongodb-artifact-generator/src/release-notes/jira.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/jira.ts
@@ -1,0 +1,160 @@
+import JiraApi from "jira-client";
+import { JiraIssueArtifact } from "./projects";
+import { splitDiff } from "./splitDiff";
+
+export type JiraReleaseArtifacts = {
+  /**
+   Fetches the issues relevant to a given release.
+   */
+  getIssues(): Promise<JiraIssueArtifact[]>;
+};
+
+export type MakeJiraReleaseArtifactsArgs = {
+  /**
+   A Jira API client
+   */
+  jiraApi: JiraApi;
+
+  /**
+   The Jira project key
+   */
+  project?: string;
+
+  /**
+   The version of the release. This (naïvely) corresponds to a Jira fixVersion.
+   */
+  version: string;
+};
+
+export function makeJiraReleaseArtifacts({
+  jiraApi,
+  project,
+  version,
+}: MakeJiraReleaseArtifactsArgs): JiraReleaseArtifacts {
+  return {
+    getIssues: async () => {
+      // Fetch the issues relevant to the given version
+      const queryParts = [`fixVersion = ${version}`];
+      if (project) {
+        queryParts.push(`project = ${project}`);
+      }
+      const jqlQuery = queryParts.join(" AND ");
+      const response = (await jiraApi.searchJira(jqlQuery, {
+        expand: ["customfield_15650"],
+        fields: [
+          "fixVersions",
+          "components",
+          "resolution",
+          "priority",
+          "summary",
+          "description",
+          "status",
+          "issuetype",
+          "project",
+        ],
+      })) as JiraSearchResponse;
+
+      console.log(`Found ${response.total} issues`);
+
+      return response.issues.map((issue) => ({
+        type: "jira-issue",
+        data: {
+          key: issue.key,
+          summary: issue.fields.summary,
+          description: issue.fields.description,
+          components: issue.fields.components.map(
+            (component) => component.name
+          ),
+          fixVersions: issue.fields.fixVersions.map(
+            (fixVersion) => fixVersion.name
+          ),
+          resolution: issue.fields.resolution.name,
+          priority: issue.fields.priority.name,
+          status: issue.fields.status.name,
+          issuetype: issue.fields.issuetype.name,
+        },
+      }));
+    },
+  };
+}
+
+type JiraSearchResponse = {
+  expand: string;
+  startAt: number;
+  maxResults: number;
+  total: number;
+  issues: JiraIssue[];
+};
+
+type JiraIssue = {
+  expand: string;
+  id: string;
+  self: string;
+  key: string;
+  fields: {
+    fixVersions: {
+      self: string;
+      id: string;
+      name: string;
+      archived: boolean;
+      released: boolean;
+      releaseDate?: string;
+    }[];
+    components: {
+      self: string;
+      id: string;
+      name: string;
+    }[];
+    resolution: {
+      self: string;
+      id: string;
+      description: string;
+      name: string;
+    };
+    priority: {
+      self: string;
+      iconUrl: string;
+      name: string;
+      id: string;
+    };
+    summary: string;
+    description: string;
+    // assignee: {
+    //   name: string;
+    // };
+    status: {
+      self: string;
+      description: string;
+      name: string;
+      id: string;
+      iconUrl: string;
+    };
+    issuetype: {
+      self: string;
+      id: string;
+      description: string;
+      iconUrl: string;
+      name: string;
+      subtask: boolean;
+      avatarId: number;
+    };
+    project: {
+      self: string;
+      id: string;
+      key: string;
+      name: string;
+      projectTypeKey: string;
+    };
+  };
+};
+
+function convertJiraIssueToArtifact(issue: JiraIssue) {
+  return {
+    type: "jira-issue",
+    data: {
+      key: issue.key,
+      summary: issue.fields.summary,
+      description: issue.fields.description,
+    },
+  };
+}

--- a/packages/mongodb-artifact-generator/src/release-notes/jira.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/jira.ts
@@ -1,6 +1,7 @@
 import JiraApi from "jira-client";
 import { JiraIssueArtifact } from "./projects";
 import { splitDiff } from "./splitDiff";
+import { z } from "zod";
 
 export type JiraReleaseArtifacts = {
   /**
@@ -9,21 +10,22 @@ export type JiraReleaseArtifacts = {
   getIssues(): Promise<JiraIssueArtifact[]>;
 };
 
-export type MakeJiraReleaseArtifactsArgs = {
+export const JiraReleaseInfo = z.object({
+  version: z
+    .string()
+    .describe(
+      "The version of the release. This (naïvely) corresponds to a Jira fixVersion."
+    ),
+  project: z.string().optional().describe("The Jira project key."),
+});
+
+export type JiraReleaseInfo = z.infer<typeof JiraReleaseInfo>;
+
+export type MakeJiraReleaseArtifactsArgs = JiraReleaseInfo & {
   /**
    A Jira API client
    */
   jiraApi: JiraApi;
-
-  /**
-   The Jira project key
-   */
-  project?: string;
-
-  /**
-   The version of the release. This (naïvely) corresponds to a Jira fixVersion.
-   */
-  version: string;
 };
 
 export function makeJiraReleaseArtifacts({
@@ -53,8 +55,6 @@ export function makeJiraReleaseArtifacts({
           "project",
         ],
       })) as JiraSearchResponse;
-
-      console.log(`Found ${response.total} issues`);
 
       return response.issues.map((issue) => ({
         type: "jira-issue",

--- a/packages/mongodb-artifact-generator/src/release-notes/jira.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/jira.ts
@@ -1,6 +1,5 @@
 import JiraApi from "jira-client";
 import { JiraIssueArtifact } from "./projects";
-import { splitDiff } from "./splitDiff";
 import { z } from "zod";
 
 export type JiraReleaseArtifacts = {

--- a/packages/mongodb-artifact-generator/src/release-notes/projects.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/projects.ts
@@ -40,7 +40,45 @@ export type JiraIssueArtifact = {
   };
 };
 
-export type ReleaseArtifact = GitCommitArtifact | JiraIssueArtifact;
+export type ReleaseArtifact =
+  | GitCommitArtifact
+  | GitDiffArtifact
+  | JiraIssueArtifact;
+
+export function releaseArtifactIdentifier({ type, data }: ReleaseArtifact) {
+  switch (type) {
+    case "git-commit":
+      return `${type}::${data.hash}`;
+    case "git-diff":
+      return `${type}::${data.fileName}:${data.oldHash}...${data.newHash}`;
+    case "jira-issue":
+      return `${type}::${data.key}`;
+  }
+}
+
+export function releaseArtifactShortMetadata({ type, data }: ReleaseArtifact) {
+  switch (type) {
+    case "git-commit":
+      return {
+        type: type,
+        hash: data.hash,
+        message: data.message,
+      };
+    case "git-diff":
+      return {
+        type: type,
+        oldHash: data.oldHash,
+        newHash: data.newHash,
+        fileName: data.fileName,
+      };
+    case "jira-issue":
+      return {
+        type: type,
+        key: data.key,
+        summary: data.summary,
+      };
+  }
+}
 
 // | {
 //     type: "jira-release";

--- a/packages/mongodb-artifact-generator/src/release-notes/projects.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/projects.ts
@@ -5,22 +5,34 @@ export type Project = {
   getReleaseArtifacts(version: string): Promise<ReleaseArtifact[]>;
 };
 
-export type ReleaseArtifact =
-  | {
-      type: "git-commit";
-      data: {
-        hash: string;
-        message: string;
-      };
-    }
-  | {
-      type: "git-diff";
-      data: {
-        oldCommit: string;
-        newCommit: string;
-        diff: string;
-      };
-    };
+export type GitCommitArtifact = {
+  type: "git-commit";
+  data: {
+    hash: string;
+    message: string;
+    files: {
+      fileName: string;
+      additions: number;
+      deletions: number;
+      changes: number;
+      hash: string;
+      status: string;
+    }[];
+  };
+};
+
+export type GitDiffArtifact = {
+  type: "git-diff";
+  data: {
+    oldHash: string;
+    newHash: string;
+    fileName: string;
+    diff: string;
+  };
+};
+
+export type ReleaseArtifact = GitCommitArtifact;
+
 // | {
 //     type: "jira-issue";
 //     data: {
@@ -43,10 +55,3 @@ export type ReleaseArtifact =
 //       issues: string[];
 //     };
 //   }
-// | {
-//     type: "confluence-page";
-//     data: {
-//       title: string;
-//       content: string;
-//     };
-//   };

--- a/packages/mongodb-artifact-generator/src/release-notes/projects.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/projects.ts
@@ -31,16 +31,17 @@ export type GitDiffArtifact = {
   };
 };
 
-export type ReleaseArtifact = GitCommitArtifact;
+export type JiraIssueArtifact = {
+  type: "jira-issue";
+  data: {
+    key: string;
+    summary: string;
+    description: string;
+  };
+};
 
-// | {
-//     type: "jira-issue";
-//     data: {
-//       key: string;
-//       summary: string;
-//       description: string;
-//     };
-//   }
+export type ReleaseArtifact = GitCommitArtifact | JiraIssueArtifact;
+
 // | {
 //     type: "jira-release";
 //     data: {

--- a/packages/mongodb-artifact-generator/src/release-notes/projects.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/projects.ts
@@ -1,0 +1,52 @@
+export type Project = {
+  name: string;
+  description: string;
+  validateReleaseVersionFormat(version: string): boolean;
+  getReleaseArtifacts(version: string): Promise<ReleaseArtifact[]>;
+};
+
+export type ReleaseArtifact =
+  | {
+      type: "git-commit";
+      data: {
+        hash: string;
+        message: string;
+      };
+    }
+  | {
+      type: "git-diff";
+      data: {
+        oldCommit: string;
+        newCommit: string;
+        diff: string;
+      };
+    };
+// | {
+//     type: "jira-issue";
+//     data: {
+//       key: string;
+//       summary: string;
+//       description: string;
+//     };
+//   }
+// | {
+//     type: "jira-release";
+//     data: {
+//       version: string;
+//       description: string;
+//     };
+//   }
+// | {
+//     type: "jira-changelog";
+//     data: {
+//       version: string;
+//       issues: string[];
+//     };
+//   }
+// | {
+//     type: "confluence-page";
+//     data: {
+//       title: string;
+//       content: string;
+//     };
+//   };

--- a/packages/mongodb-artifact-generator/src/release-notes/splitDiff.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/splitDiff.ts
@@ -1,0 +1,31 @@
+export type SplitDiffResult = {
+  fileName: string;
+  diff: string;
+};
+
+export function splitDiff(diff: string): SplitDiffResult[] {
+  // Split the diff into parts for each file
+  const parts = diff.split("diff --git");
+
+  // Remove the first item if it's empty (it will be if the file starts with 'diff --git')
+  if (parts[0].trim() === "") {
+    parts.shift();
+  }
+
+  return parts.map((part, index) => {
+    // Extract the filename
+    const lines = part.split("\n");
+    const filenameLine = lines[0]; // This is usually the first line after 'diff --git'
+    const filenames = filenameLine.split(" b/"); // Split on ' b/' to get the new filename
+
+    const fileName =
+      filenames.length > 1
+        ? filenames[1].trim().replace(/\//g, "_")
+        : `file_${index + 1}`;
+
+    return {
+      fileName,
+      diff: `diff --git ${part}`,
+    };
+  });
+}

--- a/packages/mongodb-artifact-generator/src/release-notes/summarizeReleaseArtifact.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/summarizeReleaseArtifact.ts
@@ -1,0 +1,103 @@
+import { stripIndents, html } from "common-tags";
+import {
+  GenerateChatCompletion,
+  makeGenerateChatCompletion,
+  systemMessage,
+  userMessage,
+} from "../chat";
+import { ReleaseArtifact, releaseArtifactIdentifier } from "./projects";
+import { RunLogger } from "../runlogger";
+
+export function safeFileName(fileName: string) {
+  return fileName.replace(/[/\\?%*:|"<>]/g, "-");
+}
+
+export async function summarizeReleaseArtifact({
+  logger,
+  generate,
+  projectDescription,
+  artifact,
+}: {
+  logger?: RunLogger;
+  generate?: GenerateChatCompletion;
+  projectDescription: string;
+  artifact: ReleaseArtifact;
+}) {
+  generate = generate ?? makeGenerateChatCompletion();
+  const chatTemplate = [
+    systemMessage(stripIndents`
+      Your task is to analyze a provided artifact associated with a software release and write a succinct summarized description. Artifacts may include information from task tracking software like Jira, source control information like Git diffs and commit messages, or other sources.
+
+      Your summary should be a brief, high-level description of the artifact's contents and purpose. It should avoid technical details and focus on the artifact's significance and relevance to the project. The goal is to provide a clear, concise overview that can be used to generate a change log entry for the release.
+
+      The user may prepend the artifact with additional style guide information or other metadata. This section is denoted by frontmatter enclosed in triple dashes (---). Do not mention this frontmatter in the summary but do follow its guidance.
+
+      Limit the summary length to a maximum of 200 words.
+
+      <Section description="A description of the software project this release is for">
+        ${projectDescription}
+      </Section>
+    `),
+    userMessage(createUserPromptForReleaseArtifact(artifact)),
+  ];
+  logger?.appendArtifact(
+    `chatTemplates/${safeFileName(releaseArtifactIdentifier(artifact))}`,
+    chatTemplate
+      .map((m) => {
+        switch (m.role) {
+          case "system":
+            return `<SystemMessage>\n${m.content}\n</SystemMessage>`;
+          case "user":
+            return `<UserMessage>\n${m.content}\n</UserMessage>`;
+        }
+      })
+      .join("\n")
+  );
+  logger?.logInfo(`[summarizeReleaseArtifact chatTemplate] ${chatTemplate}`);
+
+  const output = await generate(chatTemplate);
+  if (!output) {
+    throw new Error("Something went wrong while generating the summary ☹️");
+  }
+  return output;
+}
+
+function frontmatter(
+  ...objs: (string | unknown[] | Record<string, unknown>)[]
+) {
+  const tokens = ["---"];
+  for (const [i, obj] of Object.entries(objs)) {
+    if (Number(i) > 0) tokens.push("\n");
+    if (typeof obj === "string") {
+      tokens.push(obj);
+    } else if (Array.isArray(obj)) {
+      obj.forEach((value) => {
+        tokens.push(JSON.stringify(value));
+      });
+    } else {
+      Object.entries(obj).forEach(([key, value]) => {
+        if (typeof value === "object") {
+          value = JSON.stringify(value);
+        }
+        tokens.push(`${key}: ${value}`);
+      });
+    }
+  }
+  tokens.push("---\n");
+  return tokens.join("\n");
+}
+
+function createUserPromptForReleaseArtifact(artifact: ReleaseArtifact) {
+  const artifactString = JSON.stringify(artifact);
+  switch (artifact.type) {
+    case "git-commit": {
+      const fm = frontmatter(
+        "Focus on the changes the commit applies. Do not mention the commit hash or other git-specific information in the summary."
+      );
+      return `${fm}\n${artifactString}`;
+    }
+    case "git-diff":
+    case "jira-issue":
+      return artifactString;
+  }
+}

--- a/packages/mongodb-artifact-generator/src/runlogger.ts
+++ b/packages/mongodb-artifact-generator/src/runlogger.ts
@@ -192,7 +192,6 @@ export const flushArtifactsToFile: ArtifactFlushHandler = async (
 ) => {
   await assertFlushDirectory(options);
   for (const artifact of artifacts) {
-    console.log("Writing artifact to file", artifact);
     const filePath = path.join(getFlushDirectoryPath(options), artifact.name);
     await assertDirectory(path.dirname(filePath));
     await fs.writeFile(filePath, ensureFileEndsWithNewline(artifact.content), {
@@ -209,7 +208,6 @@ export const defaultFlushArtifacts: ArtifactFlushHandler = async (
     ...createDefaultFlushOptions(),
     ...optionOverrides,
   };
-  flushArtifactsToConsole(artifacts, options);
   flushArtifactsToFile(artifacts, options);
 };
 

--- a/packages/mongodb-artifact-generator/src/runlogger.ts
+++ b/packages/mongodb-artifact-generator/src/runlogger.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { z } from "zod";
-import { ObjectId } from "mongodb";
+import { ObjectId } from "mongodb-rag-core";
 
 export type Artifact = z.infer<typeof ArtifactSchema>;
 const ArtifactSchema = z

--- a/packages/mongodb-artifact-generator/src/standardConfig.ts
+++ b/packages/mongodb-artifact-generator/src/standardConfig.ts
@@ -8,6 +8,8 @@ import {
   OpenAIClient,
   AzureKeyCredential,
 } from "mongodb-rag-core";
+import { Octokit } from "@octokit/rest";
+import JiraApi from "jira-client";
 
 const {
   OPENAI_ENDPOINT,
@@ -15,6 +17,9 @@ const {
   OPENAI_EMBEDDING_DEPLOYMENT,
   MONGODB_CONNECTION_URI,
   MONGODB_DATABASE_NAME,
+  GITHUB_ACCESS_TOKEN,
+  JIRA_USERNAME,
+  JIRA_PASSWORD,
 } = assertEnvVars(ArtifactGeneratorEnvVars);
 
 export const standardConfig = {
@@ -40,6 +45,21 @@ export const standardConfig = {
       connectionUri: MONGODB_CONNECTION_URI,
       databaseName: MONGODB_DATABASE_NAME,
     }),
+  jiraApi: () => {
+    return new JiraApi({
+      protocol: "https",
+      host: "jira.mongodb.org",
+      apiVersion: "2",
+      strictSSL: true,
+      username: JIRA_USERNAME,
+      password: JIRA_PASSWORD,
+    });
+  },
+  githubApi: async () => {
+    return new Octokit({
+      auth: GITHUB_ACCESS_TOKEN,
+    });
+  },
 } satisfies Config;
 
 export default standardConfig;

--- a/packages/mongodb-artifact-generator/src/standardConfig.ts
+++ b/packages/mongodb-artifact-generator/src/standardConfig.ts
@@ -9,7 +9,7 @@ import {
   AzureKeyCredential,
 } from "mongodb-rag-core";
 import { Octokit } from "@octokit/rest";
-// import JiraApi from "jira-client";
+import JiraApi from "jira-client";
 
 const {
   OPENAI_ENDPOINT,
@@ -45,16 +45,16 @@ export const standardConfig = {
       connectionUri: MONGODB_CONNECTION_URI,
       databaseName: MONGODB_DATABASE_NAME,
     }),
-  // jiraApi: () => {
-  //   return new JiraApi({
-  //     protocol: "https",
-  //     host: "jira.mongodb.org",
-  //     apiVersion: "2",
-  //     strictSSL: true,
-  //     username: JIRA_USERNAME,
-  //     password: JIRA_PASSWORD,
-  //   });
-  // },
+  jiraApi: () => {
+    return new JiraApi({
+      protocol: "https",
+      host: "jira.mongodb.org",
+      apiVersion: "2",
+      strictSSL: true,
+      username: JIRA_USERNAME,
+      password: JIRA_PASSWORD,
+    });
+  },
   githubApi: async () => {
     return new Octokit({
       auth: GITHUB_ACCESS_TOKEN,

--- a/packages/mongodb-artifact-generator/src/standardConfig.ts
+++ b/packages/mongodb-artifact-generator/src/standardConfig.ts
@@ -9,7 +9,7 @@ import {
   AzureKeyCredential,
 } from "mongodb-rag-core";
 import { Octokit } from "@octokit/rest";
-import JiraApi from "jira-client";
+// import JiraApi from "jira-client";
 
 const {
   OPENAI_ENDPOINT,
@@ -45,16 +45,16 @@ export const standardConfig = {
       connectionUri: MONGODB_CONNECTION_URI,
       databaseName: MONGODB_DATABASE_NAME,
     }),
-  jiraApi: () => {
-    return new JiraApi({
-      protocol: "https",
-      host: "jira.mongodb.org",
-      apiVersion: "2",
-      strictSSL: true,
-      username: JIRA_USERNAME,
-      password: JIRA_PASSWORD,
-    });
-  },
+  // jiraApi: () => {
+  //   return new JiraApi({
+  //     protocol: "https",
+  //     host: "jira.mongodb.org",
+  //     apiVersion: "2",
+  //     strictSSL: true,
+  //     username: JIRA_USERNAME,
+  //     password: JIRA_PASSWORD,
+  //   });
+  // },
   githubApi: async () => {
     return new Octokit({
       auth: GITHUB_ACCESS_TOKEN,


### PR DESCRIPTION
## Jira

- (EAI-321) POC - Git commits/PRs for Specific Release
- (EAI-322) POC - Code Diffs for Specific Release
- (EAI-320) POC - Jira Issues for Specific Release
- (EAI-348) Summarize Release Artifacts

## Changes

- Release info is defined in yaml and passed in via `--releaseInfo ./path/to/file.yaml`
- Sources git commits/patches & jira issues for a release
- Summarizes release artifacts with GPT-4

## How to use

First time:

```shell
cd mongodb-artifact-generator
npm install
npm link # makes mongodb-ai binary available in your shell
```

Once the bin is available:

```shell
mongodb-ai generateReleaseNotes \
  --runId="my-run \
  --releaseInfo="./context/release-notes/atlas-cli-releaseInfo.yaml" 
```

The POC run takes around 45 seconds to summarize 31 artifacts. There are console logs to track progress.

When the run is complete, the generated artifacts are available in the `runlogs/generateReleaseNotes/<runId>` directory.
