### PR TITLE
Remove mongodb-rag-core from UI package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2236,117 +2236,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@azure-rest/core-client": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.5.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/abort-controller": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-auth": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-sse": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/openai": {
-      "version": "1.0.0-beta.11",
-      "license": "MIT",
-      "dependencies": {
-        "@azure-rest/core-client": "^1.1.7",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.13.0",
-        "@azure/core-sse": "^2.0.0",
-        "@azure/core-util": "^1.4.0",
-        "@azure/logger": "^1.0.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
       "license": "MIT",
@@ -17320,6 +17209,7 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -17956,14 +17846,6 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -18729,6 +18611,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -20088,7 +19971,8 @@
     },
     "node_modules/bson": {
       "version": "6.10.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -25673,6 +25557,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -25723,6 +25608,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -30690,42 +30576,6 @@
       "resolved": "packages/mongodb-chatbot-verified-answers",
       "link": true
     },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/punycode": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mongodb-memory-server": {
       "version": "10.1.2",
       "dev": true,
@@ -30874,14 +30724,6 @@
       "version": "2.0.1",
       "license": "Python-2.0",
       "optional": true
-    },
-    "node_modules/mongodb-schema/node_modules/bson": {
-      "version": "6.9.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=16.20.1"
-      }
     },
     "node_modules/mongodb-schema/node_modules/cliui": {
       "version": "8.0.1",
@@ -39711,21 +39553,6 @@
       "version": "2.0.2",
       "license": "MIT"
     },
