### PR TITLE
env var skip fix

### DIFF
--- a/packages/benchmarks/src/radiantModels.test.ts
+++ b/packages/benchmarks/src/radiantModels.test.ts
@@ -11,11 +11,14 @@ jest.setTimeout(60000);
 // NOTE: due to this issue https://github.com/nodejs/node/issues/39964,
 // you must run the tests with a Node version >= 20.0.0
 describe.skip("Radiant models", () => {
-  const { RADIANT_API_KEY, RADIANT_ENDPOINT, MONGODB_AUTH_COOKIE } =
-    assertEnvVars(envVars);
   test.each(radiantModels)(
     "'$label' model should generate data",
     async (model) => {
+      // Note: this is inside of the tests so that this doesn't throw with the skipped tests.
+      // THe assertion inside of the describe block will throw if the env vars are not set,
+      // even if the block is skipped.
+      const { RADIANT_API_KEY, RADIANT_ENDPOINT, MONGODB_AUTH_COOKIE } =
+        assertEnvVars(envVars);
       const chatLlm = await makeRadiantChatLlm({
         apiKey: RADIANT_API_KEY,
         endpoint: RADIANT_ENDPOINT,


### PR DESCRIPTION
Jira: n/a

## Changes

- Skip loading env vars for benchmarks package radiant tests. they were causing test suite to fail.
-

## Notes

- note that the tests are in fact passing despite the 🟡. issue w drone from yesterday makes it so webhook for green check (✅ ) never got called 
