### PR TITLE
(EAI-489): Braintrust-driven evals for adding new model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18035,6 +18035,98 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/autoevals": {
+      "version": "0.0.85",
+      "resolved": "https://registry.npmjs.org/autoevals/-/autoevals-0.0.85.tgz",
+      "integrity": "sha512-FhHXn15ZIUaQX5NPbIskMxsl4iFqQfT1//FIFcWMqiogCBqlNqi3b7y0hTwzORcwCMRKjbmD6rNRkvW6F4acbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintrust/core": "0.0.51",
+        "ajv": "^8.13.0",
+        "compute-cosine-similarity": "^1.1.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "linear-sum-assignment": "^1.0.7",
+        "mustache": "^4.2.0",
+        "openai": "4.47.1",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.5"
+      }
+    },
+    "node_modules/autoevals/node_modules/@types/node": {
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/autoevals/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/autoevals/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/autoevals/node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/autoevals/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/autoevals/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/autoevals/node_modules/openai": {
+      "version": "4.47.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.47.1.tgz",
+      "integrity": "sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
       "license": "MIT",
@@ -19410,6 +19502,12 @@
         "node": "*"
       }
     },
+    "node_modules/cheminfo-types": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/cheminfo-types/-/cheminfo-types-1.8.0.tgz",
+      "integrity": "sha512-OVzDu3sR6L5zYnD3YYQZe8Teaf1+Vooh8aJo5BMo3BfUQ8992Np6/x4q7Jr06M5XQwqq3oTGGd15kfHSlk8l5Q==",
+      "license": "MIT"
+    },
     "node_modules/chmod": {
       "version": "0.2.1",
       "dev": true,
@@ -20076,6 +20174,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compute-cosine-similarity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-cosine-similarity/-/compute-cosine-similarity-1.1.0.tgz",
+      "integrity": "sha512-FXhNx0ILLjGi9Z9+lglLzM12+0uoTnYkHm7GiadXDAr0HGVLm25OivUS1B/LPkbzzvlcXz/1EvWg9ZYyJSdhTw==",
+      "dependencies": {
+        "compute-dot": "^1.1.0",
+        "compute-l2norm": "^1.1.0",
+        "validate.io-array": "^1.0.5",
+        "validate.io-function": "^1.0.2"
+      }
+    },
+    "node_modules/compute-dot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dot/-/compute-dot-1.1.0.tgz",
+      "integrity": "sha512-L5Ocet4DdMrXboss13K59OK23GXjiSia7+7Ukc7q4Bl+RVpIXK2W9IHMbWDZkh+JUEvJAwOKRaJDiFUa1LTnJg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2"
+      }
+    },
+    "node_modules/compute-l2norm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-l2norm/-/compute-l2norm-1.1.0.tgz",
+      "integrity": "sha512-6EHh1Elj90eU28SXi+h2PLnTQvZmkkHWySpoFz+WOlVNLz3DQoC4ISUHSV9n5jMxPHtKGJ01F4uu2PsXBB8sSg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -20680,6 +20807,12 @@
     "node_modules/culvert": {
       "version": "0.1.2",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-0.7.1.tgz",
+      "integrity": "sha512-Ifi3fH46Bco+Lb1mOlTxbFEuF3NdyElEVVD+EmoK327I0JzKAP4x57cl+HoxHqFcVd8F/uXLC+wtY3n/R1uO2w==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -23228,6 +23361,12 @@
       "version": "2.1.1",
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
       "funding": [
@@ -23350,6 +23489,12 @@
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fft.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
+      "integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
       "license": "MIT"
     },
     "node_modules/figures": {
@@ -25261,6 +25406,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "license": "MIT",
@@ -27000,6 +27154,15 @@
       "version": "0.2.9",
       "license": "MIT"
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tiktoken": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.12.tgz",
@@ -27641,6 +27804,18 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linear-sum-assignment": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/linear-sum-assignment/-/linear-sum-assignment-1.0.7.tgz",
+      "integrity": "sha512-jfLoSGwZNyjfY8eK4ayhjfcIu3BfWvP6sWieYzYI3AWldwXVoWEz1gtrQL10v/8YltYLBunqNjeVFXPMUs+MJg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheminfo-types": "^1.7.3",
+        "install": "^0.13.0",
+        "ml-matrix": "^6.11.0",
+        "ml-spectra-processing": "^14.2.2"
       }
     },
     "node_modules/lines-and-columns": {
@@ -29664,11 +29839,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/ml-array-max": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+      "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
     "node_modules/ml-array-mean": {
       "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+      "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+      "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0",
+        "ml-array-max": "^1.2.4",
+        "ml-array-min": "^1.2.3"
       }
     },
     "node_modules/ml-array-sum": {
@@ -29691,6 +29895,31 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/ml-matrix": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.11.1.tgz",
+      "integrity": "sha512-Fvp1xF1O07tt6Ux9NcnEQTei5UlqbRpvvaFZGs7l3Ij+nOaEDcmbSVtxwNa8V4IfdyFI1NLNUteroMJ1S6vcEg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.1",
+        "ml-array-rescale": "^1.3.7"
+      }
+    },
+    "node_modules/ml-spectra-processing": {
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-14.5.3.tgz",
+      "integrity": "sha512-WYOnAOrCI5XKwonOtlR9oieFe/+ARBLocA+mZO89WLRCV7J/U/lFjxjOQv5/RXsoOF1udUUfxCZCjUMGfkhe5A==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search": "^1.3.6",
+        "cheminfo-types": "^1.7.3",
+        "fft.js": "^4.0.4",
+        "is-any-array": "^2.0.1",
+        "ml-matrix": "^6.11.1",
+        "ml-xsadd": "^2.0.0",
+        "spline-interpolator": "^1.0.0"
+      }
+    },
     "node_modules/ml-tree-similarity": {
       "version": "1.0.0",
       "license": "MIT",
@@ -29698,6 +29927,12 @@
         "binary-search": "^1.3.5",
         "num-sort": "^2.0.0"
       }
