### PR TITLE
(EAI-457) [UI] Custom chatbot trigger helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18534,10 +18534,6 @@
       "version": "1.2.3",
       "license": "MIT"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "license": "MIT"
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "dev": true,
@@ -40673,7 +40669,6 @@
         "@lg-chat/rich-links": "^1.0.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "buffer": "^6.0.3",
-        "classnames": "^2.5.1",
         "esbuild": "^0.17.19",
         "mongodb-rag-core": "^0.0.5",
         "prettier": "^2.8.8",

--- a/packages/mongodb-chatbot-ui/package.json
+++ b/packages/mongodb-chatbot-ui/package.json
@@ -103,7 +103,6 @@
     "@lg-chat/rich-links": "^1.0.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "buffer": "^6.0.3",
-    "classnames": "^2.5.1",
     "esbuild": "^0.17.19",
     "mongodb-rag-core": "^0.0.5",
     "prettier": "^2.8.8",

--- a/packages/mongodb-chatbot-ui/src/ActionButtonTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/ActionButtonTrigger.tsx
@@ -2,7 +2,7 @@ import { useDarkMode } from "@leafygreen-ui/leafygreen-provider";
 import { ChatTrigger } from "@lg-chat/fixed-chat-window";
 import { ChatbotTriggerProps } from "./ChatbotTrigger";
 import { useChatbotContext } from "./useChatbotContext";
