### PR TITLE
(EAI-614) add init action to ingest:pages and ingest:embed options

### DIFF
--- a/packages/ingest-mongodb-public/package.json
+++ b/packages/ingest-mongodb-public/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "license": "Apache-2.0",
   "keywords": [],
+  "main": "build/config.js",
   "engines": {
     "node": ">=18",
     "npm": ">=8"
@@ -18,8 +19,8 @@
     "lint:fix": "npm run lint -- --fix && prettier ./src --check --write",
     "ingest:all": "ingest all --config ./build/config.js",
     "ingest:k8s": "../../node_modules/mongodb-rag-ingest/build/main.js all --config ./build/config.js",
-    "ingest:pages": "ingest pages update --config ./build/config.js",
-    "ingest:embed": "ingest embed update --config ./build/config.js",
+    "ingest:pages": "ingest pages --config ./build/config.js",
+    "ingest:embed": "ingest embed --config ./build/config.js",
     "ingest:pages:meta": "ingest pages update --config ./build/meta.config.js",
     "ingest:k8s:coachGtmPages": "../../node_modules/mongodb-rag-ingest/build/main.js pages update --config ./build/coachGtm.config.js",
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --forceExit"

--- a/packages/ingest-mongodb-public/package.json
+++ b/packages/ingest-mongodb-public/package.json
@@ -18,8 +18,8 @@
     "lint:fix": "npm run lint -- --fix && prettier ./src --check --write",
     "ingest:all": "ingest all --config ./build/config.js",
     "ingest:k8s": "../../node_modules/mongodb-rag-ingest/build/main.js all --config ./build/config.js",
-    "ingest:pages": "ingest pages --config ./build/config.js",
-    "ingest:embed": "ingest embed --config ./build/config.js",
+    "ingest:pages": "ingest pages init --config ./build/config.js && ingest pages update --config ./build/config.js",
+    "ingest:embed": "ingest embed init --config ./build/config.js && ingest embed update --config ./build/config.js",
     "ingest:pages:meta": "ingest pages update --config ./build/meta.config.js",
     "ingest:k8s:coachGtmPages": "../../node_modules/mongodb-rag-ingest/build/main.js pages update --config ./build/coachGtm.config.js",
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --forceExit"

--- a/packages/ingest-mongodb-public/package.json
+++ b/packages/ingest-mongodb-public/package.json
@@ -5,7 +5,6 @@
   "author": "",
   "license": "Apache-2.0",
   "keywords": [],
-  "main": "build/config.js",
   "engines": {
     "node": ">=18",
     "npm": ">=8"

--- a/packages/mongodb-rag-ingest/src/commands/embed.ts
+++ b/packages/mongodb-rag-ingest/src/commands/embed.ts
@@ -7,10 +7,7 @@ import {
 } from "../withConfig";
 import { logger, updateEmbeddedContent } from "mongodb-rag-core";
 
-const commandModule: CommandModule<
-  unknown,
-  LoadConfigArgs
-> = {
+const commandModule: CommandModule<unknown, LoadConfigArgs> = {
   command: "embed <action>",
   describe: "Manage embedded content",
   builder(args) {
@@ -18,8 +15,7 @@ const commandModule: CommandModule<
       .command({
         command: "init",
         describe: "Initialize embedded content store",
-        builder: (updateArgs) =>
-          withConfigOptions(updateArgs),
+        builder: (updateArgs) => withConfigOptions(updateArgs),
         handler: (updateArgs) => withConfig(doInitEmbedCommand, updateArgs),
       })
       .command({
@@ -56,8 +52,7 @@ const commandModule: CommandModule<
             description:
               "A source name to delete. If unspecified, deletes all sources.",
           }),
-        handler: (deleteArgs) =>
-          withConfig(doDeleteEmbedCommand, deleteArgs),
+        handler: (deleteArgs) => withConfig(doDeleteEmbedCommand, deleteArgs),
       });
   },
   handler: (_args) => {
@@ -67,7 +62,9 @@ const commandModule: CommandModule<
 
 export default commandModule;
 
-export const doInitEmbedCommand = async ({ embeddedContentStore }: ResolvedConfig) => {
+export const doInitEmbedCommand = async ({
+  embeddedContentStore,
+}: ResolvedConfig) => {
   if (!embeddedContentStore) {
     throw new Error(`Failed to initialize embedded content store.`);
   }
@@ -87,10 +84,7 @@ export const doUpdateEmbedCommand = async (
     chunkOptions,
     concurrencyOptions,
   }: ResolvedConfig,
-  {
-    since,
-    source,
-  }: UpdateEmbedCommandArgs
+  { since, source }: UpdateEmbedCommandArgs
 ) => {
   const sourceNames =
     source === undefined

--- a/packages/mongodb-rag-ingest/src/commands/embed.ts
+++ b/packages/mongodb-rag-ingest/src/commands/embed.ts
@@ -16,6 +16,13 @@ const commandModule: CommandModule<
   builder(args) {
     return args
       .command({
+        command: "init",
+        describe: "Initialize embedded content store",
+        builder: (updateArgs) =>
+          withConfigOptions(updateArgs),
+        handler: (updateArgs) => withConfig(doInitEmbedCommand, updateArgs),
+      })
+      .command({
         command: "update",
         describe: "Update embedded content data",
         builder: (updateArgs) =>
@@ -59,6 +66,12 @@ const commandModule: CommandModule<
 };
 
 export default commandModule;
+
+export const doInitEmbedCommand = async ({ embeddedContentStore }: ResolvedConfig) => {
+  if (embeddedContentStore) {
+    await embeddedContentStore?.init?.();
+  }
+};
 
 type UpdateEmbedCommandArgs = {
   since: Date;

--- a/packages/mongodb-rag-ingest/src/commands/embed.ts
+++ b/packages/mongodb-rag-ingest/src/commands/embed.ts
@@ -68,9 +68,10 @@ const commandModule: CommandModule<
 export default commandModule;
 
 export const doInitEmbedCommand = async ({ embeddedContentStore }: ResolvedConfig) => {
-  if (embeddedContentStore) {
-    await embeddedContentStore?.init?.();
+  if (!embeddedContentStore) {
+    throw new Error(`Failed to initialize embedded content store.`);
   }
+  await embeddedContentStore.init?.();
 };
 
 type UpdateEmbedCommandArgs = {

--- a/packages/mongodb-rag-ingest/src/commands/pages.ts
+++ b/packages/mongodb-rag-ingest/src/commands/pages.ts
@@ -12,6 +12,13 @@ const commandModule: CommandModule<
   builder(args) {
     return args
       .command({
+        command: "init",
+        describe: "Initialize page store",
+        builder: (updateArgs) =>
+          withConfigOptions(updateArgs),
+        handler: (updateArgs) => withConfig(doInitPagesCommand, updateArgs),
+      })
+      .command({
         command: "update",
         describe: "Update pages data from sources",
         builder: (updateArgs) =>
@@ -47,6 +54,12 @@ const commandModule: CommandModule<
 };
 
 export default commandModule;
+
+export const doInitPagesCommand = async ({ pageStore }: ResolvedConfig) => {
+  if (pageStore) {
+    await pageStore?.init?.();
+  }
+};
 
 type UpdatePagesCommandArgs = {
   source?: string | string[];

--- a/packages/mongodb-rag-ingest/src/commands/pages.ts
+++ b/packages/mongodb-rag-ingest/src/commands/pages.ts
@@ -56,9 +56,10 @@ const commandModule: CommandModule<
 export default commandModule;
 
 export const doInitPagesCommand = async ({ pageStore }: ResolvedConfig) => {
-  if (pageStore) {
-    await pageStore?.init?.();
+  if (!pageStore) {
+    throw new Error(`Failed to initialize page store.`);
   }
+  await pageStore.init?.();
 };
 
 type UpdatePagesCommandArgs = {

--- a/packages/mongodb-rag-ingest/src/commands/pages.ts
+++ b/packages/mongodb-rag-ingest/src/commands/pages.ts
@@ -3,10 +3,7 @@ import { logger, updatePages } from "mongodb-rag-core";
 import { LoadConfigArgs } from "../withConfig";
 import { withConfig, withConfigOptions, ResolvedConfig } from "../withConfig";
 
-const commandModule: CommandModule<
-  Record<string, unknown>,
-  LoadConfigArgs
-> = {
+const commandModule: CommandModule<Record<string, unknown>, LoadConfigArgs> = {
   command: "pages <action>",
   describe: "Manage pages data from sources",
   builder(args) {
@@ -14,8 +11,7 @@ const commandModule: CommandModule<
       .command({
         command: "init",
         describe: "Initialize page store",
-        builder: (updateArgs) =>
-          withConfigOptions(updateArgs),
+        builder: (updateArgs) => withConfigOptions(updateArgs),
         handler: (updateArgs) => withConfig(doInitPagesCommand, updateArgs),
       })
       .command({

--- a/packages/mongodb-rag-ingest/src/withConfig.ts
+++ b/packages/mongodb-rag-ingest/src/withConfig.ts
@@ -66,12 +66,6 @@ export const withConfig = async <T>(
   const config = await loadConfig(args);
   const [resolvedConfig, cleanup] = await resolveConfig(config);
   try {
-    // TODO: after merge of EAI-482, create separate commands for the init() calls.
-    // e.g. `ingest pages init` and `ingest embed init`
-    // will make sense after that PR b/c that refactors current `pages` and `embed`
-    // commands to have sub-actions, e.g. `pages update` and `pages delete`
-    await resolvedConfig?.embeddedContentStore?.init?.();
-    await resolvedConfig?.pageStore?.init?.();
     return await action(resolvedConfig, args);
   } finally {
     await Promise.all(


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-614

## Changes

- init added to ingest:pages
- init added to ingest:embed
- init calls removed from withConfig function

## Notes

- I modified the npm commands for `ingest:pages` and `ingest:embed` to be able to run this locally. I can remove this, but leaving it in for now so that I remember to address it. It might make sense to set up `ingest:<pages|embed>:update` if we need a one liner for the update action, and have `ingest:<pages|embed>` set up to accept actions. I could use some context on when these commands are called before making that decision. 