-    "node_modules/typechat": {
-      "version": "0.0.10",
-      "license": "MIT",
-      "workspaces": [
-        "./",
-        "./examples/*"
-      ],
-      "dependencies": {
-        "axios": "^1.4.0",
-        "typescript": "^5.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",
       "license": "MIT",
@@ -39874,6 +39701,7 @@
     },
     "node_modules/typescript": {
       "version": "5.3.3",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -41819,14 +41647,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "packages/benchmarks/node_modules/bson": {
-      "version": "6.9.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
     "packages/benchmarks/node_modules/camelcase": {
       "version": "6.3.0",
       "dev": true,
@@ -42868,13 +42688,6 @@
         "@types/webidl-conversions": "*"
       }
     },
-    "packages/mongodb-atlas/node_modules/bson": {
-      "version": "6.3.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
     "packages/mongodb-atlas/node_modules/mongodb": {
       "version": "6.3.0",
       "license": "Apache-2.0",
@@ -43458,9 +43271,6 @@
     },
     "packages/mongodb-chatbot-ui": {
       "version": "0.10.2",
-      "bundleDependencies": [
-        "mongodb-rag-core"
-      ],
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",
@@ -43493,9 +43303,9 @@
         "@lg-chat/message-rating": "^2.0.2",
         "@lg-chat/rich-links": "^1.2.0",
         "@microsoft/fetch-event-source": "^2.0.1",
+        "bson": "^5.5.1",
         "buffer": "^6.0.3",
         "esbuild": "^0.17.19",
-        "mongodb-rag-core": "^0.0.5",
         "prettier": "^2.8.8",
         "react-markdown": "^8.0.7",
         "react-transition-group": "^4.4.5",
@@ -43625,7 +43435,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
       "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.20.1"
@@ -44074,74 +43883,6 @@
       ],
       "license": "MIT"
     },
-    "packages/mongodb-chatbot-ui/node_modules/mongodb": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
-      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
-      }
-    },
-    "packages/mongodb-chatbot-ui/node_modules/mongodb-rag-core": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mongodb-rag-core/-/mongodb-rag-core-0.0.5.tgz",
-      "integrity": "sha512-5H6SoZkz3nY8SS8dT6IhjJGmjDpJs0PwoQwVsl/hMB4cgANrDEWJ39WS819BqUIaQXfe9Cvw9x15BlKmEemRlg==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@azure/openai": "^1.0.0-beta.5",
-        "common-tags": "^1",
-        "dotenv": "^16.3.1",
-        "exponential-backoff": "^3.1.1",
-        "front-matter": "^4.0.2",
-        "gray-matter": "^4.0.3",
-        "mongodb": "^5.6.0",
-        "openai": "^3",
-        "toml": "^3.0.0",
-        "typechat": "^0.0.10",
-        "winston": "^3",
-        "yaml": "^2.3.1",
-        "zod": "^3.21.4"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=8"
-      }
-    },
     "packages/mongodb-chatbot-ui/node_modules/remark-parse": {
       "version": "11.0.0",
       "license": "MIT",
@@ -44243,19 +43984,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/mongodb-chatbot-ui/node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "packages/mongodb-chatbot-verified-answers": {
@@ -45496,16 +45224,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "packages/mongodb-rag-ingest/node_modules/bson": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.0.tgz",
-      "integrity": "sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
       }
     },
     "packages/mongodb-rag-ingest/node_modules/camelcase": {

--- a/packages/mongodb-chatbot-ui/package.json
+++ b/packages/mongodb-chatbot-ui/package.json
@@ -67,9 +67,6 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "bundleDependencies": [
-    "mongodb-rag-core"
-  ],
   "dependencies": {
     "@emotion/css": "^11.11.2",
     "@leafygreen-ui/badge": "^8.1.2",
@@ -101,9 +98,9 @@
     "@lg-chat/message-rating": "^2.0.2",
     "@lg-chat/rich-links": "^1.2.0",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "bson": "^5.5.1",
     "buffer": "^6.0.3",
     "esbuild": "^0.17.19",
-    "mongodb-rag-core": "^0.0.5",
     "prettier": "^2.8.8",
     "react-markdown": "^8.0.7",
     "react-transition-group": "^4.4.5",

--- a/packages/mongodb-chatbot-ui/src/App.tsx
+++ b/packages/mongodb-chatbot-ui/src/App.tsx
@@ -11,7 +11,7 @@ import { Chatbot } from "./Chatbot";
 import { DocsChatbot } from "./DocsChatbot";
 import { DevCenterChatbot } from "./DevCenterChatbot";
 import { HotkeyTrigger } from "./HotkeyTrigger";
-import { makePrioritizeReferenceDomain } from "./sortReferences";
+import { makePrioritizeReferenceDomain } from "./references";
 
 const prefersDarkMode = () =>
   window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;

--- a/packages/mongodb-chatbot-ui/src/ChatbotView.tsx
+++ b/packages/mongodb-chatbot-ui/src/ChatbotView.tsx
@@ -1,4 +1,4 @@
-import { References } from "mongodb-rag-core";
+import { References } from "./references";
 import { ChatMessageFeedProps } from "./ChatMessageFeed";
 import { DarkModeProps } from "./DarkMode";
 

--- a/packages/mongodb-chatbot-ui/src/DevCenterChatbot.tsx
+++ b/packages/mongodb-chatbot-ui/src/DevCenterChatbot.tsx
@@ -9,7 +9,7 @@ import { MongoDbLegalDisclosure } from "./MongoDbLegal";
 import { mongoDbVerifyInformationMessage } from "./ui-text";
 import { PoweredByAtlasVectorSearch } from "./PoweredByAtlasVectorSearch";
 import { css } from "@emotion/css";
-import { References } from "mongodb-rag-core";
+import { References } from "./references";
 
 export type DevCenterChatbotProps = DarkModeProps & {
   initialMessageText?: string;

--- a/packages/mongodb-chatbot-ui/src/createMessage.ts
+++ b/packages/mongodb-chatbot-ui/src/createMessage.ts
@@ -1,4 +1,4 @@
-import { References } from "mongodb-rag-core";
+import { type References } from "./references";
 import {
   AssistantMessageMetadata,
   MessageData,

--- a/packages/mongodb-chatbot-ui/src/messageLinks.test.ts
+++ b/packages/mongodb-chatbot-ui/src/messageLinks.test.ts
@@ -1,4 +1,4 @@
-import { References } from "mongodb-rag-core";
+import { References } from "./references";
 import {
   formatReferences,
   getMessageLinks,

--- a/packages/mongodb-chatbot-ui/src/messageLinks.ts
+++ b/packages/mongodb-chatbot-ui/src/messageLinks.ts
@@ -1,10 +1,10 @@
 import { isRichLinkVariantName, type RichLinkProps } from "@lg-chat/rich-links";
-import { References } from "mongodb-rag-core";
 import {
   isReferenceToDomain,
   makePrioritizeReferenceDomain,
+  type References,
   SortReferences,
-} from "./sortReferences";
+} from "./references";
 import { addQueryParams, getCurrentPageUrl } from "./utils";
 import { MessageData } from "./services/conversations";
 

--- a/packages/mongodb-chatbot-ui/src/references.test.ts
+++ b/packages/mongodb-chatbot-ui/src/references.test.ts
@@ -1,8 +1,8 @@
-import { References } from "mongodb-rag-core";
 import {
+  type References,
   isReferenceToDomain,
   makePrioritizeReferenceDomain,
-} from "./sortReferences";
+} from "./references";
 
 const testReferences = [
   {

--- a/packages/mongodb-chatbot-ui/src/references.ts
+++ b/packages/mongodb-chatbot-ui/src/references.ts
@@ -1,4 +1,27 @@
-import { Reference } from "mongodb-rag-core";
+import { z } from "zod";
+
+/**
+  A formatted reference for an assistant message.
+
+  For example, a Reference might be a docs page, dev center article, or
+  a MongoDB University module.
+ */
+export type Reference = z.infer<typeof Reference>;
+export const Reference = z.object({
+  url: z.string(),
+  title: z.string(),
+  metadata: z
+    .object({
+      sourceName: z.string().optional().describe("The name of the source."),
+      sourceType: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+    })
+    .passthrough() // We accept additional unknown metadata fields
+    .optional(),
+});
+
+export type References = z.infer<typeof References>;
+export const References = z.array(Reference);
 
 export type SortReferences = (left: Reference, right: Reference) => -1 | 0 | 1;
 

--- a/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
@@ -10,7 +10,7 @@ import {
   UnknownStreamEvent,
   getCustomRequestOrigin,
 } from "./conversations";
-import { type References } from "mongodb-rag-core";
+import { type References } from "../references";
 import * as FetchEventSource from "@microsoft/fetch-event-source";
 // Mock fetch for regular awaited HTTP requests
 // TODO: make TypeScript compiler ok with this, or skip putting this in the compiled code for staging

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -1,5 +1,6 @@
 import { fetchEventSource } from "@microsoft/fetch-event-source";
-import { References, VerifiedAnswer } from "mongodb-rag-core";
+import { type VerifiedAnswer } from "../verifiedAnswer";
+import { type References } from "../references";
 import { ConversationState } from "../useConversation";
 import { strict as assert } from "node:assert";
 import { isProductionBuild } from "../utils";

--- a/packages/mongodb-chatbot-ui/src/useConversation.test.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useConversation, type UseConversationParams } from "./useConversation";
-import { ObjectId } from "mongodb-rag-core/mongodb";
+import { ObjectId } from "bson";
 import { mockNextFetchResult } from "./test-utils";
 
 const baseUseConversationParams = {

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useReducer } from "react";
-import { type References } from "mongodb-rag-core";
 import {
   MessageData,
   ConversationService,
@@ -15,7 +14,7 @@ import {
   isProductionBuild,
 } from "./utils";
 import { makePrioritizeCurrentMongoDbReferenceDomain } from "./messageLinks";
-import { SortReferences } from "./sortReferences";
+import { type References, SortReferences } from "./references";
 
 const STREAMING_MESSAGE_ID = "streaming-response";
 

--- a/packages/mongodb-chatbot-ui/src/verifiedAnswer.ts
+++ b/packages/mongodb-chatbot-ui/src/verifiedAnswer.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { Reference } from "./references";
+
+export const Question = z.object({
+  embedding: z
+    .array(z.number())
+    .describe("The vector embedding of the question text."),
+  embedding_model: z
+    .string()
+    .describe(
+      "The name of the embedding model used to generate the embedding."
+    ),
+  embedding_model_version: z
+    .string()
+    .describe(
+      "The version of the embedding model used to generate the embedding."
+    ),
+  text: z.string().describe("The text of the question."),
+});
+
+export type Question = z.infer<typeof Question>;
+
+export const VerifiedAnswer = z.object({
+  _id: z.string().describe("A unique identifier for the answer."),
+  question: Question,
+  answer: z
+    .string()
+    .describe(
+      "The text of the verified answer. This is returned verbatim to the user as the response to their question."
+    ),
+  author_email: z
+    .string()
+    .email()
+    .describe("The email address of the author or source of the answer."),
+  hidden: z.boolean().optional(),
+  references: z
+    .array(Reference)
+    .describe(
+      "Reference links with additional information related to the answer."
+    ),
+  created: z.date().describe("The date and time the answer was created."),
+  updated: z
+    .date()
+    .optional()
+    .describe("The date and time the answer was most recently updated."),
+});
+
+export type VerifiedAnswer = z.infer<typeof VerifiedAnswer>;


### PR DESCRIPTION
For some arcane reasons, we can't import non-type symbols from core. We only use it minimally anyway, so this removes the dependency and copies the zod schemas from core into the UI package.