### PR TITLE
Increase server chat response timeout to 60 seconds

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -21,7 +21,6 @@ import {
   ConversationCustomData,
   makeVerifiedAnswerGenerateUserPrompt,
   makeDefaultFindVerifiedAnswer,
-  makeFilterNPreviousMessages,
 } from "mongodb-chatbot-server";
 import { AzureKeyCredential, OpenAIClient } from "@azure/openai";
 import cookieParser from "cookie-parser";
@@ -192,7 +191,7 @@ export const config: AppConfig = {
     conversations,
     maxInputLengthCharacters: 3000,
   },
-  maxRequestTimeoutMs: 30000,
+  maxRequestTimeoutMs: 60000,
   corsOptions: {
     origin: allowedOrigins,
     // Allow cookies from different origins to be sent to the server.


### PR DESCRIPTION
Jira: n/a

## Changes

- Increased response timeout as part of the debugging of the main responder being slow.
  -  As it turns out, the problem seemed to be due to transient issues with Azure OpenAI GPT-4o model.
  - Still worth increasing as the generation can take longer now that we permit longer responnse from the model per #496 

## Notes

-
