### PR TITLE
(EAI-484) Fix broken langchain chat model wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41332,7 +41332,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.11",
-        "@langchain/core": "^0.2.9",
+        "@langchain/core": "^0.2.27",
         "@langchain/openai": "^0.2.1",
         "@supercharge/promise-pool": "^3.2.0",
         "axios": "^1.6.7",
@@ -41361,17 +41361,16 @@
       }
     },
     "packages/mongodb-chatbot-evaluation/node_modules/@langchain/core": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.15.tgz",
-      "integrity": "sha512-L096itIBQ5XNsy5BCCPqIQEk/x4rzI+U4BhYT+fDBYtljESshIi/WzXdmiGfY/6MpVjB76jNuaRgMDmo1m9NeQ==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.27.tgz",
+      "integrity": "sha512-QAIlGxXWW7fox1oGmQjEHs1fbPaXOE9CeunmwZl9grFpu1igdkLbKnEJF7fjbVchyJHRB6yzpQ1bwP/S12O4mQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "~0.1.30",
-        "ml-distance": "^4.0.0",
+        "langsmith": "~0.1.39",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
@@ -41708,15 +41707,16 @@
       }
     },
     "packages/mongodb-chatbot-evaluation/node_modules/langsmith": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.36.tgz",
-      "integrity": "sha512-D5hhkFl31uxFdffx0lA6pin0lt8Pv2dpHFZYpSgEzvQ26PQ/Y/tnniQ+aCNokIXuLhMa7uqLtb6tfwjfiZXgdg==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.42.tgz",
+      "integrity": "sha512-P7o8sEkWVh009XFMm23hJ8yy4h6cNBw0vFxPw2uUS8KSF2tjgDDGlBU6SYXfemho4zucWAwONclnjU84HwYpFw==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^9.0.1",
         "commander": "^10.0.1",
         "p-queue": "^6.6.2",
         "p-retry": "4",
+        "semver": "^7.6.3",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
@@ -41798,6 +41798,18 @@
       },
       "bin": {
         "openai": "bin/cli"
+      }
+    },
+    "packages/mongodb-chatbot-evaluation/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/mongodb-chatbot-evaluation/node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4390,15 +4390,14 @@
       "license": "MIT"
     },
     "node_modules/@langchain/anthropic": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.2.3.tgz",
-      "integrity": "sha512-f2fqzLGcvsXXUyZ1vl8cgwkKDGLshOGrPuR9hkhGuBG5m91eq755OqPBxWJuS1TFtNU813cXft3xh0MQbxavwg==",
-      "dev": true,
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.2.15.tgz",
+      "integrity": "sha512-b9zVryoqqzyKelCJoc/8R8EziGfUyaX9w13BNXGoZ+RwMU88XaM05xeqxcJFOezVTi0aH4yoEZ6Kw/CtsukI0A==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.22.0",
-        "@langchain/core": ">=0.2.9 <0.3.0",
-        "fast-xml-parser": "^4.3.5",
+        "@anthropic-ai/sdk": "^0.25.2",
+        "@langchain/core": ">=0.2.21 <0.3.0",
+        "fast-xml-parser": "^4.4.1",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.4"
       },
@@ -4407,10 +4406,9 @@
       }
     },
     "node_modules/@langchain/anthropic/node_modules/@anthropic-ai/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-dv4BCC6FZJw3w66WNLsHlUFjhu19fS1L/5jMPApwhZLa/Oy1j0A2i3RypmDtHEPp4Wwg3aZkSHksp7VzYWjzmw==",
-      "dev": true,
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.25.2.tgz",
+      "integrity": "sha512-F1Hck/asswwidFLtGdMg3XYgRxEUfygNbpkq5KEaEGsHNaSfxeX18/uZGQCL0oQNcj/tYNx8BaFXVwRhFDi45g==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -4419,23 +4417,20 @@
         "agentkeepalive": "^4.2.1",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
+        "node-fetch": "^2.6.7"
       }
     },
     "node_modules/@langchain/anthropic/node_modules/@langchain/core": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.15.tgz",
-      "integrity": "sha512-L096itIBQ5XNsy5BCCPqIQEk/x4rzI+U4BhYT+fDBYtljESshIi/WzXdmiGfY/6MpVjB76jNuaRgMDmo1m9NeQ==",
-      "dev": true,
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.27.tgz",
+      "integrity": "sha512-QAIlGxXWW7fox1oGmQjEHs1fbPaXOE9CeunmwZl9grFpu1igdkLbKnEJF7fjbVchyJHRB6yzpQ1bwP/S12O4mQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "~0.1.30",
-        "ml-distance": "^4.0.0",
+        "langsmith": "~0.1.39",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
@@ -4451,7 +4446,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -4462,10 +4456,9 @@
       }
     },
     "node_modules/@langchain/anthropic/node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
