### PR TITLE
(EAI-466): move common modules from `mongodb-artifact-generator` to `mongodb-rag-core`

### DIFF
--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
@@ -19,15 +19,12 @@ export type MakeClassifyChangelogScope = {
 
 export function makeClassifyChangelog({
   openAiClient,
-  logger,
 }: MakeClassifyChangelogScope) {
   const classifyChangelogAudience = makeClassifyChangelogAudience({
     openAiClient,
-    logger,
   });
   const classifyChangelogScope = makeClassifyChangelogScope({
     openAiClient,
-    logger,
   });
 
   return async function classifyChangelog({

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
@@ -4,7 +4,7 @@ import { makeClassifyChangelogAudience } from "./classifyChangelogAudience";
 import { makeClassifyChangelogScope } from "./classifyChangelogScope";
 import { iOfN } from "../utils";
 import { RunLogger } from "../runlogger";
-import { Classification } from "../chat/makeClassifier";
+import { Classification } from "mongodb-rag-core";
 
 export type ClassifiedChangelog = {
   audience: Classification;

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogAudience.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogAudience.ts
@@ -1,6 +1,5 @@
 import { OpenAIClient } from "mongodb-rag-core";
-import { makeClassifier } from "../chat/makeClassifier";
-import { RunLogger } from "../runlogger";
+import { makeClassifier } from "mongodb-rag-core";
 
 const classificationTypes = [
   {
@@ -41,7 +40,6 @@ const classificationTypes = [
 
 export type MakeClassifyChangelogAudienceArgs = {
   openAiClient: OpenAIClient;
-  logger?: RunLogger;
 };
 
 export function makeClassifyChangelogAudience({

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogScope.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogScope.ts
@@ -1,6 +1,5 @@
 import { OpenAIClient } from "mongodb-rag-core";
-import { makeClassifier } from "../chat/makeClassifier";
-import { RunLogger } from "../runlogger";
+import { makeClassifier } from "mongodb-rag-core";
 
 const classificationTypes = [
   {
@@ -86,16 +85,13 @@ const classificationTypes = [
 
 export type MakeClassifyChangelogScope = {
   openAiClient: OpenAIClient;
-  logger?: RunLogger;
 };
 
 export function makeClassifyChangelogScope({
   openAiClient,
-  logger,
 }: MakeClassifyChangelogScope) {
   return makeClassifier({
     openAiClient,
-    logger,
     classificationTypes,
     chainOfThought: true,
   });

--- a/packages/mongodb-rag-core/src/index.ts
+++ b/packages/mongodb-rag-core/src/index.ts
@@ -22,7 +22,7 @@ export * from "./CoreEnvVars";
 export * from "./DatabaseConnection";
 export * from "./DataStreamer";
 export * from "./logger";
-export * from "./conversations/MongoDbConversations";
+export * from "./makeClassifier";
 export * from "./References";
 export * from "./VectorStore";
 export * from "./arrayFilters";

--- a/packages/mongodb-rag-core/src/makeClassifier.test.ts
+++ b/packages/mongodb-rag-core/src/makeClassifier.test.ts
@@ -1,9 +1,6 @@
-import {
-  AzureKeyCredential,
-  CORE_OPENAI_CONNECTION_ENV_VARS,
-  OpenAIClient,
-  assertEnvVars,
-} from "mongodb-rag-core";
+import { OpenAIClient, AzureKeyCredential } from "@azure/openai";
+import { assertEnvVars } from "./assertEnvVars";
+import { CORE_OPENAI_CONNECTION_ENV_VARS } from "./CoreEnvVars";
 import { Classification, makeClassifier } from "./makeClassifier";
 
 const { OPENAI_ENDPOINT, OPENAI_API_KEY } = assertEnvVars(

--- a/packages/mongodb-rag-core/src/makeClassifier.ts
+++ b/packages/mongodb-rag-core/src/makeClassifier.ts
@@ -1,8 +1,3 @@
-import "dotenv/config";
-import {
-  assertEnvVars,
-  CORE_OPENAI_CHAT_COMPLETION_ENV_VARS,
-} from "mongodb-rag-core";
 import {
   ChatRequestMessage,
   FunctionDefinition,
@@ -10,7 +5,8 @@ import {
 } from "@azure/openai";
 import { html, stripIndents } from "common-tags";
 import { z } from "zod";
-import { RunLogger } from "../runlogger";
+import { assertEnvVars } from "./assertEnvVars";
+import { CORE_OPENAI_CHAT_COMPLETION_ENV_VARS } from "./CoreEnvVars";
 
 export type Classifier = ({
   input,
@@ -62,12 +58,10 @@ export const Classification = z.object({
 
 export function makeClassifier({
   openAiClient,
-  logger,
   classificationTypes,
   chainOfThought = false,
 }: {
   openAiClient: OpenAIClient;
-  logger?: RunLogger;
 
   /**
    A list of valid classification types.
@@ -173,19 +167,6 @@ export function makeClassifier({
     const classification = Classification.parse(
       JSON.parse(response.functionCall.arguments)
     );
-
-    logger?.appendArtifact(
-      `chatTemplates/classifier-${Date.now()}.json`,
-      stripIndents`
-        <SystemMessage>
-          ${messages[0].content}
-        </SystemMessage>
-        <Classification>
-          ${JSON.stringify(classification)}
-        </Classification>
-      `
-    );
-
     return classification;
   };
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-466

## Changes

- move `makeClassifier`
-

## Notes

- note: in the jira issue, there was a note about including some general 'translate' or 'summarize' LLM functions, but i didn't see any generalizable implementations to include.
