### PR TITLE
fix exports for compiling to NodeNext

### DIFF
--- a/packages/mongodb-artifact-generator/src/withConfig.ts
+++ b/packages/mongodb-artifact-generator/src/withConfig.ts
@@ -14,7 +14,7 @@ export const loadConfig = async ({
     configPathIn === undefined ? "build/standardConfig.js" : configPathIn
   );
 
-  const partialConfig = (await import(path)).default as Partial<Config>;
+  const partialConfig = (await import(path)).default.default as Partial<Config>;
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-artifact-generator/src/withConfig.ts
+++ b/packages/mongodb-artifact-generator/src/withConfig.ts
@@ -16,7 +16,7 @@ export const loadConfig = async ({
 
   const maybePartialConfig = (await import(path)).default;
   const partialConfig = (maybePartialConfig?.default ??
-    maybePartialConfig.default) as Partial<Config>;
+    maybePartialConfig) as Partial<Config>;
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-artifact-generator/src/withConfig.ts
+++ b/packages/mongodb-artifact-generator/src/withConfig.ts
@@ -14,7 +14,9 @@ export const loadConfig = async ({
     configPathIn === undefined ? "build/standardConfig.js" : configPathIn
   );
 
-  const partialConfig = (await import(path)).default.default as Partial<Config>;
+  const maybePartialConfig = (await import(path)).default;
+  const partialConfig = (maybePartialConfig?.default ??
+    maybePartialConfig.default) as Partial<Config>;
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-chatbot-evaluation/src/withConfig.ts
+++ b/packages/mongodb-chatbot-evaluation/src/withConfig.ts
@@ -14,8 +14,9 @@ export const loadConfig = async ({
     configPathIn === undefined ? "eval.config.cjs" : configPathIn
   );
 
-  const partialConfigConstructor = (await import(path)).default
-    .default as () => Promise<Partial<EvalConfig>>;
+  const maybePartialConfigConstructor = (await import(path)).default;
+  const partialConfigConstructor = (maybePartialConfigConstructor.default ??
+    maybePartialConfigConstructor) as () => Promise<Partial<EvalConfig>>;
   const partialConfig = await partialConfigConstructor();
 
   const missingProperties: string[] = [];

--- a/packages/mongodb-chatbot-evaluation/src/withConfig.ts
+++ b/packages/mongodb-chatbot-evaluation/src/withConfig.ts
@@ -14,7 +14,7 @@ export const loadConfig = async ({
     configPathIn === undefined ? "eval.config.cjs" : configPathIn
   );
 
-  const partialConfigConstructor = (await import(path))
+  const partialConfigConstructor = (await import(path)).default
     .default as () => Promise<Partial<EvalConfig>>;
   const partialConfig = await partialConfigConstructor();
 

--- a/packages/mongodb-rag-ingest/src/withConfig.ts
+++ b/packages/mongodb-rag-ingest/src/withConfig.ts
@@ -14,7 +14,9 @@ export const loadConfig = async ({
     configPathIn === undefined ? "ingest.config.cjs" : configPathIn
   );
 
-  const partialConfig = (await import(path)).default.default as Partial<Config>;
+  const maybePartialConfig = (await import(path)).default;
+  const partialConfig = (maybePartialConfig?.default ??
+    maybePartialConfig.default) as Partial<Config>;
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-rag-ingest/src/withConfig.ts
+++ b/packages/mongodb-rag-ingest/src/withConfig.ts
@@ -13,8 +13,10 @@ export const loadConfig = async ({
   const path = Path.resolve(
     configPathIn === undefined ? "ingest.config.cjs" : configPathIn
   );
+  console.log(path);
 
-  const partialConfig = (await import(path)).default as Partial<Config>;
+  const partialConfig = (await import(path)).default.default as Partial<Config>;
+  console.log(partialConfig);
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-rag-ingest/src/withConfig.ts
+++ b/packages/mongodb-rag-ingest/src/withConfig.ts
@@ -13,10 +13,8 @@ export const loadConfig = async ({
   const path = Path.resolve(
     configPathIn === undefined ? "ingest.config.cjs" : configPathIn
   );
-  console.log(path);
 
   const partialConfig = (await import(path)).default.default as Partial<Config>;
-  console.log(partialConfig);
 
   const missingProperties: string[] = [];
   const config: Config = {

--- a/packages/mongodb-rag-ingest/src/withConfig.ts
+++ b/packages/mongodb-rag-ingest/src/withConfig.ts
@@ -15,8 +15,8 @@ export const loadConfig = async ({
   );
 
   const maybePartialConfig = (await import(path)).default;
-  const partialConfig = (maybePartialConfig?.default ??
-    maybePartialConfig.default) as Partial<Config>;
+  const partialConfig = (maybePartialConfig.default ??
+    maybePartialConfig) as Partial<Config>;
 
   const missingProperties: string[] = [];
   const config: Config = {


### PR DESCRIPTION
Jira: n/a

## Changes

- now that we're compiling to `NodeNext`, we need to change how we import in the CLI w/ config packages. 
  - fixes bug introduced in https://github.com/mongodb/chatbot/pull/548
-

## Notes

- noticed in #543 
