### PR TITLE
(EAI-371) [UI] Work around setext headings

### DIFF
--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -409,7 +409,22 @@ export function useConversation(params: UseConversationParams = {}) {
     let streamedTokens: string[] = [];
     const streamingIntervalMs = 50;
     const streamingInterval = setInterval(() => {
-      const [nextToken, ...remainingTokens] = bufferedTokens;
+      const [firstToken, ...remainingTokens] = bufferedTokens;
+      let nextToken: string | undefined = firstToken;
+
+      const onlyWhitespaceAndOrHyphenRegex = /^[\s-]*$/;
+      if (
+        onlyWhitespaceAndOrHyphenRegex.test(firstToken) &&
+        remainingTokens.length > 0
+      ) {
+        // Strings like " -" or "  - " can have weird interactions with
+        // other streamed text, e.g. text flash as a heading for one
+        // interval due to being parsed as a "setext heading". If we
+        // detect one, instead of just rendering it we first try to
+        // combine it with the next token.
+        remainingTokens[0] = firstToken + remainingTokens[0];
+        nextToken = undefined;
+      }
 
       bufferedTokens = remainingTokens;
 


### PR DESCRIPTION
Jira: (EAI-371) [UI] Work around setext headings

## Changes

- Right now we have an issue where for one token's worth of streaming we'll render a line as heading. This works around that by not dispatching the offending tokens. Instead, when we encounter one we combine it with the following token.