+    },
+    "node_modules/ml-xsadd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-2.0.0.tgz",
+      "integrity": "sha512-VoAYUqmPRmzKbbqRejjqceGFp3VF81Qe8XXFGU0UXLxB7Mf4GGvyGq5Qn3k4AiQgDEV6WzobqlPOd+j0+m6IrA==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.5.0",
@@ -37149,6 +37384,15 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/spline-interpolator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spline-interpolator/-/spline-interpolator-1.0.0.tgz",
+      "integrity": "sha512-s8lowgsWE5wjHGEsk/4VADp7xAHw+pNy3OGp96fYjVTwLSx/83+BBmTFP2wZDRM0kj45q8zSyOV5fUcGn4hLEw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^0.7.1"
+      }
+    },
     "node_modules/split": {
       "version": "1.0.1",
       "dev": true,
@@ -39585,6 +39829,17 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+      "license": "MIT"
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
@@ -40806,6 +41061,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.11",
+        "autoevals": "^0.0.85",
+        "braintrust": "^0.0.153",
         "chatbot-server-mongodb-public": "*",
         "dotenv": "^16",
         "llamaindex": "^0.1.21",
@@ -40837,10 +41094,428 @@
         "npm": ">=8"
       }
     },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.13.tgz",
+      "integrity": "sha512-NDQUUBDQoWk9aGn2pOA5wiM5CdO57KeYTEph7PpKGEU8IyqI0d+CiYKISOia6Omy17d+Dw/ZM6KP98F89BGJ5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.20",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.20.tgz",
+      "integrity": "sha512-nCQZRUTi/+y+kf1ep9rujpbQEtsIwySzlQAudiFeVhzzDi9rYvWp5tOSVu8/ArT+i1xSc2tw40akxb1TX73ofQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/react": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-0.0.46.tgz",
+      "integrity": "sha512-MQHC6AxEUi10++8LsnR3NUK+VkxB2sEWVlFxYrj6PKF5krxWnLgoCmpvbAdM6oc5b9byySBJaj6ZxRxutRpWtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.13",
+        "@ai-sdk/ui-utils": "0.0.33",
+        "swr": "2.2.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/solid": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.36.tgz",
+      "integrity": "sha512-pm57goMQczSpPTNrUrwbab5BybZYofBRZ10UkTi2KgJP5i+S/sGHSh/xtgZz+xNpUt42pk8aYvOiNDN1ppjkDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.13",
+        "@ai-sdk/ui-utils": "0.0.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.7.7"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/svelte": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.38.tgz",
+      "integrity": "sha512-sTNkxzhS1B0TDdVWZR6yXG+3qQGYAxMwcEKzMVjm1VdpGlZits1PxF39aVvPldaWM8QB4MrVE+H5b5dTA43D0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.13",
+        "@ai-sdk/ui-utils": "0.0.33",
+        "sswr": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.33.tgz",
+      "integrity": "sha512-2oZjZzZG3AGQihO1d3mWqgFuywTtjBtkUEeE7d8nicw3QQv9m1MwrbQqRhhKbbBetBke6V9o5FQ5wngmb/+3iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.20",
+        "@ai-sdk/provider-utils": "1.0.13",
+        "json-schema": "0.4.0",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.22.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.20.tgz",
+      "integrity": "sha512-nCQZRUTi/+y+kf1ep9rujpbQEtsIwySzlQAudiFeVhzzDi9rYvWp5tOSVu8/ArT+i1xSc2tw40akxb1TX73ofQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@ai-sdk/vue": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-0.0.38.tgz",
+      "integrity": "sha512-iqVPsRDXkrfIFzwrWoUKqBzMqSHxJQoompdj0LCC9v3s9c4ndn9Vx67nB5g2ee3fO3bY/O9vLebDwYyVKM4glg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.13",
+        "@ai-sdk/ui-utils": "0.0.33",
+        "swrv": "1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "packages/chatbot-eval-mongodb-public/node_modules/@types/node": {
       "version": "12.20.55",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/ai": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-3.3.11.tgz",
