### PR TITLE
(EAI-655) fix mongo-memory-server test flakiness

### DIFF
--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -29,9 +29,12 @@ jest.setTimeout(30000);
 describe("MongoDbEmbeddedContentStore", () => {
   let store: MongoDbEmbeddedContentStore | undefined;
   let mongod: MongoMemoryReplSet | undefined;
-  beforeEach(async () => {
+  let uri: string;
+  beforeAll(async () => {
     mongod = await MongoMemoryReplSet.create();
-    const uri = mongod.getUri();
+    uri = mongod.getUri();
+  });
+  beforeEach(async () => {
     store = makeMongoDbEmbeddedContentStore({
       connectionUri: uri,
       databaseName: "test-database",
@@ -43,6 +46,8 @@ describe("MongoDbEmbeddedContentStore", () => {
 
   afterEach(async () => {
     await store?.drop();
+  });
+  afterAll(async () => {
     await store?.close();
     await mongod?.stop();
   });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
@@ -70,10 +70,11 @@ describe("MongoDbPageStore", () => {
   let store: MongoDbPageStore | undefined;
   let mongoServer: MongoMemoryServer;
   let uri: string;
-  beforeEach(async () => {
+  beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     uri = mongoServer.getUri();
-
+  });
+  beforeEach(async () => {
     store = await makeMongoDbPageStore({
       connectionUri: uri,
       databaseName: "test-database",
@@ -84,6 +85,8 @@ describe("MongoDbPageStore", () => {
     assert(store);
     await store.drop();
     await store.close();
+  });
+  afterAll(async () => {
     await mongoServer.stop();
   });
 

--- a/packages/mongodb-rag-ingest/src/commands/all.test.ts
+++ b/packages/mongodb-rag-ingest/src/commands/all.test.ts
@@ -64,11 +64,12 @@ describe("allCommand", () => {
   const mockDataSourceNames = mockDataSources.map(
     (dataSource) => dataSource.name
   );
-
-  beforeEach(async () => {
+  beforeAll(async () => {
     databaseName = "test-all-command";
     mongod = await MongoMemoryReplSet.create();
     uri = mongod.getUri();
+  });
+  beforeEach(async () => {
     embedStore = makeMongoDbEmbeddedContentStore({
       connectionUri: uri,
       databaseName,
@@ -110,6 +111,8 @@ describe("allCommand", () => {
     await pageStore?.close();
     await embedStore.drop();
     await embedStore.close();
+  });
+  afterAll(async () => {
     assert(mongod);
     await mongod.stop();
   });


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-655

## Changes
In an attempt to fix flakiness,
- moved mongo memory server creation from beforeEach to beforeAll

## Notes

- This should fix flakiness issues. If it does not, we can look into creating the mongo memory server globally