-      "dev": true,
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -4475,7 +4468,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4488,7 +4480,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4498,8 +4489,9 @@
       }
     },
     "node_modules/@langchain/anthropic/node_modules/fast-xml-parser": {
-      "version": "4.3.6",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",
@@ -4522,20 +4514,19 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@langchain/anthropic/node_modules/langsmith": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.36.tgz",
-      "integrity": "sha512-D5hhkFl31uxFdffx0lA6pin0lt8Pv2dpHFZYpSgEzvQ26PQ/Y/tnniQ+aCNokIXuLhMa7uqLtb6tfwjfiZXgdg==",
-      "dev": true,
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.42.tgz",
+      "integrity": "sha512-P7o8sEkWVh009XFMm23hJ8yy4h6cNBw0vFxPw2uUS8KSF2tjgDDGlBU6SYXfemho4zucWAwONclnjU84HwYpFw==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^9.0.1",
         "commander": "^10.0.1",
         "p-queue": "^6.6.2",
         "p-retry": "4",
+        "semver": "^7.6.3",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
@@ -4553,6 +4544,18 @@
         "openai": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@langchain/core": {
@@ -4610,12 +4613,12 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.2.6.tgz",
-      "integrity": "sha512-LZgSzHOZPJGsZr2ZXJICqZo1GN0kUyP9/RN+T45g7HDdMRfS5Df7fJgY9w7EIfznT83Q0Ywhz+At/UvWMR3xhw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.2.7.tgz",
+      "integrity": "sha512-f2XDXbExJf4SYsy17QSiq0YY/UWJXhJwoiS8uRi/gBa20zBQ8+bBFRnb9vPdLkOkGiaTy+yXZVFro3a9iW2r3w==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/core": ">=0.2.21 <0.3.0",
+        "@langchain/core": ">=0.2.26 <0.3.0",
         "js-tiktoken": "^1.0.12",
         "openai": "^4.55.0",
         "zod": "^3.22.4",
@@ -4626,9 +4629,9 @@
       }
     },
     "node_modules/@langchain/openai/node_modules/@langchain/core": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.23.tgz",
