### PR TITLE
(EAI-514 & EAI-516): Increase default+implementation max input size to `3000`

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -189,6 +189,7 @@ export const config: AppConfig = {
     maxUserMessagesInConversation: 50,
     maxUserCommentLength: 500,
     conversations,
+    maxInputLengthCharacters: 3000,
   },
   maxRequestTimeoutMs: 30000,
   corsOptions: {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
@@ -37,7 +37,7 @@ import {
   generateResponse,
 } from "../generateResponse";
 
-export const DEFAULT_MAX_INPUT_LENGTH = 300; // magic number for max input size for LLM
+export const DEFAULT_MAX_INPUT_LENGTH = 3000; // magic number for max input size for LLM
 export const DEFAULT_MAX_USER_MESSAGES_IN_CONVERSATION = 7; // magic number for max messages in a conversation
 
 export type AddMessageRequestBody = z.infer<typeof AddMessageRequestBody>;

--- a/packages/mongodb-chatbot-ui/src/App.tsx
+++ b/packages/mongodb-chatbot-ui/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
           onClose={() => {
             console.log("Docs Chatbot closed");
           }}
+          maxInputCharacters={3000}
         >
           <DocsChatbot suggestedPrompts={SUGGESTED_PROMPTS} />
         </Chatbot>

--- a/packages/mongodb-chatbot-ui/src/Chatbot.tsx
+++ b/packages/mongodb-chatbot-ui/src/Chatbot.tsx
@@ -31,7 +31,7 @@ export function Chatbot({
 }: ChatbotProps) {
   const { darkMode } = useDarkMode(props.darkMode);
 
-  const DEFAULT_MAX_INPUT_CHARACTERS = 300;
+  const DEFAULT_MAX_INPUT_CHARACTERS = 3000;
   const maxInputCharacters =
     props.maxInputCharacters ?? DEFAULT_MAX_INPUT_CHARACTERS;
 


### PR DESCRIPTION
Jira:
- https://jira.mongodb.org/browse/EAI-514
- https://jira.mongodb.org/browse/EAI-516

## Changes

- Increase server default max input size to 3000
- Increase server implementation max input size to 3000
- Increase frontend default max input size to 3000
- Increase frontend implementation max input size to 3000

## Notes

-
