### PR TITLE
(EAI-649): Stub out example classifier type

### DIFF
--- a/packages/datasets/src/classifyCodeExampleDocsTeam.ts
+++ b/packages/datasets/src/classifyCodeExampleDocsTeam.ts
@@ -1,0 +1,66 @@
+/**
+   @fileoverview Contains classification as defined by MongoDB Docs team (https://docs.google.com/document/d/199fTaNlvMXb1GmloQRkh8MYPfYyuQakaYIsAuZvgKvU/)
+ */
+import { ClassificationType, makeClassifier } from "mongodb-rag-core";
+
+const classificationTypes: ClassificationType[] = [
+  {
+    type: "api_method_signature",
+    description:
+      "API method signature code block showing an API method name and arguments",
+    examples: [
+      {
+        // From https://www.mongodb.com/docs/languages/python/pymongo-driver/current/write/insert/#insert-one-document
+        text: `\`\`\`\`python
+sample_restaurants.restaurants.insert_one({"name" : "Mongo's Burgers"})
+        \`\`\``,
+        reason:
+          'Shows the minimum required arguments for the "insert_one" method. Therefore this is an API method signature.',
+      },
+      {
+        // From https://www.mongodb.com/docs/manual/reference/method/db.collection.insertOne/#syntax
+        text: `\`\`\`\`javascript
+db.collection.insertOne(
+    <document>,
+    {
+      writeConcern: <document>
+    }
+)
+\`\`\``,
+        reason:
+          "Complete API method signature, showing all possible arguments in an abstract form. Therefore this is an API method signature.",
+      },
+    ],
+  },
+  {
+    type: "return_example",
+    description:
+      "A JSON blob, example document, or other return object type demonstrating what a user might expect from executing a piece of code",
+    examples: [],
+  },
+  {
+    type: "example_configuration_object",
+    description:
+      "Example object, often represented in YAML or JSON, enumerating parameters and their types",
+    examples: [],
+  },
+  {
+    type: "usage_example",
+    description:
+      "A longer code snippet that establishes parameters, performs basic set-up code, and includes the larger context to demonstrate how to accomplish a task",
+    examples: [],
+  },
+  {
+    type: "sample_application",
+    description:
+      "Runnable applications that connect more discrete pieces of code, and may include error handling, framework integrations, or User Interface elements",
+    examples: [],
+  },
+  // Note: adding this b/c there will certainly be types of code examples that don't cleanly fit into these buckets.
+  // For example, if there was a file tree in a code block.
+  {
+    type: "unknown",
+    description:
+      "Unknown classification type. The code example doesn't easily fit into any of the other categories.",
+  },
+];

--- a/packages/mongodb-artifact-generator/src/chat/makeClassifierWithLogger.ts
+++ b/packages/mongodb-artifact-generator/src/chat/makeClassifierWithLogger.ts
@@ -1,0 +1,28 @@
+import { Classifier, makeClassifier } from "mongodb-rag-core";
+import { RunLogger } from "../runlogger";
+import { stripIndents } from "common-tags";
+
+export function makeClassifierWithLogger(
+  args: Parameters<typeof makeClassifier>[0] & { logger?: RunLogger }
+) {
+  const { logger, ...classifierBuilder } = args;
+  const classifier = makeClassifier(classifierBuilder);
+  const classifierWithLogger: Classifier = async (
+    args: Parameters<typeof classifier>[0]
+  ) => {
+    const result = await classifier(args);
+    logger?.appendArtifact(
+      `chatTemplates/classifier-${Date.now()}.json`,
+      stripIndents`
+        <SystemMessage>
+          ${result.inputMessages[0].content}
+        </SystemMessage>
+        <Classification>
+          ${JSON.stringify(result.classification)}
+        </Classification>
+      `
+    );
+    return result;
+  };
+  return classifierWithLogger;
+}

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelog.ts
@@ -4,7 +4,7 @@ import { makeClassifyChangelogAudience } from "./classifyChangelogAudience";
 import { makeClassifyChangelogScope } from "./classifyChangelogScope";
 import { iOfN } from "../utils";
 import { RunLogger } from "../runlogger";
