### PR TITLE
Add braintrust to mongodb-rag-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,17 +27,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ai-sdk/provider": {
-      "version": "0.0.11",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/provider-utils": {
       "version": "1.0.9",
       "license": "Apache-2.0",
@@ -4314,7 +4303,9 @@
       "license": "MIT"
     },
     "node_modules/@braintrust/core": {
-      "version": "0.0.69",
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@braintrust/core/-/core-0.0.70.tgz",
+      "integrity": "sha512-5Zei4Rd8mWcuLBUC1p96Bi3x2YaYdrmd5fws5gC2qgnUSdEo2Xy5+IaJe2gUTWd/R01HhAtjBnRZ5j80s8Hmag==",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^6.3.1",
@@ -4485,6 +4476,70 @@
         "node": ">=16"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.18.20",
       "cpu": [
@@ -4494,6 +4549,278 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -19696,11 +20023,13 @@
       }
     },
     "node_modules/braintrust": {
-      "version": "0.0.175",
+      "version": "0.0.176",
+      "resolved": "https://registry.npmjs.org/braintrust/-/braintrust-0.0.176.tgz",
+      "integrity": "sha512-yD4UNcDbftUiDAhUFFwlPutTVxBbV1+e+kqk6i33Db3f7EqX6GlgITaBRtzCSdOHVt5znJna7jNOQU0lnZzQSg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^1.0.1",
-        "@braintrust/core": "0.0.69",
+        "@braintrust/core": "0.0.70",
         "@next/env": "^14.2.3",
         "@vercel/functions": "^1.0.2",
         "ai": "^3.2.16",
@@ -23263,6 +23592,70 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
       "version": "0.17.19",
       "cpu": [
@@ -23272,6 +23665,278 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -41711,7 +42376,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -41755,7 +42422,6 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.705.0",
         "@supercharge/promise-pool": "^3.2.0",
-        "braintrust": "^0.0.175",
         "dotenv": "^16",
         "mongodb-chatbot-server": "*",
         "mongodb-rag-core": "*",
@@ -42012,7 +42678,6 @@
         "@typescript-eslint/parser": "^5.58.0",
         "autoevals": "^0.0.92",
         "babel-jest": "^29.5.0",
-        "braintrust": "^0.0.167",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-jest": "^27.2.1",
@@ -42027,160 +42692,6 @@
       "engines": {
         "node": ">=18",
         "npm": ">=8"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.17",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.22",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
-      "version": "0.0.22",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/react": {
-      "version": "0.0.54",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.17",
-        "@ai-sdk/ui-utils": "0.0.40",
-        "swr": "2.2.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/solid": {
-      "version": "0.0.43",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.17",
-        "@ai-sdk/ui-utils": "0.0.40"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "solid-js": "^1.7.7"
-      },
-      "peerDependenciesMeta": {
-        "solid-js": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/svelte": {
-      "version": "0.0.45",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.17",
-        "@ai-sdk/ui-utils": "0.0.40",
-        "sswr": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "svelte": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "svelte": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.40",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.22",
-        "@ai-sdk/provider-utils": "1.0.17",
-        "json-schema": "0.4.0",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
-      "version": "0.0.22",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/@ai-sdk/vue": {
-      "version": "0.0.45",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.17",
-        "@ai-sdk/ui-utils": "0.0.40",
-        "swrv": "1.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "vue": "^3.3.4"
-      },
-      "peerDependenciesMeta": {
-        "vue": {
-          "optional": true
-        }
       }
     },
     "packages/chatbot-server-mongodb-public/node_modules/@braintrust/core": {
@@ -42199,65 +42710,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/ai": {
-      "version": "3.3.26",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.22",
-        "@ai-sdk/provider-utils": "1.0.17",
-        "@ai-sdk/react": "0.0.54",
-        "@ai-sdk/solid": "0.0.43",
-        "@ai-sdk/svelte": "0.0.45",
-        "@ai-sdk/ui-utils": "0.0.40",
-        "@ai-sdk/vue": "0.0.45",
-        "@opentelemetry/api": "1.9.0",
-        "eventsource-parser": "1.1.2",
-        "json-schema": "0.4.0",
-        "jsondiffpatch": "0.6.0",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "openai": "^4.42.0",
-        "react": "^18 || ^19",
-        "sswr": "^2.1.0",
-        "svelte": "^3.0.0 || ^4.0.0",
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "openai": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "sswr": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "0.0.22",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/chatbot-server-mongodb-public/node_modules/ajv": {
@@ -42315,103 +42767,10 @@
         "openai": "bin/cli"
       }
     },
-    "packages/chatbot-server-mongodb-public/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/braintrust": {
-      "version": "0.0.167",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ai-sdk/provider": "^0.0.11",
-        "@braintrust/core": "0.0.63",
-        "@next/env": "^14.2.3",
-        "@vercel/functions": "^1.0.2",
-        "ai": "^3.2.16",
-        "argparse": "^2.0.1",
-        "chalk": "^4.1.2",
-        "cli-progress": "^3.12.0",
-        "dotenv": "^16.4.5",
-        "esbuild": "^0.18.20",
-        "eventsource-parser": "^1.1.2",
-        "graceful-fs": "^4.2.11",
-        "minimatch": "^9.0.3",
-        "mustache": "^4.2.0",
-        "pluralize": "^8.0.0",
-        "simple-git": "^3.21.0",
-        "slugify": "^1.6.6",
-        "source-map": "^0.7.4",
-        "uuid": "^9.0.1",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.5"
-      },
-      "bin": {
-        "braintrust": "dist/cli.js"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/braintrust/node_modules/@braintrust/core": {
-      "version": "0.0.63",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asteasolutions/zod-to-openapi": "^6.3.1",
-        "uuid": "^9.0.1",
-        "zod": "^3.22.4"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
     "packages/chatbot-server-mongodb-public/node_modules/form-data-encoder": {
       "version": "1.7.2",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "dev": true,
-      "license": "ISC"
     },
     "packages/chatbot-server-mongodb-public/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -42428,72 +42787,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/nanoid": {
-      "version": "3.3.6",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/openai": {
-      "version": "4.56.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/chatbot-server-mongodb-public/node_modules/source-map": {
-      "version": "0.7.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "packages/ingest-mongodb-public": {
       "version": "0.9.0",
@@ -44387,6 +44680,7 @@
         "@supercharge/promise-pool": "^3.2.0",
         "acquit": "^1.3.0",
         "acquit-require": "^0.1.1",
+        "braintrust": "^0.0.176",
         "common-tags": "^1",
         "deep-equal": "^2.2.3",
         "dotenv": "^16.3.1",
@@ -45426,6 +45720,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "packages/mongodb-rag-core/node_modules/zod-to-json-schema": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
+      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "packages/mongodb-rag-ingest": {

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.705.0",
     "@supercharge/promise-pool": "^3.2.0",
-    "braintrust": "^0.0.175",
     "dotenv": "^16",
     "mongodb-chatbot-server": "*",
     "mongodb-rag-core": "*",

--- a/packages/benchmarks/src/discovery/DiscoveryEval.ts
+++ b/packages/benchmarks/src/discovery/DiscoveryEval.ts
@@ -1,5 +1,10 @@
 import { strict as assert } from "assert";
-import { Eval, EvalCase, EvalScorer, EvalTask } from "braintrust";
+import {
+  Eval,
+  EvalCase,
+  EvalScorer,
+  EvalTask,
+} from "mongodb-rag-core/braintrust";
 import { OpenAI } from "mongodb-rag-core/openai";
 import fs from "fs";
 import { getConversationsEvalCasesFromYaml } from "mongodb-rag-core/eval";

--- a/packages/benchmarks/src/makeOpenAiClientFactory.ts
+++ b/packages/benchmarks/src/makeOpenAiClientFactory.ts
@@ -6,7 +6,7 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 import { ModelConfig } from "./models";
 import { strict as assert } from "assert";
-import { wrapOpenAI, wrapTraced } from "braintrust";
+import { wrapOpenAI, wrapTraced } from "mongodb-rag-core/braintrust";
 interface BaseModelProviderConfig {
   apiKey: string;
   endpoint: string;

--- a/packages/benchmarks/src/quizQuestions/QuizQuestionEval.ts
+++ b/packages/benchmarks/src/quizQuestions/QuizQuestionEval.ts
@@ -1,4 +1,9 @@
-import { Eval, EvalCase, EvalScorer, EvalTask } from "braintrust";
+import {
+  Eval,
+  EvalCase,
+  EvalScorer,
+  EvalTask,
+} from "mongodb-rag-core/braintrust";
 import { OpenAI } from "mongodb-rag-core/openai";
 import { QuizQuestionData } from "./QuizQuestionData";
 import { strict as assert } from "assert";

--- a/packages/benchmarks/src/quizQuestions/getQuizQuestionEvalCasesFromBraintrust.ts
+++ b/packages/benchmarks/src/quizQuestions/getQuizQuestionEvalCasesFromBraintrust.ts
@@ -1,4 +1,4 @@
-import { initDataset } from "braintrust";
+import { initDataset } from "mongodb-rag-core/braintrust";
 import { QuizQuestionDataSchema } from "./QuizQuestionData";
 import { z } from "zod";
 import { QuizQuestionEvalCase } from "./QuizQuestionEval";

--- a/packages/chatbot-server-mongodb-public/package.json
+++ b/packages/chatbot-server-mongodb-public/package.json
@@ -50,7 +50,6 @@
     "@typescript-eslint/parser": "^5.58.0",
     "autoevals": "^0.0.92",
     "babel-jest": "^29.5.0",
-    "braintrust": "^0.0.167",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-jest": "^27.2.1",

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -28,7 +28,7 @@ import { systemPrompt } from "./systemPrompt";
 import { addReferenceSourceType } from "./processors/makeMongoDbReferences";
 import path from "path";
 import express from "express";
-import { wrapOpenAI, wrapTraced } from "braintrust";
+import { wrapOpenAI, wrapTraced } from "mongodb-rag-core/braintrust";
 import { AzureOpenAI } from "mongodb-rag-core/openai";
 import { MongoClient } from "mongodb-rag-core/mongodb";
 export const {

--- a/packages/chatbot-server-mongodb-public/src/conversations.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/conversations.eval.ts
@@ -1,4 +1,9 @@
-import { Eval, EvalCase, traced, EvalScorer } from "braintrust";
+import {
+  Eval,
+  EvalCase,
+  traced,
+  EvalScorer,
+} from "mongodb-rag-core/braintrust";
 import { getConversationsEvalCasesFromYaml } from "mongodb-rag-core/eval";
 import { MongoDbTag } from "./mongoDbMetadata";
 import { config, conversations } from "./config";

--- a/packages/chatbot-server-mongodb-public/src/processors/retrieveRelevantContent.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/retrieveRelevantContent.eval.ts
@@ -1,5 +1,10 @@
 import "dotenv/config";
-import { Eval, EvalCase, EvalScorer, EvalTask } from "braintrust";
+import {
+  Eval,
+  EvalCase,
+  EvalScorer,
+  EvalTask,
+} from "mongodb-rag-core/braintrust";
 import fs from "fs";
 import path from "path";
 import { strict as assert } from "assert";

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
@@ -30,6 +30,7 @@ import { GenerateUserPromptFunc } from "../../processors/GenerateUserPromptFunc"
 import { FilterPreviousMessages } from "../../processors/FilterPreviousMessages";
 import { filterOnlySystemPrompt } from "../../processors/filterOnlySystemPrompt";
 import { generateResponse } from "../generateResponse";
+
 export const DEFAULT_MAX_INPUT_LENGTH = 3000; // magic number for max input size for LLM
 export const DEFAULT_MAX_USER_MESSAGES_IN_CONVERSATION = 7; // magic number for max messages in a conversation
 

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
@@ -30,7 +30,6 @@ import { GenerateUserPromptFunc } from "../../processors/GenerateUserPromptFunc"
 import { FilterPreviousMessages } from "../../processors/FilterPreviousMessages";
 import { filterOnlySystemPrompt } from "../../processors/filterOnlySystemPrompt";
 import { generateResponse } from "../generateResponse";
-
 export const DEFAULT_MAX_INPUT_LENGTH = 3000; // magic number for max input size for LLM
 export const DEFAULT_MAX_USER_MESSAGES_IN_CONVERSATION = 7; // magic number for max messages in a conversation
 

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -30,6 +30,7 @@
     "./langchain": "./build/langchain.js",
     "./mongodb": "./build/mongodb.js",
     "./openai": "./build/openai.js",
+    "./braintrust": "./build/braintrust.js",
     "./dataSources": "./build/dataSources/index.js",
     "./eval": "./build/eval/index.js"
   },
@@ -79,6 +80,7 @@
     "@supercharge/promise-pool": "^3.2.0",
     "acquit": "^1.3.0",
     "acquit-require": "^0.1.1",
+    "braintrust": "^0.0.176",
     "common-tags": "^1",
     "deep-equal": "^2.2.3",
     "dotenv": "^16.3.1",

--- a/packages/mongodb-rag-core/src/braintrust.ts
+++ b/packages/mongodb-rag-core/src/braintrust.ts
@@ -1,0 +1,1 @@
+export * from "braintrust";


### PR DESCRIPTION
Jira: n/a

## Changes

- Add `braintrust` as dependency to mongodb-rag-core, and use throughout project. doing this b/c we will need to integrate it with `mongodb-chatbot-server` for observability. this'll make 3 packages dependent on the library, so easier to maintain if we keep dependency centralized to core. 
-

## Notes

-
