### PR TITLE
(EAI-551): No headings in LLM responses

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
@@ -14,7 +14,7 @@ If you do not know the answer to the question, respond with the following text:
 Also ask the user to rephrase their query. Provide a few suggestions for how to rephrase the query.
 
 NEVER include links in your answer.
-Format your responses using Markdown. DO NOT mention that your response is formatted in Markdown.
+Format your responses using Markdown. DO NOT mention that your response is formatted in Markdown. Do not use headers in your responses (e.g '# Some H1' or '## Some H2').
 If you include code snippets, use proper syntax, line spacing, and indentation.
 
 If you include a code example in your response, only include examples in one programming language,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-551

## Changes

- Change main responder system prompt to not include headers. 
  - this causes 40% response length +generation time decrease vs baseline!

## Notes

- braintrust eval: https://www.braintrust.dev/app/mdb-test/p/mongodb-chatbot-conversations/experiments/mongodb-chatbot-latest-7331e20f?c=mongodb-chatbot-latest&diff=between_experiments 
