### PR TITLE
(EAI-549) Don't assign a rich link badge based on mongodb-corp sourceName

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/makeMongoDbReferences.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/makeMongoDbReferences.ts
@@ -76,8 +76,6 @@ export function mongodbReferenceType(
         return "Book";
       case "devcenter":
         return "Article";
-      case "mongodb-corp":
-        return "Website";
     }
   }
 


### PR DESCRIPTION
Jira: (EAI-549) Don't assign a rich link badge based on mongodb-corp sourceName