-import { Classification } from "../chat/makeClassifier";
+import { Classification } from "mongodb-rag-core";
 
 export type ClassifiedChangelog = {
   audience: Classification;
@@ -35,8 +35,12 @@ export function makeClassifyChangelog({
   }: {
     changelog: string;
   }): Promise<ClassifiedChangelog> {
-    const audience = await classifyChangelogAudience({ input: changelog });
-    const scope = await classifyChangelogScope({ input: changelog });
+    const { classification: audience } = await classifyChangelogAudience({
+      input: changelog,
+    });
+    const { classification: scope } = await classifyChangelogScope({
+      input: changelog,
+    });
 
     return {
       audience,

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogAudience.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogAudience.ts
@@ -1,5 +1,5 @@
 import { OpenAI } from "mongodb-rag-core/openai";
-import { makeClassifier } from "../chat/makeClassifier";
+import { makeClassifierWithLogger } from "../chat/makeClassifierWithLogger";
 import { RunLogger } from "../runlogger";
 
 const classificationTypes = [
@@ -47,7 +47,7 @@ export type MakeClassifyChangelogAudienceArgs = {
 export function makeClassifyChangelogAudience({
   openAiClient,
 }: MakeClassifyChangelogAudienceArgs) {
-  return makeClassifier({
+  return makeClassifierWithLogger({
     openAiClient,
     classificationTypes,
     chainOfThought: true,

--- a/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogScope.ts
+++ b/packages/mongodb-artifact-generator/src/release-notes/classifyChangelogScope.ts
@@ -1,5 +1,5 @@
 import { OpenAI } from "mongodb-rag-core/openai";
-import { makeClassifier } from "../chat/makeClassifier";
+import { makeClassifierWithLogger } from "../chat/makeClassifierWithLogger";
 import { RunLogger } from "../runlogger";
 
 const classificationTypes = [
@@ -93,7 +93,7 @@ export function makeClassifyChangelogScope({
   openAiClient,
   logger,
 }: MakeClassifyChangelogScope) {
-  return makeClassifier({
+  return makeClassifierWithLogger({
     openAiClient,
     logger,
     classificationTypes,

--- a/packages/mongodb-rag-core/src/index.ts
+++ b/packages/mongodb-rag-core/src/index.ts
@@ -20,6 +20,7 @@ export * from "./DatabaseConnection";
 export * from "./DataStreamer";
 export * from "./logger";
 export * from "./conversations/MongoDbConversations";
+export * from "./makeClassifier";
 export * from "./References";
 export * from "./VectorStore";
 export * from "./arrayFilters";

--- a/packages/mongodb-rag-core/src/makeClassifier.test.ts
+++ b/packages/mongodb-rag-core/src/makeClassifier.test.ts
@@ -1,9 +1,7 @@
-import {
-  CORE_OPENAI_CONNECTION_ENV_VARS,
-  assertEnvVars,
-} from "mongodb-rag-core";
+import { assertEnvVars } from "./assertEnvVars";
+import { CORE_OPENAI_CONNECTION_ENV_VARS } from "./CoreEnvVars";
 import { Classification, makeClassifier } from "./makeClassifier";
-import { AzureOpenAI } from "mongodb-rag-core/openai";
+import { AzureOpenAI } from "./openai";
 
 const { OPENAI_ENDPOINT, OPENAI_API_KEY, OPENAI_API_VERSION } = assertEnvVars(
   CORE_OPENAI_CONNECTION_ENV_VARS
@@ -74,7 +72,7 @@ describe("makeClassifier", () => {
     const results: string[] = [];
     for (const input of hotdogInputs) {
       const result = await classifyIsHotdog({ input });
-      results.push(result.type);
+      results.push(result.classification.type);
     }
     expect(results).toEqual([
       "hotdog",
@@ -96,7 +94,7 @@ describe("makeClassifier", () => {
     const results: Classification[] = [];
     for (const input of hotdogInputs) {
       const result = await classifyIsHotdog({ input });
-      results.push(result);
+      results.push(result.classification);
     }
     const resultTypes = results.map((r) => r.type);
     expect(resultTypes).toEqual([


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-649

## Changes

- Migrate base classifier to MongoDB RAG core
- refactor artifact generator to accomodate 
- Create sample classifier for docs team based on their definitions

## Notes

-