-import classNames from "classnames";
+import { cx } from "@emotion/css";
 
 export type ActionButtonTriggerProps = ChatbotTriggerProps & {
   text?: string;
@@ -17,7 +17,7 @@ export function ActionButtonTrigger(props: ActionButtonTriggerProps) {
 
   return (
     <ChatTrigger
-      className={classNames(className)}
+      className={cx(className)}
       darkMode={darkMode}
       onClick={openChat}
     >

--- a/packages/mongodb-chatbot-ui/src/FloatingActionButtonTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/FloatingActionButtonTrigger.tsx
@@ -1,5 +1,4 @@
-import { css } from "@emotion/css";
-import classNames from "classnames";
+import { css, cx } from "@emotion/css";
 import {
   ActionButtonTrigger,
   type ActionButtonTriggerProps,
@@ -30,7 +29,7 @@ export function FloatingActionButtonTrigger({
 }: FloatingActionButtonTriggerProps) {
   return (
     <ActionButtonTrigger
-      className={classNames(styles.chat_trigger, className)}
+      className={cx(styles.chat_trigger, className)}
       {...props}
     />
   );

--- a/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
@@ -93,9 +93,7 @@ export function InputBarTrigger({
           darkMode={darkMode}
           hasError={hasError ?? false}
           badgeText={
-            focused || inputText.length > 0
-              ? undefined
-              : isExperimental
+            !focused && inputText.length === 0 && isExperimental
               ? "Experimental"
               : undefined
           }

--- a/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
@@ -3,9 +3,11 @@ import { useDarkMode } from "@leafygreen-ui/leafygreen-provider";
 import { Error as ErrorText } from "@leafygreen-ui/typography";
 import { InputBar, SuggestedPrompt, SuggestedPrompts } from "./InputBar";
 import { defaultChatbotFatalErrorMessage } from "./ui-text";
-import { ChatbotTriggerProps } from "./ChatbotTrigger";
 import { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch";
-import { useTextInputTrigger } from "./useTextInputTrigger";
+import {
+  type ChatbotTextInputTriggerProps,
+  useTextInputTrigger,
+} from "./useTextInputTrigger";
 
 const styles = {
   info_box: css`
@@ -38,10 +40,8 @@ const styles = {
   `,
 };
 
-export type InputBarTriggerProps = ChatbotTriggerProps & {
+export type InputBarTriggerProps = ChatbotTextInputTriggerProps & {
   bottomContent?: React.ReactNode;
-  fatalErrorMessage?: string;
-  placeholder?: string;
   suggestedPrompts?: string[];
 };
 
@@ -76,16 +76,14 @@ export function InputBarTrigger({
   });
 
   const showSuggestedPrompts =
+    // There are suggested prompts defined
     suggestedPrompts.length > 0 &&
-    inputText.length === 0 &&
+    // There is no conversation history
     conversation.messages.length === 0 &&
+    // The user has not typed anything
+    inputText.length === 0 &&
+    // We're not waiting for the reply to the user's first message
     !awaitingReply;
-  const badgeText =
-    focused || inputText.length > 0
-      ? undefined
-      : isExperimental
-      ? "Experimental"
-      : undefined;
 
   return (
     <div className={cx(styles.chatbot_container, className)}>
@@ -94,7 +92,13 @@ export function InputBarTrigger({
           key={"inputBarTrigger"}
           darkMode={darkMode}
           hasError={hasError ?? false}
-          badgeText={badgeText}
+          badgeText={
+            focused || inputText.length > 0
+              ? undefined
+              : isExperimental
+              ? "Experimental"
+              : undefined
+          }
           dropdownProps={{
             usePortal: false,
           }}

--- a/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
@@ -1,18 +1,11 @@
-import { css } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import { useDarkMode } from "@leafygreen-ui/leafygreen-provider";
 import { Error as ErrorText } from "@leafygreen-ui/typography";
-import {
-  InputBar,
-  MongoDbInputBarPlaceholder,
-  SuggestedPrompt,
-  SuggestedPrompts,
-} from "./InputBar";
+import { InputBar, SuggestedPrompt, SuggestedPrompts } from "./InputBar";
 import { defaultChatbotFatalErrorMessage } from "./ui-text";
-import { useState } from "react";
 import { ChatbotTriggerProps } from "./ChatbotTrigger";
-import { useChatbotContext } from "./useChatbotContext";
-import classNames from "classnames";
 import { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch";
+import { useTextInputTrigger } from "./useTextInputTrigger";
 
 const styles = {
   info_box: css`
@@ -52,29 +45,36 @@ export type InputBarTriggerProps = ChatbotTriggerProps & {
   suggestedPrompts?: string[];
 };
 
-export function InputBarTrigger(props: InputBarTriggerProps) {
-  const { darkMode } = useDarkMode(props.darkMode);
+export function InputBarTrigger({
+  className,
+  suggestedPrompts = [],
+  bottomContent,
+  fatalErrorMessage = defaultChatbotFatalErrorMessage,
+  placeholder,
+  darkMode: darkModeProp,
+}: InputBarTriggerProps) {
+  const { darkMode } = useDarkMode(darkModeProp);
+
   const {
-    className,
-    suggestedPrompts = [],
-    bottomContent,
-    fatalErrorMessage = defaultChatbotFatalErrorMessage,
-  } = props;
-  const {
-    openChat,
-    awaitingReply,
-    handleSubmit,
     conversation,
+    isExperimental,
     inputText,
+    inputPlaceholder,
     setInputText,
     inputTextError,
-    isExperimental,
-  } = useChatbotContext();
+    canSubmit,
+    awaitingReply,
+    openChat,
+    focused,
+    setFocused,
+    handleSubmit,
+    hasError,
+    showError,
+  } = useTextInputTrigger({
+    fatalErrorMessage,
+    placeholder,
+  });
 
-  const [focused, setFocused] = useState(false);
-  const canSubmit = inputTextError.length === 0 && !conversation.error;
-  const hasError = inputTextError !== "";
-  const showError = inputTextError !== "" && !open;
   const showSuggestedPrompts =
     suggestedPrompts.length > 0 &&
     inputText.length === 0 &&
@@ -86,12 +86,9 @@ export function InputBarTrigger(props: InputBarTriggerProps) {
       : isExperimental
       ? "Experimental"
       : undefined;
-  const inputPlaceholder = conversation.error
-    ? fatalErrorMessage
-    : props.placeholder ?? MongoDbInputBarPlaceholder();
 
   return (
-    <div className={classNames(styles.chatbot_container, className)}>
+    <div className={cx(styles.chatbot_container, className)}>
       <div className={styles.chatbot_input}>
         <InputBar
           key={"inputBarTrigger"}

--- a/packages/mongodb-chatbot-ui/src/index.tsx
+++ b/packages/mongodb-chatbot-ui/src/index.tsx
@@ -11,6 +11,11 @@ export {
 } from "./useConversation.tsx";
 export { useChatbot } from "./useChatbot.tsx";
 export { useChatbotContext } from "./useChatbotContext.tsx";
+export {
+  useTextInputTrigger,
+  type UseTextInputTriggerArgs,
+  type ChatbotTextInputTriggerProps,
+} from "./useTextInputTrigger.ts";
 export { MongoDbInputBarPlaceholder } from "./InputBar.tsx";
 export {
   InputBarTrigger,

--- a/packages/mongodb-chatbot-ui/src/useTextInputTrigger.ts
+++ b/packages/mongodb-chatbot-ui/src/useTextInputTrigger.ts
@@ -2,12 +2,40 @@ import { useState } from "react";
 import { MongoDbInputBarPlaceholder } from "./InputBar";
 import { defaultChatbotFatalErrorMessage } from "./ui-text";
 import { useChatbotContext } from "./useChatbotContext";
+import { ChatbotTriggerProps } from "./ChatbotTrigger";
 
 export type UseTextInputTriggerArgs = {
   placeholder?: string;
   fatalErrorMessage?: string;
 };
 
+/**
+  The base props for a Chatbot trigger component that allows the user to input text.
+ */
+export type ChatbotTextInputTriggerProps = ChatbotTriggerProps &
+  UseTextInputTriggerArgs;
+
+/**
+ * A hook that provides the necessary props to create a Chatbot trigger component that allows the user to input text.
+ * @param args - The arguments to configure the trigger.
+ * @returns The props to create a Chatbot trigger component that allows the user to input text.
+ * @example
+ * ```tsx
+ * const textInputTrigger = useTextInputTrigger({
+ *   placeholder: "Type something...",
+ *   fatalErrorMessage: "An error occurred. Please try again.",
+ * });
+ * return <MyInputBar
+ *   value={textInputTrigger.inputText}
+ *   placeholder={textInputTrigger.inputPlaceholder}
+ *   error={textInputTrigger.inputTextError || undefined}
+ *   onTextChange={newText => textInputTrigger.setInputText(newText)}
+ *   onSubmit={() => {
+ *     textInputTrigger.handleSubmit(textInputTrigger.inputText);
+ *   }}
+ * />;
+ * ```
+ */
 export function useTextInputTrigger({
   placeholder = MongoDbInputBarPlaceholder(),
   fatalErrorMessage = defaultChatbotFatalErrorMessage,
@@ -19,9 +47,11 @@ export function useTextInputTrigger({
     conversation,
     isExperimental,
   } = useChatbotContext();
+
   const [focused, setFocused] = useState(false);
   const [inputText, setInputText] = useState("");
   const [inputTextError, setInputTextError] = useState("");
+
   const inputPlaceholder = conversation.error ? fatalErrorMessage : placeholder;
   const canSubmit = inputTextError.length === 0 && !conversation.error;
   const hasError = inputTextError !== "";

--- a/packages/mongodb-chatbot-ui/src/useTextInputTrigger.ts
+++ b/packages/mongodb-chatbot-ui/src/useTextInputTrigger.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { MongoDbInputBarPlaceholder } from "./InputBar";
+import { defaultChatbotFatalErrorMessage } from "./ui-text";
+import { useChatbotContext } from "./useChatbotContext";
+
+export type UseTextInputTriggerArgs = {
+  placeholder?: string;
+  fatalErrorMessage?: string;
+};
+
+export function useTextInputTrigger({
+  placeholder = MongoDbInputBarPlaceholder(),
+  fatalErrorMessage = defaultChatbotFatalErrorMessage,
+}: UseTextInputTriggerArgs) {
+  const {
+    openChat,
+    awaitingReply,
+    handleSubmit,
+    conversation,
+    isExperimental,
+  } = useChatbotContext();
+  const [focused, setFocused] = useState(false);
+  const [inputText, setInputText] = useState("");
+  const [inputTextError, setInputTextError] = useState("");
+  const inputPlaceholder = conversation.error ? fatalErrorMessage : placeholder;
+  const canSubmit = inputTextError.length === 0 && !conversation.error;
+  const hasError = inputTextError !== "";
+  const showError = inputTextError !== "" && !open;
+
+  return {
+    conversation,
+    isExperimental,
+    inputText,
+    setInputText,
+    inputTextError,
+    inputPlaceholder,
+    setInputTextError,
+    canSubmit,
+    awaitingReply,
+    openChat,
+    focused,
+    setFocused,
+    handleSubmit,
+    hasError,
+    showError,
+  };
+}


### PR DESCRIPTION
Jira: (EAI-457) [UI] Custom chatbot trigger helpers

## Changes

- Refactors most of `InputBarTrigger` data and logic into a separate, re-usable hook
- Cleans up unnecessary `classnames` dependency in favor of Emotion's basically equivalent `cx`

## Notes

- Makes it easier for devs to make input bar triggers like ours but with custom components/logic
- Most applicable use is for upcoming DOP work on a new trigger
