### PR TITLE
(EAI-571) [UI] Support creating conversation on first message

### DIFF
--- a/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
+++ b/packages/mongodb-chatbot-ui/src/InputBarTrigger.tsx
@@ -125,9 +125,6 @@ export function InputBarTrigger({
             if (conversation.messages.length > 0) {
               openChat();
             }
-            if (!conversation.conversationId) {
-              await conversation.createConversation();
-            }
           }}
           onFocus={() => {
             setFocused(true);

--- a/packages/mongodb-chatbot-ui/src/conversationStore.ts
+++ b/packages/mongodb-chatbot-ui/src/conversationStore.ts
@@ -6,7 +6,7 @@ import {
 import { combine } from "zustand/middleware";
 import createMessage, { CreateMessageArgs } from "./createMessage";
 import { References } from "./references";
-import { removeArrayElementAt } from "./utils";
+import { nonProd, removeArrayElementAt } from "./utils";
 
 export type ConversationState = {
   conversationId?: string;
@@ -57,13 +57,17 @@ export const makeConversationStore = (name = "default") => {
         },
         setConversationId: (conversationId: string) => {
           if (conversationId === "") {
-            console.warn("Attempted to set an empty conversation ID");
+            nonProd(() => {
+              console.warn("Attempted to set an empty conversation ID");
+            });
             return;
           }
           if (get().conversationId) {
-            console.warn(
-              "Attempted to set a conversation ID when one is already set"
-            );
+            nonProd(() => {
+              console.warn(
+                "Attempted to set a conversation ID when one is already set"
+              );
+            });
             return;
           }
           set((prevState) => ({

--- a/packages/mongodb-chatbot-ui/src/conversationStore.ts
+++ b/packages/mongodb-chatbot-ui/src/conversationStore.ts
@@ -49,11 +49,27 @@ export type ConversationStore = ReturnType<typeof makeConversationStore>;
 
 export const makeConversationStore = (name = "default") => {
   return createStore(
-    combine(initialConversationState, (set) => ({
+    combine(initialConversationState, (set, get) => ({
       name,
       api: {
         initialize: (initialState: ConversationState) => {
           set(initialState);
+        },
+        setConversationId: (conversationId: string) => {
+          if (conversationId === "") {
+            console.warn("Attempted to set an empty conversation ID");
+            return;
+          }
+          if (get().conversationId) {
+            console.warn(
+              "Attempted to set a conversation ID when one is already set"
+            );
+            return;
+          }
+          set((prevState) => ({
+            ...prevState,
+            conversationId,
+          }));
         },
         setConversationError: (errorMessage: string) => {
           set((prevState) => ({

--- a/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
@@ -164,123 +164,265 @@ describe("ConversationService", () => {
     }).rejects.toThrow("Conversation not found");
   });
 
-  it("adds messages w/ an awaited response", async () => {
-    const conversationId = "650b4b260f975ef031016c8b";
-    const mockMessage = {
-      id: "650b4be0d5a57dd66be2ccb8",
-      role: "assistant",
-      content: "I'm sorry, I don't know how to help with that.",
-      createdAt: new Date().getTime(),
-      references: [
-        { title: "Title 1", url: "https://example.com/1" },
-        { title: "Title 2", url: "https://example.com/2" },
-        { title: "Title 3", url: "https://example.com/3" },
-      ],
-    };
-    mockFetchResponse({ data: mockMessage });
-    const awaitedMessage = await conversationService.addMessage({
-      conversationId,
-      message: "Hello world!",
+  describe("addMessage (awaited)", () => {
+    it("adds messages to an existing conversation", async () => {
+      const conversationId = "650b4b260f975ef031016c8b";
+      const mockMessage = {
+        id: "650b4be0d5a57dd66be2ccb8",
+        role: "assistant",
+        content: "I'm sorry, I don't know how to help with that.",
+        createdAt: new Date().getTime(),
+        references: [
+          { title: "Title 1", url: "https://example.com/1" },
+          { title: "Title 2", url: "https://example.com/2" },
+          { title: "Title 3", url: "https://example.com/3" },
+        ],
+      };
+      mockFetchResponse({ data: mockMessage });
+      const awaitedMessage = await conversationService.addMessage({
+        conversationId,
+        message: "Hello world!",
+      });
+      expect(awaitedMessage).toEqual(mockMessage);
     });
-    expect(awaitedMessage).toEqual(mockMessage);
+
+    it("creates a new conversation when provided a null conversation ID", async () => {
+      const mockMessage = {
+        id: "650b4be0d5a57dd66be2ccb9",
+        role: "assistant",
+        content: "I'm sorry, I don't know how to help with that.",
+        createdAt: new Date().getTime(),
+        references: [
+          { title: "Title 1", url: "https://example.com/1" },
+          { title: "Title 2", url: "https://example.com/2" },
+          { title: "Title 3", url: "https://example.com/3" },
+        ],
+      };
+      mockFetchResponse({
+        data: { ...mockMessage, metadata: { conversationId: "asdf" } },
+      });
+      const awaitedMessage = await conversationService.addMessage({
+        conversationId: "null",
+        message: "Hello world!",
+      });
+      expect(awaitedMessage.content).toEqual(mockMessage.content);
+      expect(awaitedMessage.references).toEqual(mockMessage.references);
+      expect(awaitedMessage.metadata?.conversationId).toBeDefined();
+    });
   });
 
-  it("adds messages w/ a streamed response", async () => {
-    const conversationId = "650b4b260f975ef031016c8c";
-    const mockStreamedMessageId = "651466eecffc98fe887000da";
+  describe("addMessage (streaming)", () => {
+    it("adds messages to an existing conversation", async () => {
+      const conversationId = "650b4b260f975ef031016c8c";
+      const mockStreamedMessageId = "651466eecffc98fe887000da";
 
-    const mockedEvents = mockFetchEventSourceResponse<ConversationStreamEvent>(
-      {
-        id: undefined,
-        type: undefined,
-        data: {
-          type: "metadata",
-          data: {
-            verifiedAnswer: {
-              _id: "66060bf9888068d1e6163ac4",
-              updated: new Date("2024-03-26T01:22:12.000Z").toISOString(),
-              created: new Date("2024-01-21T00:31:16.000Z").toISOString(),
+      const mockedEvents =
+        mockFetchEventSourceResponse<ConversationStreamEvent>(
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "metadata",
+              data: {
+                verifiedAnswer: {
+                  _id: "66060bf9888068d1e6163ac4",
+                  updated: new Date("2024-03-26T01:22:12.000Z").toISOString(),
+                  created: new Date("2024-01-21T00:31:16.000Z").toISOString(),
+                },
+              },
             },
           },
-        },
-      },
-      {
-        id: undefined,
-        type: undefined,
-        data: { type: "delta", data: "Once upon" },
-      },
-      {
-        id: undefined,
-        type: undefined,
-        data: { type: "delta", data: " a time there was a" },
-      },
-      {
-        id: undefined,
-        type: undefined,
-        data: { type: "delta", data: " very long string." },
-      },
-      {
-        id: undefined,
-        type: undefined,
-        data: {
-          type: "references",
-          data: [
-            { title: "Title 1", url: "https://example.com/1" },
-            { title: "Title 2", url: "https://example.com/2" },
-            { title: "Title 3", url: "https://example.com/3" },
-          ],
-        },
-      },
-      {
-        id: undefined,
-        type: undefined,
-        data: { type: "finished", data: mockStreamedMessageId },
-      }
-    );
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: "Once upon" },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: " a time there was a" },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: " very long string." },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "references",
+              data: [
+                { title: "Title 1", url: "https://example.com/1" },
+                { title: "Title 2", url: "https://example.com/2" },
+                { title: "Title 3", url: "https://example.com/3" },
+              ],
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "finished", data: mockStreamedMessageId },
+          }
+        );
 
-    const streamedMetadata: AssistantMessageMetadata[] = [];
-    const streamedTokens: string[] = [];
-    const streamedReferences: References[] = [];
-    let streamedMessageId: string | undefined;
-    let finishedStreaming = false;
-    await conversationService.addMessageStreaming({
-      conversationId,
-      message: "Hello world!",
-      maxRetries: 0,
-      onResponseDelta: async (data: string) => {
-        streamedTokens.push(data);
-      },
-      onReferences: async (data: References) => {
-        streamedReferences.push(data);
-      },
-      onResponseFinished: async (messageId: string) => {
-        streamedMessageId = messageId;
-        finishedStreaming = true;
-      },
-      onMetadata: async (metadata) => {
-        streamedMetadata.push(metadata);
-      },
+      const streamedMetadata: AssistantMessageMetadata[] = [];
+      const streamedTokens: string[] = [];
+      const streamedReferences: References[] = [];
+      let streamedMessageId: string | undefined;
+      let finishedStreaming = false;
+      await conversationService.addMessageStreaming({
+        conversationId,
+        message: "Hello world!",
+        maxRetries: 0,
+        onResponseDelta: async (data: string) => {
+          streamedTokens.push(data);
+        },
+        onReferences: async (data: References) => {
+          streamedReferences.push(data);
+        },
+        onResponseFinished: async (messageId: string) => {
+          streamedMessageId = messageId;
+          finishedStreaming = true;
+        },
+        onMetadata: async (metadata) => {
+          streamedMetadata.push(metadata);
+        },
+      });
+      expect(streamedMessageId).toEqual(mockStreamedMessageId);
+      expect(streamedTokens).toEqual(
+        filterMockedConversationEventsData<DeltaStreamEvent>(
+          mockedEvents,
+          "delta"
+        )
+      );
+      expect(streamedReferences).toEqual(
+        filterMockedConversationEventsData<ReferencesStreamEvent>(
+          mockedEvents,
+          "references"
+        )
+      );
+      expect(streamedMetadata).toEqual(
+        filterMockedConversationEventsData<MetadataStreamEvent>(
+          mockedEvents,
+          "metadata"
+        )
+      );
+      expect(finishedStreaming).toEqual(true);
     });
-    expect(streamedMessageId).toEqual(mockStreamedMessageId);
-    expect(streamedTokens).toEqual(
-      filterMockedConversationEventsData<DeltaStreamEvent>(
-        mockedEvents,
-        "delta"
-      )
-    );
-    expect(streamedReferences).toEqual(
-      filterMockedConversationEventsData<ReferencesStreamEvent>(
-        mockedEvents,
-        "references"
-      )
-    );
-    expect(streamedMetadata).toEqual(
-      filterMockedConversationEventsData<MetadataStreamEvent>(
-        mockedEvents,
-        "metadata"
-      )
-    );
-    expect(finishedStreaming).toEqual(true);
+
+    it("creates a new conversation when provided a null conversation ID", async () => {
+      const mockStreamedMessageId = "651466eecffc98fe887000db";
+
+      const mockedEvents =
+        mockFetchEventSourceResponse<ConversationStreamEvent>(
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "metadata",
+              data: {
+                verifiedAnswer: {
+                  _id: "66060bf9888068d1e6163ac5",
+                  updated: new Date("2024-03-26T01:22:12.000Z").toISOString(),
+                  created: new Date("2024-01-21T00:31:16.000Z").toISOString(),
+                },
+              },
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "metadata",
+              data: {
+                conversationId: "66060bf9888068d1e6163ac5",
+              },
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: "Once upon" },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: " a time there was a" },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "delta", data: " very long string." },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "references",
+              data: [
+                { title: "Title 1", url: "https://example.com/1" },
+                { title: "Title 2", url: "https://example.com/2" },
+                { title: "Title 3", url: "https://example.com/3" },
+              ],
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "finished", data: mockStreamedMessageId },
+          }
+        );
+
+      const streamedMetadata: AssistantMessageMetadata[] = [];
+      const streamedTokens: string[] = [];
+      const streamedReferences: References[] = [];
+      let streamedConversationId: string | undefined;
+      let streamedMessageId: string | undefined;
+      let finishedStreaming = false;
+      await conversationService.addMessageStreaming({
+        conversationId: "null",
+        message: "Hello world!",
+        maxRetries: 0,
+        onMetadata: async (metadata) => {
+          streamedMetadata.push(metadata);
+          if (metadata.conversationId) {
+            streamedConversationId = metadata.conversationId;
+          }
+        },
+        onResponseDelta: async (data: string) => {
+          streamedTokens.push(data);
+        },
+        onReferences: async (data: References) => {
+          streamedReferences.push(data);
+        },
+        onResponseFinished: async (messageId: string) => {
+          streamedMessageId = messageId;
+          finishedStreaming = true;
+        },
+      });
+      expect(streamedMessageId).toEqual(mockStreamedMessageId);
+      expect(streamedTokens).toEqual(
+        filterMockedConversationEventsData<DeltaStreamEvent>(
+          mockedEvents,
+          "delta"
+        )
+      );
+      expect(streamedReferences).toEqual(
+        filterMockedConversationEventsData<ReferencesStreamEvent>(
+          mockedEvents,
+          "references"
+        )
+      );
+      expect(streamedMetadata).toEqual(
+        filterMockedConversationEventsData<MetadataStreamEvent>(
+          mockedEvents,
+          "metadata"
+        )
+      );
+      expect(streamedConversationId).toBeDefined();
+      expect(finishedStreaming).toEqual(true);
+    });
   });
 
   it("gracefully handles unknown stream event types", async () => {

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -2,7 +2,7 @@ import { fetchEventSource } from "@microsoft/fetch-event-source";
 import { type VerifiedAnswer } from "../verifiedAnswer";
 import { type References } from "../references";
 import { strict as assert } from "node:assert";
-import { isProductionBuild } from "../utils";
+import { nonProd } from "../utils";
 
 export type Role = "user" | "assistant";
 
@@ -328,25 +328,25 @@ export class ConversationService {
       onmessage(ev) {
         const event = JSON.parse(ev.data);
         if (!isSomeStreamEvent(event)) {
-          if (!isProductionBuild()) {
+          nonProd(() => {
             console.error(
               `Received an unknown event: ${JSON.stringify(event)}`
             );
-          }
+          });
           return;
         }
         if (!isConversationStreamEventType(event.type)) {
-          if (!isProductionBuild()) {
+          nonProd(() => {
             console.error(`Received an unknown event type: ${event.type}`);
-          }
+          });
           return;
         }
         if (!isConversationStreamEvent(event)) {
-          if (!isProductionBuild()) {
+          nonProd(() => {
             console.error(
               `Received an invalid conversation event: ${JSON.stringify(event)}`
             );
-          }
+          });
           return;
         }
         switch (event.type) {

--- a/packages/mongodb-chatbot-ui/src/services/conversations.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.ts
@@ -21,6 +21,13 @@ export type AssistantMessageMetadata = {
   [k: string]: unknown;
 
   /**
+    The conversation ID that this message is part of. If you add a message
+    without specifying a conversation ID, which creates a new conversation, this
+    field contains the ID of the new conversation.
+  */
+  conversationId?: string;
+
+  /**
     If the message came from the verified answers collection, contains the
     metadata about the verified answer.
   */

--- a/packages/mongodb-chatbot-ui/src/useChatbot.tsx
+++ b/packages/mongodb-chatbot-ui/src/useChatbot.tsx
@@ -52,13 +52,7 @@ export function useChatbot({
     }
     onOpen?.();
     startTransition(() => {
-      if (!conversation.conversationId) {
-        conversation.createConversation().then(() => {
-          setOpen(true);
-        });
-      } else {
-        setOpen(true);
-      }
+      setOpen(true);
     });
   }
 
@@ -90,11 +84,6 @@ export function useChatbot({
   }
 
   function canSubmit(text: string) {
-    // Don't let users submit a message if the conversation hasn't fully loaded
-    if (!conversation.conversationId) {
-      console.error(`Cannot add message without a conversationId`);
-      return false;
-    }
     // Don't let users submit a message if something is wrong with their input text
     if (inputData.error) {
       console.error(`Cannot add message with invalid input text`);

--- a/packages/mongodb-chatbot-ui/src/utils.test.ts
+++ b/packages/mongodb-chatbot-ui/src/utils.test.ts
@@ -8,6 +8,7 @@ import {
   getCurrentPageUrl,
   renameFields,
   omit,
+  nonProd,
 } from "./utils";
 
 const alice = { name: "alice", age: 25, createdAt: new Date("1999-01-01") };
@@ -130,5 +131,32 @@ describe("omit", () => {
     });
 
     expect(bobAfter).toEqual({ age: 42 });
+  });
+});
+
+describe("nonProd", () => {
+  const originalProcessEnv = process.env.NODE_ENV;
+  test("runs the provided callback in non-production environments", () => {
+    const callback = vi.fn();
+
+    try {
+      process.env.NODE_ENV = "development";
+      nonProd(callback);
+      expect(callback).toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalProcessEnv;
+    }
+  });
+
+  test("does not run the provided callback in production environments", () => {
+    const callback = vi.fn();
+
+    try {
+      process.env.MODE = "production";
+      nonProd(callback);
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      process.env.MODE = originalProcessEnv;
+    }
   });
 });

--- a/packages/mongodb-chatbot-ui/src/utils.ts
+++ b/packages/mongodb-chatbot-ui/src/utils.ts
@@ -153,3 +153,12 @@ export type DeepPartial<T> = {
 export function isProductionBuild() {
   return import.meta.env.MODE === "production";
 }
+
+/**
+  A function that only runs if we're not in a production build.
+ */
+export function nonProd(fn: () => void): void {
+  if (!isProductionBuild()) {
+    fn();
+  }
+}


### PR DESCRIPTION
Jira: (EAI-571) [UI] Support creating conversation on first message

## Changes

- No more calls to `createConversation` - instead we always create the conversation on the first message
  - Works locally with both streaming and awaited responses

## Notes

- We never really counted "raw interactions" anyway, but this notably will make it so our db doesn't track if someone opens that chatbot but doesn't send a message.
