### PR TITLE
(EAI-472) FAQ Finder script is missing search filter

### DIFF
--- a/packages/scripts/src/findFaq.ts
+++ b/packages/scripts/src/findFaq.ts
@@ -215,7 +215,7 @@ export const makeFaqVectorStoreCollectionWrapper = (
         path,
         k,
         minScore,
-        filter,
+        filter = {},
         numCandidates,
       }: Partial<FindNearestNeighborsOptions> = {
         // Default options


### PR DESCRIPTION
Jira: (EAI-472) FAQ Finder script is missing search filter

## Changes

- Adds a default `filter = {}` for vector search to avoid the error breaking the script
