### PR TITLE
(EAI-518): Allow for more previous messages in context

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -21,6 +21,7 @@ import {
   ConversationCustomData,
   makeVerifiedAnswerGenerateUserPrompt,
   makeDefaultFindVerifiedAnswer,
+  makeFilterNPreviousMessages,
 } from "mongodb-chatbot-server";
 import { AzureKeyCredential, OpenAIClient } from "@azure/openai";
 import cookieParser from "cookie-parser";
@@ -142,7 +143,7 @@ export const generateUserPrompt = makeVerifiedAnswerGenerateUserPrompt({
     openAiClient: preprocessorOpenAiClient,
     model: OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
     findContent,
-    numPrecedingMessagesToInclude: 2,
+    numPrecedingMessagesToInclude: 5,
   }),
 });
 

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -143,7 +143,7 @@ export const generateUserPrompt = makeVerifiedAnswerGenerateUserPrompt({
     openAiClient: preprocessorOpenAiClient,
     model: OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
     findContent,
-    numPrecedingMessagesToInclude: 5,
+    numPrecedingMessagesToInclude: 6,
   }),
 });
 

--- a/packages/chatbot-server-mongodb-public/src/processors/extractMongoDbMetadataFromUserMessage.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/extractMongoDbMetadataFromUserMessage.eval.ts
@@ -6,7 +6,7 @@ import { Eval } from "braintrust";
 import { Scorer } from "autoevals";
 import { MongoDbTag } from "../mongoDbMetadata";
 import {
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT,
+  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
   openAiClient,
 } from "../test/evalHelpers";
 
@@ -204,7 +204,7 @@ const ProgrammingLanguageCorrect: Scorer<
   };
 };
 
-const model = OPENAI_CHAT_COMPLETION_DEPLOYMENT;
+const model = OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT;
 Eval("extract-mongodb-metadata", {
   data: evalCases,
   experimentName: model,

--- a/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.test.ts
@@ -4,7 +4,6 @@ import {
   ObjectId,
 } from "mongodb-chatbot-server";
 import {
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT,
   OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
   preprocessorOpenAiClient,
 } from "../test/testHelpers";

--- a/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
@@ -197,7 +197,6 @@ function makeUserContentForLlm({
   maxContextTokenCount: number;
 }) {
   const previousConversationMessages = messages
-    .filter((message) => message.role !== "system")
     .map((message) => message.role.toUpperCase() + ": " + message.content)
     .join("\n");
   const relevantMetadata = JSON.stringify({

--- a/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeStepBackRagGenerateUserPrompt.ts
@@ -55,7 +55,9 @@ export const makeStepBackRagGenerateUserPrompt = ({
     const precedingMessagesToInclude =
       numPrecedingMessagesToInclude === 0
         ? []
-        : messages.slice(-numPrecedingMessagesToInclude);
+        : messages
+            .filter((m) => m.role !== "system")
+            .slice(-numPrecedingMessagesToInclude);
     // Run both at once to save time
     const [metadata, guardrailResult] = await Promise.all([
       extractMongoDbMetadataFromUserMessage({

--- a/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.eval.ts
@@ -10,7 +10,7 @@ import { MongoDbTag } from "../mongoDbMetadata";
 import {
   JUDGE_LLM,
   JUDGE_OPENAI_API_KEY,
-  OPENAI_CHAT_COMPLETION_DEPLOYMENT,
+  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
   openAiClient,
 } from "../test/evalHelpers";
 type MongoDbGuardrailEvalCaseTag = "irrelevant" | "inappropriate" | "valid";
@@ -224,7 +224,7 @@ Reference: {{expected}}
   return res;
 };
 
-const model = OPENAI_CHAT_COMPLETION_DEPLOYMENT;
+const model = OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT;
 
 Eval("user-message-guardrail", {
   data: evalCases,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-518

## Changes

- Allow for including more previous messages in the context. 
  - We can do this now that we're using GPT-4o, which has a bigger context window.
- Fixed bug where we were passing the system prompt to the preprocessors. Validated that evals still run as expected w/o regression.

## Notes

-
