### PR TITLE
(EAI-498): Upgrade main responder LLM + system prompt to reduce AI non answers

### DIFF
--- a/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
+++ b/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
@@ -11,25 +11,25 @@ import { evaluateRagConversationsReferenceFree } from "./evaluateRagConversation
 const runs = [
   // {
   //   model: "gpt-35",
-  //   generatedDataRunId: new Object("669019be0aae97ffdafcd0ff").toString(),
+  //   generatedDataRunId: new ObjectId("669019be0aae97ffdafcd0ff").toString(),
   // },
   // {
   //   model: "gpt-4o",
-  //   generatedDataRunId: new Object("66901df714b4b4953729c844").toString(),
+  //   generatedDataRunId: new ObjectId("66901df714b4b4953729c844").toString(),
   // },
   // {
   //   model: "gpt-4o-mini",
-  //   generatedDataRunId: new Object("66c35ec36e955a072a6f8784").toString(),
+  //   generatedDataRunId: new ObjectId("66c35ec36e955a072a6f8784").toString(),
   // },
   //   {
   //     model: "gpt-35-preprocessor-gpt4o-mini-responder",
-  //     generatedDataRunId: new Object("66c37e6c97b47998dd59e87e").toString(),
+  //     generatedDataRunId: new ObjectId("66c37e6c97b47998dd59e87e").toString(),
   //     description: `Uses GPT-3.5 for pre-processsing tasks: metadata extraction, user input guardrail, and query rewriting.
   // Uses GPT-4o mini for the main responder.`,
   //   },
   {
     model: "gpt-35-preprocessor-gpt4o-responder",
-    generatedDataRunId: new Object("66cc95022525d293a0ef4cc3").toString(),
+    generatedDataRunId: new ObjectId("66cc95022525d293a0ef4cc3").toString(),
     description: `Uses GPT-3.5 for pre-processsing tasks: metadata extraction, user input guardrail, and query rewriting.
 Uses GPT-4o for the main responder. Also updated system prompt to include fewer non-answers.`,
   },

--- a/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
+++ b/packages/chatbot-eval-mongodb-public/src/braintrust/evaluateRagConversationsData.ts
@@ -21,11 +21,17 @@ const runs = [
   //   model: "gpt-4o-mini",
   //   generatedDataRunId: new Object("66c35ec36e955a072a6f8784").toString(),
   // },
+  //   {
+  //     model: "gpt-35-preprocessor-gpt4o-mini-responder",
+  //     generatedDataRunId: new Object("66c37e6c97b47998dd59e87e").toString(),
+  //     description: `Uses GPT-3.5 for pre-processsing tasks: metadata extraction, user input guardrail, and query rewriting.
+  // Uses GPT-4o mini for the main responder.`,
+  //   },
   {
-    model: "gpt-35-preprocessor-gpt4o-mini-responder",
-    generatedDataRunId: new Object("66c37e6c97b47998dd59e87e").toString(),
+    model: "gpt-35-preprocessor-gpt4o-responder",
+    generatedDataRunId: new Object("66cc95022525d293a0ef4cc3").toString(),
     description: `Uses GPT-3.5 for pre-processsing tasks: metadata extraction, user input guardrail, and query rewriting.
-Uses GPT-4o mini for the main responder.`,
+Uses GPT-4o for the main responder. Also updated system prompt to include fewer non-answers.`,
   },
 ];
 async function main() {

--- a/packages/chatbot-server-mongodb-public/environments/dev-rel.yml
+++ b/packages/chatbot-server-mongodb-public/environments/dev-rel.yml
@@ -10,13 +10,13 @@ env:
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
   ENVIRONMENT: qa
   NODE_ENV: qa
+  OPENAI_CHAT_COMPLETION_DEPLOYMENT: gpt-4o
+  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-embedding-ada-002
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-staging
   OPENAI_ENDPOINT: docs-chatbot-staging
   OPENAI_API_KEY: docs-chatbot-staging
-  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-staging
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT: dev-rel-generator
 
 ingress:
   enabled: true

--- a/packages/chatbot-server-mongodb-public/environments/production.yml
+++ b/packages/chatbot-server-mongodb-public/environments/production.yml
@@ -10,14 +10,14 @@ env:
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
   ALLOWED_ORIGINS: https://mongodb.com,https://www.mongodb.com
   NODE_ENV: production
+  OPENAI_CHAT_COMPLETION_DEPLOYMENT: gpt-4o
+  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: DocsAIChatbot
+  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-embedding-ada-002
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-prod
   OPENAI_ENDPOINT: docs-chatbot-prod
   OPENAI_API_KEY: docs-chatbot-prod
-  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-prod
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-prod
-  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
 
 ingress:
   enabled: true

--- a/packages/chatbot-server-mongodb-public/environments/qa.yml
+++ b/packages/chatbot-server-mongodb-public/environments/qa.yml
@@ -10,13 +10,13 @@ env:
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
   ENVIRONMENT: qa
   NODE_ENV: qa
+  OPENAI_CHAT_COMPLETION_DEPLOYMENT: gpt-4o
+  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-embedding-ada-002
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-staging
   OPENAI_ENDPOINT: docs-chatbot-staging
   OPENAI_API_KEY: docs-chatbot-staging
-  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-staging
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
 
 ingress:
   enabled: true

--- a/packages/chatbot-server-mongodb-public/environments/staging.yml
+++ b/packages/chatbot-server-mongodb-public/environments/staging.yml
@@ -10,14 +10,14 @@ env:
   OPENAI_CHAT_COMPLETION_MODEL_VERSION: 2023-06-01-preview
   ALLOWED_ORIGINS: https://knowledge.staging.corp.mongodb.com,https://docs-mongodborg-staging.corp.mongodb.com,https://mongodbcom-cdn.website.staging.corp.mongodb.com,https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com
   NODE_ENV: staging
+  OPENAI_CHAT_COMPLETION_DEPLOYMENT: gpt-4o
+  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-gpt-35-turbo-0613
+  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-embedding-ada-002
 
 envSecrets:
   MONGODB_CONNECTION_URI: docs-chatbot-staging
   OPENAI_ENDPOINT: docs-chatbot-staging
   OPENAI_API_KEY: docs-chatbot-staging
-  OPENAI_EMBEDDING_DEPLOYMENT: docs-chatbot-staging
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
-  OPENAI_GPT_35_CHAT_COMPLETION_DEPLOYMENT: docs-chatbot-staging
 
 ingress:
   enabled: true

--- a/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
@@ -1,18 +1,23 @@
-import { stripIndents } from "common-tags";
 import { SystemPrompt } from "mongodb-chatbot-server";
 
-export const systemPrompt: SystemPrompt = {
+export const systemPrompt = {
   role: "system",
-  content: stripIndents`You are expert MongoDB documentation chatbot.
+  content: `You are expert MongoDB documentation chatbot.
 You enthusiastically answer user questions about MongoDB products and services.
 Your personality is friendly and helpful, like a professor or tech lead.
+Be concise and informative in your responses.
 You were created by MongoDB.
-Use the context provided with each question as your primary source of truth.
-If you do not know the answer to the question based on the provided documentation content, respond with the following text:
+Use the provided context information to answer user questions. You can also use your internal knowledge of MongoDB to inform the answer.
+
+If you do not know the answer to the question, respond with the following text:
 "I'm sorry, I do not know how to answer that question. Please try to rephrase your query."
-If there is no documentation content provided, ask the user to rephrase their query. Provide a few suggestions for how to rephrase the query.
+Also ask the user to rephrase their query. Provide a few suggestions for how to rephrase the query.
+
 NEVER include links in your answer.
 Format your responses using Markdown. DO NOT mention that your response is formatted in Markdown.
 If you include code snippets, use proper syntax, line spacing, and indentation.
+
+If you include a code example in your response, only include examples in one programming language,
+unless otherwise specified in the user query. If the user query is about a programming language, include that language in the response.
 You ONLY know about the current version of MongoDB products. Versions are provided in the information. If \`version: null\`, then say that the product is unversioned.`,
-};
+} satisfies SystemPrompt;


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-498

## Changes

Based on the changes in #482, the production application is providing non-answers to too many questions b/c the exact answer isn't in the context information. This PR:

- Upgrades the main responder LLM from `gpt-4o-mini` to `gpt-4o`. 
- Updates the system prompt to allow greater freedom for the LLM to respond based on it's internal knowledge.
  - We know that GPT-4o has much better internal knowledge of MongoDB based on our benchmarking of LLMs for MongoDB + much better general reasoning ability based on common benchmarks than GPT-3.5-turbo, our previous LLM, this should be a relatively safe move. While it might introduce some more hallucinations in various edge cases, it should have a net-positive effect.
- In k8s, pass models as non-secret env vars instead of k8s secrets to allow for easier changing.

## Notes

- Evaluation results: https://www.braintrust.dev/app/mdb-test/p/mongodb-chatbot-conversations/experiments/gpt-35-preprocessor-gpt4o-responder-1724684610280
  - Note the increase in AnswerRelevancy and Faithfulness compared to `
gpt-35-preprocessor-gpt4o-mini-responder-1724088921632` and increase in Faithfulness compared to `gpt-35-1724081121844`
