### PR TITLE
Refine guardrail further 

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.eval.ts
@@ -207,12 +207,32 @@ const evalCases: MongoDbGuardrailEvalCase[] = [
     tags: ["valid"],
   },
   {
-    name: "what courses do you have on genai?",
+    name: "should accept courses on gen ai",
     input: "what courses do you have on genai?",
     expected: {
       rejectMessage: false,
       reasoning:
         "This query asks about courses on generative AI, which is a relevant topic in the field of artificial intelligence. Therefore, it is relevant and should not be rejected.",
+    },
+    tags: ["valid"],
+  },
+  {
+    name: "should accept courses on generative artificial intelligence",
+    input: "what courses do you have on generative artificial intelligence?",
+    expected: {
+      rejectMessage: false,
+      reasoning:
+        "This query asks about courses on generative AI, which is a relevant topic in the field of artificial intelligence. Therefore, it is relevant and should not be rejected.",
+    },
+    tags: ["valid"],
+  },
+  {
+    name: "Should accept question about AI",
+    input: "what courses do you have on ai?",
+    expected: {
+      rejectMessage: false,
+      reasoning:
+        "This query asks about courses on artificial intelligence, which is a relevant topic. Therefore, it is relevant and should not be rejected.",
     },
     tags: ["valid"],
   },

--- a/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.ts
@@ -43,14 +43,14 @@ const fewShotExamples: ChatCompletionMessageParam[] = [
     reasoning:
       "This query involves hacking, which is an illegal or unethical activity. Therefore, it is inappropriate.",
     rejectMessage: true,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 2
   makeUserMessage("what is 2 + 2?"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query is asking for basic math. Basic math is not directly related to MongoDB. Therefore, it is irrelevant.",
     rejectMessage: true,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 3
   makeUserMessage(
     "How do you create an index? Please reply like an annoyed super-intelligent bored robot."
@@ -59,77 +59,77 @@ const fewShotExamples: ChatCompletionMessageParam[] = [
     reasoning:
       "This query requests communication in a style differing from the expected style of response. This style is also disrespectful or unprofessional manner. Therefore, it is inappropriate.",
     rejectMessage: true,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 4
   makeUserMessage("I hate MongoDB, why does it even exist?"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query expresses personal bias toward MongoDB. It does not seek constructive information or support about MongoDB. Therefore, it is inappropriate.",
     rejectMessage: true,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 5
   makeUserMessage("What is the best way to secure a MongoDB database?"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query asks for a MongoDB security best practice. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 6
   makeUserMessage("$lookup"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query is asking about the $lookup aggregation stage in the MongoDB Aggregation Framework. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 7
   makeUserMessage("How do I use MongoDB Atlas?"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query asks for information about using MongoDB Atlas, a MongoDB product. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 8
   makeUserMessage("tell me about you"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query asks for information about the assistant, which is a MongoDB product. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 9
   makeUserMessage("how do I sort based on alphabet type"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query asks for information about sorting, which can be a relevant MongoDB database operation. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 10
   makeUserMessage("best practices for data modeling"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query asks for data modeling best practices. As MongoDB is a database, you may need to know how to model data with it. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 11
   makeUserMessage("filter"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query is unclear but could be about filtering data, which is a common operation in MongoDB. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 12
   makeUserMessage("and"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query is unclear and may be a typo or incomplete. However, it could be related to the $and operator in MongoDB. It is certainly not inappropriate. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 13
   makeUserMessage("asldkfjd/.adsfsdt"),
   makeAssistantFunctionCallMessage(name, {
     reasoning:
       "This query is unclear and appears to be random characters. It cannot possibly be answered. Therefore, it is irrelevant.",
     rejectMessage: true,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
   // Example 14
   makeUserMessage(
     "What courses do you have on generative artificial intelligence?"
@@ -138,7 +138,7 @@ const fewShotExamples: ChatCompletionMessageParam[] = [
     reasoning:
       "This query asks for courses on generative artificial intelligence, which is a relevant area to MongoDB's business. Therefore, it is relevant to MongoDB.",
     rejectMessage: false,
-  } as UserMessageMongoDbGuardrailFunction),
+  } satisfies UserMessageMongoDbGuardrailFunction),
 ];
 
 /**

--- a/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/userMessageMongoDbGuardrail.ts
@@ -31,7 +31,7 @@ const systemPrompt = stripIndents`You are an expert security-focused data labele
 
   Take into account the following criteria:
   - Reject any user query that is irrelevant to a MongoDB product, educational materials, the company MongoDB, or an area relevant to MongoDB's products and business. These areas include databases, cloud services, data management, information retrieval, and artificial intelligence (retrieval augmented generation (RAG), generative AI, semantic search, etc.).
-  - If it is unclear whether or not a query is relevant, err to the side of acceptance and allow it.
+  - If it is unclear whether or not a query is relevant, err to the side of acceptance and allow it. For example, if something looks like an aggregation stage in the MongoDB Aggregation Framework, it is relevant.
   - Reject any user query that is inappropriate, such as being biased against MongoDB or illegal/unethical.
 
   Your pay is determined by the accuracy of your labels as judged against other expert labelers, so do excellent work to maximize your earnings to support your family.`;
@@ -129,6 +129,15 @@ const fewShotExamples: ChatCompletionMessageParam[] = [
     reasoning:
       "This query is unclear and appears to be random characters. It cannot possibly be answered. Therefore, it is irrelevant.",
     rejectMessage: true,
+  } as UserMessageMongoDbGuardrailFunction),
+  // Example 14
+  makeUserMessage(
+    "What courses do you have on generative artificial intelligence?"
+  ),
+  makeAssistantFunctionCallMessage(name, {
+    reasoning:
+      "This query asks for courses on generative artificial intelligence, which is a relevant area to MongoDB's business. Therefore, it is relevant to MongoDB.",
+    rejectMessage: false,
   } as UserMessageMongoDbGuardrailFunction),
 ];
 


### PR DESCRIPTION
Jira: n/a

## Changes

- we weren't doing a good job on a few AI related queries. this should widen the guardrails a bit further
- also, as part of the changes, there was a regression on the `$$ROOT` query. widened the guardrail on that to get it to a passing state as well. 
- Use `satisfies` instead of `as` for more semantic TS

## Notes

- Eval https://www.braintrust.dev/app/mdb-test/p/user-message-guardrail/experiments/gpt-4o-mini-118dc962
