### PR TITLE
(EAI-525): Increase server LLM max output to `1000` tokens

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -84,7 +84,7 @@ export const llm = makeOpenAiChatLlm({
   deployment: OPENAI_CHAT_COMPLETION_DEPLOYMENT,
   openAiLmmConfigOptions: {
     temperature: 0,
-    maxTokens: 500,
+    maxTokens: 1000,
   },
 });
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-525

## Changes

- Increase server LLM max output to `1000` tokens

## Notes

- Since upgrading the main responder LLM to GPT-4o, the model tends toward giving longer responses, which are occasionally getting truncated. This change mitigates that problem.