+      "integrity": "sha512-KPfikv3KDqFbZXRoB3jaM6bRJGU2ivmk12ahmo8LynEq1zqJJPc/2JEqlXNG9MoAQo3tQuqYiQfDzPIEO4aObA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.20",
+        "@ai-sdk/provider-utils": "1.0.13",
+        "@ai-sdk/react": "0.0.46",
+        "@ai-sdk/solid": "0.0.36",
+        "@ai-sdk/svelte": "0.0.38",
+        "@ai-sdk/ui-utils": "0.0.33",
+        "@ai-sdk/vue": "0.0.38",
+        "@opentelemetry/api": "1.9.0",
+        "eventsource-parser": "1.1.2",
+        "json-schema": "0.4.0",
+        "jsondiffpatch": "0.6.0",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.22.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "openai": "^4.42.0",
+        "react": "^18 || ^19",
+        "sswr": "^2.1.0",
+        "svelte": "^3.0.0 || ^4.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "sswr": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.20.tgz",
+      "integrity": "sha512-nCQZRUTi/+y+kf1ep9rujpbQEtsIwySzlQAudiFeVhzzDi9rYvWp5tOSVu8/ArT+i1xSc2tw40akxb1TX73ofQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/braintrust": {
+      "version": "0.0.153",
+      "resolved": "https://registry.npmjs.org/braintrust/-/braintrust-0.0.153.tgz",
+      "integrity": "sha512-XgAetRtTk4G6jqrvIkvpX+Yw82NaDxDiHQYBp8+anriXQpdc4V4o04Nj9IO1gYqhd/q7VcKP7fteQg+y+ifwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "^0.0.11",
+        "@braintrust/core": "0.0.51",
+        "@next/env": "^14.2.3",
+        "@vercel/functions": "^1.0.2",
+        "ai": "^3.2.16",
+        "argparse": "^2.0.1",
+        "chalk": "^4.1.2",
+        "cli-progress": "^3.12.0",
+        "dotenv": "^16.4.5",
+        "esbuild": "^0.18.20",
+        "eventsource-parser": "^1.1.2",
+        "graceful-fs": "^4.2.11",
+        "minimatch": "^9.0.3",
+        "mustache": "^4.2.0",
+        "pluralize": "^8.0.0",
+        "simple-git": "^3.21.0",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "braintrust": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/openai": {
+      "version": "4.56.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.56.0.tgz",
+      "integrity": "sha512-zcag97+3bG890MNNa0DQD9dGmmTWL8unJdNkulZzWRXrl+QeD+YkBI4H58rJcwErxqGK6a0jVPZ4ReJjhDGcmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/chatbot-eval-mongodb-public/node_modules/zod-to-json-schema": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.5.tgz",
+      "integrity": "sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.22.4"
+      }
     },
     "packages/chatbot-server-mongodb-public": {
       "version": "0.5.0",

--- a/packages/chatbot-eval-mongodb-public/package.json
+++ b/packages/chatbot-eval-mongodb-public/package.json
@@ -27,7 +27,8 @@
     "pipeline:faqConversationQualityCheck": "node ./build/pipelines/faqConversationQualityCheck.js",
     "pipeline:linkInclusionCheck": "node ./build/pipelines/linkInclusionCheck.js",
     "pipeline:llmConversationQualityCheck": "node ./build/pipelines/llmConversationQualityCheck.js",
-    "pipeline:biasConversationQualityCheck": "node ./build/pipelines/biasConversationQualityCheck.js"
+    "pipeline:biasConversationQualityCheck": "node ./build/pipelines/biasConversationQualityCheck.js",
+    "braintrust:evaluateRagConversationsData": "node ./build/braintrust/evaluateRagConversationsData.js"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7",
@@ -50,6 +51,8 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.11",
+    "autoevals": "^0.0.85",
+    "braintrust": "^0.0.153",
     "chatbot-server-mongodb-public": "*",
     "dotenv": "^16",
     "llamaindex": "^0.1.21",

--- a/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
+++ b/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
@@ -1,0 +1,74 @@
+import { assertEnvVars, ObjectId } from "mongodb-rag-core";
+import "dotenv/config";
+import { strict as assert } from "assert";
+import {
+  ConversationGeneratedData,
+  makeMongoDbGeneratedDataStore,
+  SomeGeneratedData,
+} from "mongodb-chatbot-evaluation";
+import { evaluateRagConversationsReferenceFree } from "./evaluateRagConversationsReferenceFree";
+
+const runs = [
+  // {
+  //   model: "gpt-35",
+  //   generatedDataRunId: new Object("669019be0aae97ffdafcd0ff").toString(),
+  // },
+  // {
+  //   model: "gpt-4o",
+  //   generatedDataRunId: new Object("66901df714b4b4953729c844").toString(),
+  // },
+  // {
+  //   model: "gpt-4o-mini",
+  //   generatedDataRunId: new Object("66c35ec36e955a072a6f8784").toString(),
+  // },
+  {
+    model: "gpt-35-preprocessor-gpt4o-mini-responder",
+    generatedDataRunId: new Object("66c37e6c97b47998dd59e87e").toString(),
+    description: `Uses GPT-3.5 for pre-processsing tasks: metadata extraction, user input guardrail, and query rewriting.
+Uses GPT-4o mini for the main responder.`,
+  },
+];
+async function main() {
+  const {
+    MONGODB_CONNECTION_URI,
+    MONGODB_DATABASE_NAME,
+    // NOTE: This is using an OpenAI key from OpenAI directly
+    // (not Azure OpenAI).
+    OPENAI_OPENAI_API_KEY,
+  } = assertEnvVars({
+    MONGODB_DATABASE_NAME: "",
+    MONGODB_CONNECTION_URI: "",
+    OPENAI_OPENAI_API_KEY: "",
+  });
+  const modelName = "gpt-4o-mini";
+  const generatedDataStore = makeMongoDbGeneratedDataStore({
+    connectionUri: MONGODB_CONNECTION_URI,
+    databaseName: MONGODB_DATABASE_NAME,
+  });
+  for (const run of runs) {
+    const generatedDataRunId = new ObjectId(run.generatedDataRunId);
+    const genData =
+      (await generatedDataStore.findByCommandRunId(generatedDataRunId)) ?? [];
+    const conversationGeneratedData = genData.map((gd) =>
+      checkConversationGeneratedData(gd)
+    );
+    await evaluateRagConversationsReferenceFree({
+      projectName: "mongodb-chatbot-conversations",
+      conversationGeneratedData,
+      evaluatorConfig: {
+        apiKey: OPENAI_OPENAI_API_KEY,
+        modelName,
+      },
+      description: run.description,
+      experimentName: `${run.model}-${Date.now()}`,
+      metadata: run,
+    });
+  }
+  await generatedDataStore.close();
+}
+
+function checkConversationGeneratedData(generatedData?: SomeGeneratedData) {
+  assert(generatedData?.type === "conversation", "Must be conversation data");
+  return generatedData as ConversationGeneratedData;
+}
+main();

--- a/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsReferenceFree.ts
+++ b/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsReferenceFree.ts
@@ -1,0 +1,111 @@
+import * as braintrust from "braintrust";
+import {
+  AnswerRelevancy,
+  ContextRelevancy,
+  Faithfulness,
+  Scorer,
+} from "autoevals";
+import { ConversationGeneratedData } from "mongodb-chatbot-evaluation";
+import { PromisePool } from "@supercharge/promise-pool";
+import { extractConversationEvalData } from "./utils";
+export interface EvaluateRagConversationsParams {
+  projectName: string;
+  conversationGeneratedData: ConversationGeneratedData[];
+  evaluatorConfig: {
+    apiKey: string;
+    modelName: string;
+    baseUrl?: string;
+    headers?: Record<string, string>;
+  };
+  metadata?: Record<string, unknown>;
+  description?: string;
+  experimentName?: string;
+}
+
+const retrievedContext: Scorer<string, { context: string[] }> = async ({
+  context,
+}) => {
+  return {
+    name: "RetrievedContext",
+    score: context.length ? 1 : 0,
+  };
+};
+
+const allowedQuery: Scorer<string, { allowedQuery: boolean }> = async ({
+  allowedQuery,
+}) => {
+  return {
+    name: "AllowedQuery",
+    score: allowedQuery ? 1 : 0,
+  };
+};
+
+/**
+  Evaluates a {@link ConversationGeneratedData} using [Braintrust](https://braintrustdata.com)
+  based on the reference-free evaluation metrics from the `autoevals` library:
+  - {@link Faithfulness}
+  - {@link AnswerRelevancy}
+  - {@link ContextRelevancy}
+
+  Also uses the {@link retrievedContext} metric to check if any context was retrieved.
+ */
+export async function evaluateRagConversationsReferenceFree({
+  projectName,
+  conversationGeneratedData,
+  evaluatorConfig,
+  metadata,
+  description,
+  experimentName,
+}: EvaluateRagConversationsParams) {
+  const experiment = braintrust.init(projectName, {
+    metadata,
+    description,
+    experiment: experimentName,
+  });
+
+  await PromisePool.for(conversationGeneratedData)
+    .withConcurrency(3)
+    .process(async (conversation, index) => {
+      console.log(
+        `Running experiment ${index + 1}/${conversationGeneratedData.length}`
+      );
+      await experiment.traced(async (span) => {
+        const { input, output, contexts, tags, rejectQuery } =
+          extractConversationEvalData(conversation);
+
+        const scores: Record<string, number | null> = {};
+        const evaluators = [
+          Faithfulness,
+          AnswerRelevancy,
+          ContextRelevancy,
+          retrievedContext,
+          allowedQuery,
+        ];
+        for (const evaluator of evaluators) {
+          const { name, score } = await evaluator({
+            input,
+            output,
+            context: contexts,
+            openAiApiKey: evaluatorConfig.apiKey,
+            model: evaluatorConfig.modelName,
+            openAiBaseUrl: evaluatorConfig.baseUrl,
+            openAiDefaultHeaders: evaluatorConfig.headers,
+            allowedQuery: !rejectQuery,
+          });
+          scores[name] = score;
+        }
+
+        span.log({
+          input,
+          output,
+          tags,
+          scores,
+          metadata: { contexts, hasContexts: contexts.length > 0 },
+        });
+      });
+    });
+
+  const summary = await experiment.summarize();
+  console.log(summary);
+  return summary;
+}

--- a/packages/chatbot-eval-mongodb-public/src/braintrust/utils.ts
+++ b/packages/chatbot-eval-mongodb-public/src/braintrust/utils.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from "assert";
+import {
+  ConversationGeneratedData,
+  SomeGeneratedData,
+} from "mongodb-chatbot-evaluation";
+import {
+  Conversation,
+  UserMessage,
+  AssistantMessage,
+} from "mongodb-chatbot-server";
+import z from "zod";
+
+export function extractConversationEvalData(
+  conversationGeneratedData: ConversationGeneratedData
+) {
+  const { data: conversation } = conversationGeneratedData;
+  const userMessage = getLastUserMessageFromConversation(conversation);
+  const contexts = getContextsFromUserMessage(userMessage);
+  const { content: output } =
+    getLastAssistantMessageFromConversation(conversation);
+
+  return {
+    input: userMessage.content,
+    output,
+    contexts,
+    tags: conversationGeneratedData.evalData.tags,
+    rejectQuery: userMessage.rejectQuery,
+  };
+}
+
+export function getLastUserMessageFromConversation(
+  conversation: Conversation
+): UserMessage {
+  const userMessage = [...conversation.messages]
+    .reverse()
+    .find((m) => m.role === "user");
+  assert(userMessage, "Conversation must have a UserMessage");
+  return userMessage as UserMessage;
+}
+export function getLastAssistantMessageFromConversation(
+  conversation: Conversation
+): AssistantMessage {
+  const assistantMessage = [...conversation.messages]
+    .reverse()
+    .find((m) => m.role === "assistant");
+  assert(assistantMessage, "Conversation must have a AssistantMessage");
+  return assistantMessage as AssistantMessage;
+}
+
+export function getContextsFromUserMessage(userMessage: UserMessage) {
+  const { data: contexts } = z
+    .array(z.string())
+    .safeParse(userMessage.contextContent?.map((cc) => cc.text));
+  // Return empty array if no context text found
+  return contexts ?? [];
+}
+export function checkConversationGeneratedData(
+  generatedData?: SomeGeneratedData
+) {
+  assert(generatedData?.type === "conversation", "Must be conversation data");
+  return generatedData as ConversationGeneratedData;
+}

--- a/packages/chatbot-server-mongodb-public/.env.example
+++ b/packages/chatbot-server-mongodb-public/.env.example
@@ -11,3 +11,4 @@ MONGODB_DATABASE_NAME=<docs-chatbot-ENV>
 VECTOR_SEARCH_INDEX_NAME=<index_name>
 NODE_ENV=development
 ALLOWED_ORIGINS=http://example.com,http://localhost:5173
+OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT=<deployment name>

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -126,7 +126,9 @@ export const generateUserPrompt = makeVerifiedAnswerGenerateUserPrompt({
   },
   onNoVerifiedAnswerFound: makeStepBackRagGenerateUserPrompt({
     openAiClient,
-    deploymentName: OPENAI_CHAT_COMPLETION_DEPLOYMENT,
+    deploymentName:
+      process.env.OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT ??
+      OPENAI_CHAT_COMPLETION_DEPLOYMENT,
     findContent,
     numPrecedingMessagesToInclude: 2,
   }),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-489

## Changes

- Add script to do context-free RAG eval on model responses.
- For using GPT-4o mini as the main responder with GPT-3.5 for preprocessing

## Notes

- The code to run braintrust here is fairly hacky. Once we have a evaluation vendor, we will create a more first-class integration between them and the evaluation CLI
- [Evals in braintrust](https://www.braintrust.dev/app/mdb-test/p/mongodb-chatbot-conversations/experiments/gpt-35-preprocessor-gpt4o-mini-responder-1724088921632?c=gpt-35-1724081121844&s=9d6628a7-e3f2-43c7-baa6-2aa203a1b553&diff=between_experiments&search={%22filter%22:[%22output%2520!%253D%2520%2522Unfortunately%252C%2520I%2520do%2520not%2520know%2520how%2520to%2520respond%2520to%2520your%2520message.%250A%250APlease%2520try%2520to%2520rephrase%2520your%2520message.%2520Adding%2520more%2520details%2520can%2520help%2520me%2520respond%2520with%2520a%2520relevant%2520answer.%2522%22]})
- Ticket for updating the preprocessor logic - https://jira.mongodb.org/browse/EAI-491 
