### PR TITLE
(EAI-461) University course content includes tags it shouldn't

### DIFF
--- a/packages/mongodb-rag-ingest/src/sources/mongodb-university/makeUniversityPages.test.ts
+++ b/packages/mongodb-rag-ingest/src/sources/mongodb-university/makeUniversityPages.test.ts
@@ -61,12 +61,16 @@ describe("makeUniversityPages()", () => {
     );
     expect(samplePage.metadata).toEqual({
       foo: "bar",
-      tags: ["foo", "bar", "Intro to MongoDB", "University"],
+      tags: ["foo", "bar"],
       courseTitle: "Getting Started with MongoDB Atlas",
       sectionTitle:
         "Lesson 1: Introduction to MongoDB Atlas, the Developer Data Platform",
       lessonTitle: "Learn",
     });
+    // Don't include these tags that are returned by the API
+    const tagsSet = new Set(samplePage.metadata?.tags);
+    expect(tagsSet.has("Intro to MongoDB")).toBe(false);
+    expect(tagsSet.has("University")).toBe(false);
   });
 });
 

--- a/packages/mongodb-rag-ingest/src/sources/mongodb-university/makeUniversityPages.ts
+++ b/packages/mongodb-rag-ingest/src/sources/mongodb-university/makeUniversityPages.ts
@@ -78,7 +78,11 @@ function makeCatalogItemPages({
           body,
           metadata: {
             ...(metadata ?? {}),
-            tags: [...(metadata?.tags ?? []), ...catalogItem.tags],
+            // We choose to not include tags returned by the API (i.e.
+            // `catalogItem.tags`) here and instead only use tags we specify in
+            // our config. The API tags may contain internal or customer-specific
+            // data that we don't want to include in the embeddings.
+            tags: metadata?.tags ?? [],
             courseTitle,
             sectionTitle,
             lessonTitle,


### PR DESCRIPTION
Jira: (EAI-461) University course content includes tags it shouldn't

## Changes

- No longer includes tags from MDBU API
- Updates test
- Adds comments explaining why we don't do this

## Notes

-
