### PR TITLE
(EAI-158): more descriptive logging for update pages command

### DIFF
--- a/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
@@ -15,7 +15,7 @@ export const getChangedPages = async ({
   // prior deletion
   oldPages: Omit<PersistedPage, "updated">[];
   newPages: Page[];
-  sourceName: string;
+  sourceName?: string;
 }): Promise<{
   deleted: PersistedPage[];
   created: PersistedPage[];

--- a/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
@@ -23,12 +23,12 @@ export const getChangedPages = async ({
   const newPages = new Map(newPagesIn.map((page) => [page.url, page]));
 
   logger.info(
-    `After de-duplication based on page URL, there are ${oldPages.size} pages currently in the store and ${newPages.size} pages from the data source(s) to be processed.`
+    `After de-duplication based on page URL, there are ${oldPages.size} pages currently in the store and ${newPages.size} pages from the data source to be processed.`
   );
 
   // Perform set difference to find deleted, created, and changed pages.
   logger.info(
-    "Comparing pages currently in the store against pages from the data source(s) to determine which pages need to be created, updated, or deleted..."
+    "Comparing pages currently in the store against pages from the data source to determine which pages need to be created, updated, or deleted..."
   );
   // deleted = elements in old but not in new
   const deleted = [...oldPages]

--- a/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
@@ -23,11 +23,13 @@ export const getChangedPages = async ({
   const newPages = new Map(newPagesIn.map((page) => [page.url, page]));
 
   logger.info(
-    `After de-duplication based on page URL, have ${oldPages.size} unique old / ${newPages.size} unique new pages`
+    `After de-duplication based on page URL, there are ${oldPages.size} pages currently in the store and ${newPages.size} pages from the data source(s) to be processed.`
   );
 
   // Perform set difference to find deleted, created, and changed pages.
-
+  logger.info(
+    "Comparing pages currently in the store against pages from the data source(s) to determine which pages need to be created, updated, or deleted..."
+  );
   // deleted = elements in old but not in new
   const deleted = [...oldPages]
     .filter(([url, { action }]) => {
@@ -64,7 +66,7 @@ export const getChangedPages = async ({
       })
     );
 
-  // updated = elements in both old and new
+  // updated = elements in both old and new (that have the same url, but different content)
   const updated = [...newPages]
     .filter(([url, page]) => {
       const oldPage = oldPages.get(url);

--- a/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/getChangedPages.ts
@@ -9,11 +9,13 @@ import { PersistedPage, Page } from "./Page";
 export const getChangedPages = async ({
   oldPages: oldPagesIn,
   newPages: newPagesIn,
+  sourceName,
 }: {
   // Need to know the 'action' of the old pages in order to restore in case of
   // prior deletion
   oldPages: Omit<PersistedPage, "updated">[];
   newPages: Page[];
+  sourceName: string;
 }): Promise<{
   deleted: PersistedPage[];
   created: PersistedPage[];
@@ -23,12 +25,12 @@ export const getChangedPages = async ({
   const newPages = new Map(newPagesIn.map((page) => [page.url, page]));
 
   logger.info(
-    `After de-duplication based on page URL, there are ${oldPages.size} pages currently in the store and ${newPages.size} pages from the data source to be processed.`
+    `After de-duplication based on page URL, there are ${oldPages.size} pages currently in the store and ${newPages.size} pages from the data source ${sourceName} to be processed.`
   );
 
   // Perform set difference to find deleted, created, and changed pages.
   logger.info(
-    "Comparing pages currently in the store against pages from the data source to determine which pages need to be created, updated, or deleted..."
+    `Comparing pages currently in the store against pages from the data source ${sourceName} to determine which pages need to be created, updated, or deleted...`
   );
   // deleted = elements in old but not in new
   const deleted = [...oldPages]

--- a/packages/mongodb-rag-core/src/contentStore/updatePages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/updatePages.ts
@@ -62,6 +62,7 @@ export const persistPages = async ({
   const { created, updated, deleted } = await getChangedPages({
     oldPages,
     newPages: pages,
+    sourceName,
   });
 
   logger.info(

--- a/packages/mongodb-rag-core/src/contentStore/updatePages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/updatePages.ts
@@ -29,7 +29,7 @@ export const updatePages = async ({
     .process(async (source, index, pool) => {
       logger.info(`Fetching pages for ${source.name}`);
       const pages = await source.fetchPages();
-      logger.info(`${source.name} returned ${pages.length} pages`);
+      logger.info(`${source.name} returned ${pages.length} pages to process`);
       if (pages.length === 0) {
         // If a flaky data source returns no pages, we would mark all pages in
         // that source as deleted. This is probably not wanted.
@@ -58,8 +58,7 @@ export const persistPages = async ({
   sourceName: string;
 }): Promise<void> => {
   const oldPages = await store.loadPages({ sources: [sourceName] });
-  logger.info(`${sourceName} had ${oldPages.length} in the store`);
-
+  logger.info(`${sourceName} had ${oldPages.length} in the store already`);
   const { created, updated, deleted } = await getChangedPages({
     oldPages,
     newPages: pages,

--- a/packages/mongodb-rag-core/src/contentStore/updatePages.ts
+++ b/packages/mongodb-rag-core/src/contentStore/updatePages.ts
@@ -65,7 +65,7 @@ export const persistPages = async ({
   });
 
   logger.info(
-    `${deleted.length} deleted / ${created.length} created / ${updated.length} updated`
+    `${sourceName}: ${deleted.length} deleted / ${created.length} created / ${updated.length} updated`
   );
   await store.updatePages([...deleted, ...created, ...updated]);
 };


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-158

## Changes

- modified `logger.info` copy to provide a more descriptive message
- no code changes, works as intended

## Notes

- this works as expected; I believe it looked buggy because the phrasing of the log message was unclear. 

From the JIRA ticket: 
 > example of result that doesn't particularly make sense: 

```

{"level":"info","message":"wired-tiger had 159 in the store"}

{"level":"info","message":"After de-duplication based on page URL, have 159 unique old / 159 unique new pages"}

{"level":"info","message":"0 deleted / 0 created / 0 updated"}

```

> why  both 159 unique old and 159 unique new, for example? 

This is accurate. There were 159 documents in the store for `wired-tiger` before running the update. The data source `wired-tiger` has 159 urls to be processed. Since the numbers match, there are none to be created (none that were in the data source, but not yet in the store), none to be deleted (none that were in the store but had been removed from the data source). There were also none to be updated (none that had the same url but different content in the the other fields). 


This is what the logs will look like now when there are no changes to be made:
```
{"level":"info","message":"Loaded sources:\n- mongodb-university"}
{"level":"info","message":"Fetching pages for mongodb-university"}
{"level":"info","message":"mongodb-university returned 370 pages to process"}
{"level":"info","message":"mongodb-university had 370 in the store already"}
{"level":"info","message":"After de-duplication based on page URL, there are 370 pages currently in the store and 370 pages from the data source(s) to be processed."}
{"level":"info","message":"Comparing pages currently in the store against pages from the data source(s) to determine which pages need to be created, updated, or deleted..."}
{"level":"info","message":"0 deleted / 0 created / 0 updated"}
```

This is what the logs will look like after permanently deleting a data source's pages:
```
{"level":"info","message":"Loaded sources:\n- mongodb-university"}
{"level":"info","message":"Fetching pages for mongodb-university"}
{"level":"info","message":"mongodb-university returned 370 pages to process"}
{"level":"info","message":"mongodb-university had 0 in the store already"}
{"level":"info","message":"After de-duplication based on page URL, there are 0 pages currently in the store and 370 pages from the data source(s) to be processed."}
{"level":"info","message":"Comparing pages currently in the store against pages from the data source(s) to determine which pages need to be created, updated, or deleted..."}
{"level":"info","message":"0 deleted / 370 created / 0 updated"}
```

This is what the logs will look like after a soft delete (marked deleted, but not removed from store). This may be confusing as it looks like there were 370 in the store already, 370 to process, and we end with 370 created, but the `getChangedPages` function specifically looks for pages with `action=='deleted'` that also appear in pages to process and marks them as `created`.
```
{"level":"info","message":"Loaded sources:\n- mongodb-university"}
{"level":"info","message":"Fetching pages for mongodb-university"}
{"level":"info","message":"mongodb-university returned 370 pages to process"}
{"level":"info","message":"mongodb-university had 370 in the store already"}
{"level":"info","message":"After de-duplication based on page URL, there are 370 pages currently in the store and 370 pages from the data source(s) to be processed."}
{"level":"info","message":"Comparing pages currently in the store against pages from the data source(s) to determine which pages need to be created, updated, or deleted..."}
{"level":"info","message":"0 deleted / 370 created / 0 updated"}
``` 

