### PR TITLE
(EAI-619) [UI] Make invalid stream event types a no-op

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30647,11 +30647,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/mocksse": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "dev": true,
@@ -44949,7 +44944,6 @@
         "eslint-plugin-react-refresh": "^0.3.4",
         "eslint-plugin-storybook": "^0.6.12",
         "jsdom": "^22.1.0",
-        "mocksse": "^1.0.4",
         "node-stdlib-browser": "^1.2.0",
         "postcss": "^8.4.27",
         "prop-types": "^15.8.1",

--- a/packages/mongodb-chatbot-ui/package.json
+++ b/packages/mongodb-chatbot-ui/package.json
@@ -137,7 +137,6 @@
     "eslint-plugin-react-refresh": "^0.3.4",
     "eslint-plugin-storybook": "^0.6.12",
     "jsdom": "^22.1.0",
-    "mocksse": "^1.0.4",
     "node-stdlib-browser": "^1.2.0",
     "postcss": "^8.4.27",
     "prop-types": "^15.8.1",

--- a/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
@@ -7,6 +7,7 @@ import {
   DeltaStreamEvent,
   MetadataStreamEvent,
   ReferencesStreamEvent,
+  UnknownStreamEvent,
   getCustomRequestOrigin,
 } from "./conversations";
 import { type References } from "mongodb-rag-core";
@@ -277,6 +278,110 @@ describe("ConversationService", () => {
         "metadata"
       )
     );
+    expect(finishedStreaming).toEqual(true);
+  });
+
+  it("gracefully handles unknown stream event types", async () => {
+    const conversationId = "650b4b260f975ef031016c8d";
+    type PotentiallyUnknownStreamEvent =
+      | ConversationStreamEvent
+      | UnknownStreamEvent;
+    const mockedEvents =
+      mockFetchEventSourceResponse<PotentiallyUnknownStreamEvent>(
+        {
+          id: undefined,
+          type: undefined,
+          data: { type: "unknown", data: "Hello world!" },
+        },
+        {
+          id: undefined,
+          type: undefined,
+          data: {
+            type: "delta",
+            data: "Once upon a time there was a very long string.",
+          },
+        },
+        {
+          id: undefined,
+          type: undefined,
+          data: { type: "unknown", data: null },
+        },
+        {
+          id: undefined,
+          type: undefined,
+          data: {
+            type: "references",
+            data: [
+              { title: "Title 1", url: "https://example.com/1" },
+              { title: "Title 2", url: "https://example.com/2" },
+            ],
+          },
+        },
+        {
+          id: undefined,
+          type: undefined,
+          data: { type: "unknown", data: 42 },
+        },
+        {
+          id: undefined,
+          type: undefined,
+          data: { type: "finished", data: "650b4be0d5a57dd66be2ccb9" },
+        }
+      );
+
+    const deltas: string[] = [];
+    const references: References[] = [];
+    const metadatas: AssistantMessageMetadata[] = [];
+    let streamedMessageId: string | undefined;
+    let finishedStreaming = false;
+    await conversationService.addMessageStreaming({
+      conversationId,
+      message: "Hello world!",
+      maxRetries: 0,
+      onResponseDelta: async (data: string) => {
+        console.log("onResponseDelta", data);
+        deltas.push(data);
+      },
+      onResponseFinished: async (messageId: string) => {
+        console.log("onResponseFinished", messageId);
+        streamedMessageId = messageId;
+        finishedStreaming = true;
+      },
+      onReferences: async (refs) => {
+        console.log("onReferences", refs);
+        references.push(refs);
+      },
+      onMetadata: async (metadata) => {
+        console.log("onMetadata", metadata);
+        metadatas.push(metadata);
+      },
+    });
+
+    const filterableMockedEvents =
+      mockedEvents as FetchEventSource.MockEvent<ConversationStreamEvent>[];
+
+    expect(deltas).toEqual(
+      filterMockedConversationEventsData<DeltaStreamEvent>(
+        filterableMockedEvents,
+        "delta"
+      )
+    );
+
+    expect(references).toEqual(
+      filterMockedConversationEventsData<ReferencesStreamEvent>(
+        filterableMockedEvents,
+        "references"
+      )
+    );
+
+    expect(metadatas).toEqual(
+      filterMockedConversationEventsData<MetadataStreamEvent>(
+        filterableMockedEvents,
+        "metadata"
+      )
+    );
+
+    expect(streamedMessageId).toEqual("650b4be0d5a57dd66be2ccb9");
     expect(finishedStreaming).toEqual(true);
   });
 