-      "integrity": "sha512-elPg6WpAkxWEIGC9u38F2anbzqfYYEy32lJdsd9dtChcHSFmFLlXqa+SnpO3R772gUuJmcu+Pd+fCvmRFy029w==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.27.tgz",
+      "integrity": "sha512-QAIlGxXWW7fox1oGmQjEHs1fbPaXOE9CeunmwZl9grFpu1igdkLbKnEJF7fjbVchyJHRB6yzpQ1bwP/S12O4mQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^5.0.0",
@@ -4661,9 +4664,9 @@
       }
     },
     "node_modules/@langchain/openai/node_modules/@types/node": {
-      "version": "18.19.44",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
-      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -4700,9 +4703,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/openai/node_modules/langsmith": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.41.tgz",
-      "integrity": "sha512-8R7s/225Pxmv0ipMfd6sqmWVsfHLQivYlQZ0vx5K+ReoknummTenQlVK8gapk3kqRMnzkrouuRHMhWjMR6RgUA==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.42.tgz",
+      "integrity": "sha512-P7o8sEkWVh009XFMm23hJ8yy4h6cNBw0vFxPw2uUS8KSF2tjgDDGlBU6SYXfemho4zucWAwONclnjU84HwYpFw==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^9.0.1",
@@ -4730,9 +4733,9 @@
       }
     },
     "node_modules/@langchain/openai/node_modules/openai": {
-      "version": "4.55.5",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.55.5.tgz",
-      "integrity": "sha512-9OkMAMljFv1LxUFf5HLm/pw7zFd4yMgW+lKOYF80RBwuGWU+ZKF5BQGll+TEGAHu23YMeT8t6VSxI27c/DRAOA==",
+      "version": "4.56.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.56.0.tgz",
+      "integrity": "sha512-zcag97+3bG890MNNa0DQD9dGmmTWL8unJdNkulZzWRXrl+QeD+YkBI4H58rJcwErxqGK6a0jVPZ4ReJjhDGcmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -37715,7 +37718,6 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/strong-log-transformer": {
@@ -43286,8 +43288,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.5",
-        "@langchain/core": "^0.2.9",
-        "@langchain/openai": "^0.2.1",
+        "@langchain/anthropic": "^0.2.15",
+        "@langchain/core": "^0.2.27",
+        "@langchain/openai": "^0.2.7",
         "common-tags": "^1",
         "dotenv": "^16.3.1",
         "exponential-backoff": "^3.1.1",
@@ -43346,17 +43349,16 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/@langchain/core": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.15.tgz",
-      "integrity": "sha512-L096itIBQ5XNsy5BCCPqIQEk/x4rzI+U4BhYT+fDBYtljESshIi/WzXdmiGfY/6MpVjB76jNuaRgMDmo1m9NeQ==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.27.tgz",
+      "integrity": "sha512-QAIlGxXWW7fox1oGmQjEHs1fbPaXOE9CeunmwZl9grFpu1igdkLbKnEJF7fjbVchyJHRB6yzpQ1bwP/S12O4mQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "~0.1.30",
-        "ml-distance": "^4.0.0",
+        "langsmith": "~0.1.39",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
@@ -43381,15 +43383,16 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.36.tgz",
-      "integrity": "sha512-D5hhkFl31uxFdffx0lA6pin0lt8Pv2dpHFZYpSgEzvQ26PQ/Y/tnniQ+aCNokIXuLhMa7uqLtb6tfwjfiZXgdg==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.42.tgz",
+      "integrity": "sha512-P7o8sEkWVh009XFMm23hJ8yy4h6cNBw0vFxPw2uUS8KSF2tjgDDGlBU6SYXfemho4zucWAwONclnjU84HwYpFw==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^9.0.1",
         "commander": "^10.0.1",
         "p-queue": "^6.6.2",
         "p-retry": "4",
+        "semver": "^7.6.3",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
@@ -43583,6 +43586,18 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/mongodb-rag-core/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "packages/mongodb-rag-core/node_modules/whatwg-url": {
       "version": "13.0.0",

--- a/packages/mongodb-chatbot-evaluation/package.json
+++ b/packages/mongodb-chatbot-evaluation/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.11",
-    "@langchain/core": "^0.2.9",
+    "@langchain/core": "^0.2.27",
     "@langchain/openai": "^0.2.1",
     "@supercharge/promise-pool": "^3.2.0",
     "axios": "^1.6.7",

--- a/packages/mongodb-chatbot-evaluation/src/generate/generateLlmConversationData.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/generate/generateLlmConversationData.test.ts
@@ -38,8 +38,7 @@ describe("makeGenerateLlmConversationData", () => {
     });
     const generateLlmConversationData = makeGenerateLlmConversationData({
       chatLlm: makeLangchainChatLlm({
-        chatModel:
-          throwingLlm as unknown as MakeLangchainChatLlmProps["chatModel"],
+        chatModel: throwingLlm,
       }),
       backOffOptions: {
         numOfAttempts: 1,

--- a/packages/mongodb-chatbot-evaluation/src/generate/generateLlmConversationData.test.ts
+++ b/packages/mongodb-chatbot-evaluation/src/generate/generateLlmConversationData.test.ts
@@ -1,6 +1,6 @@
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import { makeGenerateLlmConversationData } from "./generateLlmConversationData";
-import { MakeLangchainChatLlmProps, ObjectId } from "mongodb-rag-core";
+import { ObjectId } from "mongodb-rag-core";
 import { testCases, triggerErrorTestCases } from "../test/mockTestCases";
 import { ChatOpenAI } from "@langchain/openai";
 import { makeLangchainChatLlm } from "mongodb-chatbot-server";

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -60,8 +60,9 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.5",
-    "@langchain/core": "^0.2.9",
-    "@langchain/openai": "^0.2.1",
+    "@langchain/anthropic": "^0.2.15",
+    "@langchain/core": "^0.2.27",
+    "@langchain/openai": "^0.2.7",
     "common-tags": "^1",
     "dotenv": "^16.3.1",
     "exponential-backoff": "^3.1.1",

--- a/packages/mongodb-rag-core/src/LangchainChatLlm.test.ts
+++ b/packages/mongodb-rag-core/src/LangchainChatLlm.test.ts
@@ -56,9 +56,7 @@ describe("LangchainChatLlm", () => {
       azureOpenAIApiVersion: OPENAI_CHAT_COMPLETION_MODEL_VERSION,
     });
     const azureLangchainChatLlm = makeLangchainChatLlm({
-      chatModel: model as unknown as Parameters<
-        typeof makeLangchainChatLlm
-      >[0]["chatModel"],
+      chatModel: model,
     });
     const { role, content } = await azureLangchainChatLlm.answerQuestionAwaited(
       {


### PR DESCRIPTION
Jira: (EAI-484) Fix broken langchain chat model wrapper

## Changes

- Upgrade to the latest `@langchain/*` dependencies.
  - Core wasn't actually referencing `@langchain/anthropic` as a dependency, so this adds that.
- Removes the `as unknown as` casts from https://github.com/mongodb/chatbot/pull/465#discussion_r1718834261
