### PR TITLE
Add missing env var for GPT-3.5 model

### DIFF
--- a/packages/chatbot-server-mongodb-public/environments/production.yml
+++ b/packages/chatbot-server-mongodb-public/environments/production.yml
@@ -17,6 +17,7 @@ envSecrets:
   OPENAI_API_KEY: docs-chatbot-prod
   OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-prod
   OPENAI_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-prod
+  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
 
 ingress:
   enabled: true

--- a/packages/chatbot-server-mongodb-public/environments/staging.yml
+++ b/packages/chatbot-server-mongodb-public/environments/staging.yml
@@ -17,6 +17,7 @@ envSecrets:
   OPENAI_API_KEY: docs-chatbot-staging
   OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-staging
   OPENAI_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
+  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
 
 ingress:
   enabled: true


### PR DESCRIPTION
Jira: n/a

## Changes

- Adding missing K8s env var for using GPT-3.5 for preprocessor.
- 

## Notes

- This should have been included in https://github.com/mongodb/chatbot/pull/475