--- a/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
@@ -291,7 +291,7 @@ describe("ConversationService", () => {
         {
           id: undefined,
           type: undefined,
-          data: { type: "unknown", data: "Hello world!" },
+          data: { type: "unknown123", data: "Hello world!" },
         },
         {
           id: undefined,
@@ -304,7 +304,7 @@ describe("ConversationService", () => {
         {
           id: undefined,
           type: undefined,
-          data: { type: "unknown", data: null },
+          data: { type: "unknownABC", data: null },
         },
         {
           id: undefined,

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -299,7 +299,6 @@ export class ConversationService {
 
       onmessage(ev) {
         const event = JSON.parse(ev.data);
-        console.log("onmessage", event);
         if (!isSomeStreamEvent(event)) {
           if (!isProductionBuild()) {
             console.error(

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -2,6 +2,7 @@ import { fetchEventSource } from "@microsoft/fetch-event-source";
 import { References, VerifiedAnswer } from "mongodb-rag-core";
 import { ConversationState } from "../useConversation";
 import { strict as assert } from "node:assert";
+import { isProductionBuild } from "../utils";
 
 export type Role = "user" | "assistant";
 
@@ -66,6 +67,13 @@ export class TimeoutError<Data extends object = object> extends Error {
   }
 }
 
+export type UnknownStreamEvent = { type: string; data: unknown };
+
+function isSomeStreamEvent(event: object): event is UnknownStreamEvent {
+  const e = event as UnknownStreamEvent;
+  return typeof e.type === "string" && typeof e.data !== "undefined";
+}
+
 export type DeltaStreamEvent = { type: "delta"; data: string };
 export type ReferencesStreamEvent = { type: "references"; data: References };
 export type MetadataStreamEvent = {
@@ -79,6 +87,29 @@ export type ConversationStreamEvent =
   | ReferencesStreamEvent
   | MetadataStreamEvent
   | FinishedStreamEvent;
+
+const isConversationStreamEventType = (
+  type: string
+): type is ConversationStreamEvent["type"] => {
+  return (
+    type === "delta" ||
+    type === "references" ||
+    type === "metadata" ||
+    type === "finished"
+  );
+};
+
+const isConversationStreamEvent = (
+  event: object
+): event is ConversationStreamEvent => {
+  const e = event as ConversationStreamEvent;
+  return (
+    (e.type === "delta" && typeof e.data === "string") ||
+    (e.type === "references" && typeof e.data === "object") ||
+    (e.type === "metadata" && typeof e.data === "object") ||
+    (e.type === "finished" && typeof e.data === "string")
+  );
+};
 
 /**
   Options to include with every fetch request made by the ConversationService.
@@ -257,18 +288,6 @@ export class ConversationService {
     let retryCount = 0;
     let moreToStream = true;
 
-    const isConversationStreamEvent = (
-      event: object
-    ): event is ConversationStreamEvent => {
-      const e = event as ConversationStreamEvent;
-      return (
-        (e.type === "delta" && typeof e.data === "string") ||
-        (e.type === "references" && typeof e.data === "object") ||
-        (e.type === "metadata" && typeof e.data === "object") ||
-        (e.type === "finished" && typeof e.data === "string")
-      );
-    };
-
     await fetchEventSource(this.getUrl(path, { stream: "true" }), {
       ...this.fetchOptions,
       // Need to convert Headers to plain object for fetchEventSource
@@ -280,8 +299,28 @@ export class ConversationService {
 
       onmessage(ev) {
         const event = JSON.parse(ev.data);
+        console.log("onmessage", event);
+        if (!isSomeStreamEvent(event)) {
+          if (!isProductionBuild()) {
+            console.error(
+              `Received an unknown event: ${JSON.stringify(event)}`
+            );
+          }
+          return;
+        }
+        if (!isConversationStreamEventType(event.type)) {
+          if (!isProductionBuild()) {
+            console.error(`Received an unknown event type: ${event.type}`);
+          }
+          return;
+        }
         if (!isConversationStreamEvent(event)) {
-          throw new Error(`Invalid event received from server: ${ev.data}`);
+          if (!isProductionBuild()) {
+            console.error(
+              `Received an invalid conversation event: ${JSON.stringify(event)}`
+            );
+          }
+          return;
         }
         switch (event.type) {
           case "delta": {

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -12,6 +12,7 @@ import {
   removeArrayElementAt,
   updateArrayElementAt,
   canUseServerSentEvents,
+  isProductionBuild,
 } from "./utils";
 import { makePrioritizeCurrentMongoDbReferenceDomain } from "./messageLinks";
 import { SortReferences } from "./sortReferences";
@@ -398,7 +399,7 @@ export function useConversation(params: UseConversationParams) {
     defaultConversationState
   );
   const dispatch = (...args: Parameters<typeof _dispatch>) => {
-    if (import.meta.env.MODE !== "production") {
+    if (!isProductionBuild()) {
       console.log(`dispatch`, ...args);
     }
     _dispatch(...args);

--- a/packages/mongodb-chatbot-ui/src/utils.ts
+++ b/packages/mongodb-chatbot-ui/src/utils.ts
@@ -149,3 +149,7 @@ export type DeepPartial<T> = {
     ? DeepPartial<T[P]>
     : T[P];
 };
+
+export function isProductionBuild() {
+  return import.meta.env.MODE === "production";
+}


### PR DESCRIPTION
Jira: (EAI-619) [UI] Make invalid stream event types a no-op

## Changes

- We're now more relaxed if the server streams an SSE event that doesn't match our expectations. We used to throw, now we just log an error (in non-prod envs)
