### PR TITLE
Update quick start guide documentation

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -172,10 +172,21 @@ You can ask the chatbot questions and see the responses.
 
 Have fun!
 
-You can also query the server directly with curl:
+You can also query the server directly with curl. To create a new conversation:
 
 ```shell
-curl -X POST http://localhost:3000/api/vi/conversations/
+curl -X POST http://localhost:3000/api/v1/conversations/
+```
+
+This creates a new conversation with an `_id` field. You can append messages to the conversation with: 
+
+```shell
+curl --location 'http://localhost:3000/api/v1/conversations/{conversationId}/messages?stream=false' \
+--header 'Origin: http://localhost:5173' \
+--header 'Content-Type: application/json' \
+--data '{
+    "message": "What is MongoDB?"
+}'
 ```
 
 To learn more about how you can configure the MongoDB Chatbot Server,


### PR DESCRIPTION
## Changes

- Fix typo in quickstart guide to point to `http://localhost:3000/api/v1/conversations/`
- Add instructions for appending new messages to the conversation

## Notes

- Example here uses `stream=false`, but users may want to use `stream=true` for longer responses
- Should note that the [default max input](https://github.com/mongodb/chatbot/blob/844bbf5e83ee8a7b6be1077c3b2407543429c0fb/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts#L40) is 300 chars, which limits the types of inputs users can provide. Temporary workaround is to override by setting `maxInputLengthCharacters` in the example [config](https://github.com/mongodb/chatbot/blob/main/examples/quick-start/packages/server/src/index.ts#L125)