### PR TITLE
(EAI-655) fix mongo-memory-server test flakiness

### DIFF
--- a/packages/benchmarks/jest.config.cjs
+++ b/packages/benchmarks/jest.config.cjs
@@ -3,4 +3,6 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["<rootDir>/build"],
   verbose: true,
+  globalSetup: "<rootDir>/src/test/globalSetup.ts",
+  globalTeardown: "<rootDir>/src/test/globalTeardown.ts",
 };

--- a/packages/benchmarks/src/test/constants.ts
+++ b/packages/benchmarks/src/test/constants.ts
@@ -1,0 +1,13 @@
+const IP = "127.0.0.1";
+const REPLICA_SET_PORT = 47018;
+const SERVER_PORT = 47017;
+const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset`;
+const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`;
+
+export {
+  IP,
+  REPLICA_SET_PORT,
+  SERVER_PORT,
+  MONGO_MEMORY_REPLICA_SET_URI,
+  MONGO_MEMORY_SERVER_URI,
+};

--- a/packages/benchmarks/src/test/globalSetup.ts
+++ b/packages/benchmarks/src/test/globalSetup.ts
@@ -1,0 +1,29 @@
+import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
+import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
+
+export default async function () {
+  try {
+    const mongoMemoryServerInstance = await MongoMemoryServer.create({
+      instance: {
+        port: SERVER_PORT,
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+
+    const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
+      instanceOpts: [
+        {
+          port: REPLICA_SET_PORT,
+        },
+      ],
+      replSet: {
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
+  } catch (error) {
+    console.error("Error in global setup:", error);
+    throw error;
+  }
+}

--- a/packages/benchmarks/src/test/globalTeardown.ts
+++ b/packages/benchmarks/src/test/globalTeardown.ts
@@ -1,0 +1,13 @@
+module.exports = async function () {
+  try {
+    if ((global as any).__MONGO_MEMORY_SERVER_INSTANCE) {
+      await (global as any).__MONGO_MEMORY_SERVER_INSTANCE.stop();
+    }
+    if ((global as any).__MONGO_MEMORY_REPLICA_SET) {
+      await (global as any).__MONGO_MEMORY_REPLICA_SET.stop();
+    }
+  } catch (error) {
+    console.error("Error in global teardown:", error);
+    throw error;
+  }
+};

--- a/packages/benchmarks/src/textToDriver/executeGeneratedDriverCode.test.ts
+++ b/packages/benchmarks/src/textToDriver/executeGeneratedDriverCode.test.ts
@@ -4,11 +4,11 @@ import {
   Collection,
   Document,
 } from "mongodb-rag-core/mongodb";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { executeGeneratedDriverCode } from "./executeGeneratedDriverCode";
+import { MONGO_MEMORY_SERVER_URI } from "../test/constants";
+
 describe("executeGeneratedDriverCode", () => {
   jest.setTimeout(60000);
-  let mongoServer: MongoMemoryServer;
   let mongoClient: MongoClient;
   let db: Db;
   let collection: Collection<Document>;
@@ -17,8 +17,7 @@ describe("executeGeneratedDriverCode", () => {
 
   beforeAll(async () => {
     // Start in-memory MongoDB instance
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
+    const uri = MONGO_MEMORY_SERVER_URI;
 
     mongoClient = new MongoClient(uri);
     await mongoClient.connect();
@@ -35,7 +34,6 @@ describe("executeGeneratedDriverCode", () => {
   afterAll(async () => {
     // Clean up
     await mongoClient.close();
-    await mongoServer.stop();
   });
 
   it("should execute generated driver code", async () => {

--- a/packages/benchmarks/src/textToDriver/generateDriverCode/extractDeterministicSampleOfDocuments.test.ts
+++ b/packages/benchmarks/src/textToDriver/generateDriverCode/extractDeterministicSampleOfDocuments.test.ts
@@ -1,12 +1,11 @@
 import { MongoClient, UUID, ObjectId } from "mongodb-rag-core/mongodb";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import {
   extractDeterministicSampleOfDocuments,
   MUST_HAVE_AT_LEAST_ONE_EXAMPLE_DOCUMENT_ERROR,
 } from "./extractDeterministicSampleOfDocuments";
+import { MONGO_MEMORY_SERVER_URI } from "../../test/constants";
 
 describe("extractDeterministicSampleOfDocuments", () => {
-  let mongod: MongoMemoryServer;
   let mongoClient: MongoClient;
   const dbName = "testdb";
   const collectionName = "testCollection";
@@ -14,8 +13,7 @@ describe("extractDeterministicSampleOfDocuments", () => {
 
   beforeAll(async () => {
     // Start the in-memory MongoDB server
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = MONGO_MEMORY_SERVER_URI;
 
     // Create a new MongoClient connected to the in-memory MongoDB
     mongoClient = new MongoClient(uri);
@@ -24,7 +22,6 @@ describe("extractDeterministicSampleOfDocuments", () => {
 
   afterAll(async () => {
     await mongoClient.close();
-    await mongod.stop();
   });
 
   afterEach(async () => {

--- a/packages/benchmarks/src/textToDriver/generateDriverCode/makeGenerateDriverCode.test.ts
+++ b/packages/benchmarks/src/textToDriver/generateDriverCode/makeGenerateDriverCode.test.ts
@@ -1,4 +1,3 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
 import {
   MongoClient,
   Db,
@@ -10,6 +9,7 @@ import {
   MakeGenerateDriverCodeParams,
 } from "./makeGenerateDriverCode";
 import { OpenAI } from "mongodb-rag-core/openai";
+import { MONGO_MEMORY_SERVER_URI } from "../../test/constants";
 
 // Mock external dependencies
 jest.mock("mongodb-rag-core/openai");
@@ -17,7 +17,6 @@ const MockedOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>;
 
 describe("makeGenerateDriverCode", () => {
   jest.setTimeout(60000);
-  let mongoServer: MongoMemoryServer;
   let mongoClient: MongoClient;
   let db: Db;
   let collection: Collection<Document>;
@@ -26,8 +25,7 @@ describe("makeGenerateDriverCode", () => {
 
   beforeAll(async () => {
     // Start in-memory MongoDB instance
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
+    const uri = MONGO_MEMORY_SERVER_URI;
 
     mongoClient = new MongoClient(uri);
     await mongoClient.connect();
@@ -44,7 +42,6 @@ describe("makeGenerateDriverCode", () => {
   afterAll(async () => {
     // Clean up
     await mongoClient.close();
-    await mongoServer.stop();
   });
 
   beforeEach(() => {

--- a/packages/mongodb-chatbot-server/jest.config.json
+++ b/packages/mongodb-chatbot-server/jest.config.json
@@ -2,5 +2,7 @@
   "preset": "ts-jest",
   "setupFiles": ["<rootDir>/src/test/jestEnvSetUp.ts"],
   "setupFilesAfterEnv": ["<rootDir>/src/test/jestSetUp.ts"],
-  "testPathIgnorePatterns": ["<rootDir>/build"]
+  "testPathIgnorePatterns": ["<rootDir>/build"],
+  "globalSetup": "<rootDir>/src/test/globalSetup.ts",
+  "globalTeardown": "<rootDir>/src/test/globalTeardown.ts"
 }

--- a/packages/mongodb-chatbot-server/src/test/constants.ts
+++ b/packages/mongodb-chatbot-server/src/test/constants.ts
@@ -1,0 +1,13 @@
+const IP = "127.0.0.1";
+const REPLICA_SET_PORT = 57018;
+const SERVER_PORT = 57017;
+const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset`;
+const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`;
+
+export {
+  IP,
+  REPLICA_SET_PORT,
+  SERVER_PORT,
+  MONGO_MEMORY_REPLICA_SET_URI,
+  MONGO_MEMORY_SERVER_URI,
+};

--- a/packages/mongodb-chatbot-server/src/test/globalSetup.ts
+++ b/packages/mongodb-chatbot-server/src/test/globalSetup.ts
@@ -1,0 +1,29 @@
+import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
+import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
+
+export default async function () {
+  try {
+    const mongoMemoryServerInstance = await MongoMemoryServer.create({
+      instance: {
+        port: SERVER_PORT,
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+
+    const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
+      instanceOpts: [
+        {
+          port: REPLICA_SET_PORT,
+        },
+      ],
+      replSet: {
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
+  } catch (error) {
+    console.error("Error in global setup:", error);
+    throw error;
+  }
+}

--- a/packages/mongodb-chatbot-server/src/test/globalTeardown.ts
+++ b/packages/mongodb-chatbot-server/src/test/globalTeardown.ts
@@ -1,0 +1,13 @@
+module.exports = async function () {
+  try {
+    if ((global as any).__MONGO_MEMORY_SERVER_INSTANCE) {
+      await (global as any).__MONGO_MEMORY_SERVER_INSTANCE.stop();
+    }
+    if ((global as any).__MONGO_MEMORY_REPLICA_SET) {
+      await (global as any).__MONGO_MEMORY_REPLICA_SET.stop();
+    }
+  } catch (error) {
+    console.error("Error in global teardown:", error);
+    throw error;
+  }
+};

--- a/packages/mongodb-chatbot-server/src/test/testConfig.ts
+++ b/packages/mongodb-chatbot-server/src/test/testConfig.ts
@@ -29,14 +29,13 @@ import {
   makeFilterNPreviousMessages,
 } from "../processors";
 import { makeDefaultReferenceLinks } from "../processors/makeDefaultReferenceLinks";
-import { MongoMemoryServer } from "mongodb-memory-server";
+import { MONGO_MEMORY_SERVER_URI } from "./constants";
+
 
 let mongoClient: MongoClient | undefined;
 export let memoryDb: Db;
-let mongod: MongoMemoryServer | undefined;
+const uri = MONGO_MEMORY_SERVER_URI
 beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  const uri = mongod.getUri();
   const testDbName = `conversations-test-${Date.now()}`;
   mongoClient = new MongoClient(uri);
   memoryDb = mongoClient.db(testDbName);
@@ -45,7 +44,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await memoryDb?.dropDatabase();
   await mongoClient?.close();
-  await mongod?.stop();
   await embeddedContentStore.close();
   await verifiedAnswerStore.close();
 });

--- a/packages/mongodb-rag-core/jest.config.cjs
+++ b/packages/mongodb-rag-core/jest.config.cjs
@@ -2,4 +2,6 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   setupFiles: ["<rootDir>/src/test/jestSetUp.ts"],
+  globalSetup: "<rootDir>/src/test/globalSetup.ts",
+  globalTeardown: "<rootDir>/src/test/globalTeardown.ts",
 };

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -54,7 +54,7 @@ describe("MongoDbEmbeddedContentStore", () => {
   const pages = [page, anotherPage];
   const uri = MONGO_MEMORY_REPLICA_SET_URI;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     store = makeMongoDbEmbeddedContentStore({
       connectionUri: uri,
       databaseName: "test-database",
@@ -62,9 +62,11 @@ describe("MongoDbEmbeddedContentStore", () => {
         embeddingName: OPENAI_RETRIEVAL_EMBEDDING_DEPLOYMENT,
       },
     });
+  });
+  beforeEach(async () => {
     for (const page of pages) {
-      embeddedContent = await store.loadEmbeddedContent({ page });
-      await store.updateEmbeddedContent({
+      embeddedContent = await store?.loadEmbeddedContent({ page });
+      await store?.updateEmbeddedContent({
         page,
         embeddedContent: [
           {
@@ -84,6 +86,8 @@ describe("MongoDbEmbeddedContentStore", () => {
 
   afterEach(async () => {
     await store?.drop();
+  });
+  afterAll(async () => {
     await store?.close();
   });
 

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -136,10 +136,13 @@ describe("MongoDbEmbeddedContentStore", () => {
       assert(store);
       const originalPageEmbedding = await store.loadEmbeddedContent({ page });
       assert(originalPageEmbedding.length === 1);
-  
+
       const newEmbeddings = [{ ...originalPageEmbedding[0], text: "new text" }];
-      await store.updateEmbeddedContent({ page, embeddedContent: newEmbeddings });
-  
+      await store.updateEmbeddedContent({
+        page,
+        embeddedContent: newEmbeddings,
+      });
+
       const pageEmbeddings = await store.loadEmbeddedContent({ page });
       expect(pageEmbeddings.length).toBe(1);
       expect(pageEmbeddings[0].text).toBe("new text");

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -10,9 +10,9 @@ import {
   MongoDbEmbeddedContentStore,
   makeMongoDbEmbeddedContentStore,
 } from "./MongoDbEmbeddedContentStore";
-import { MongoMemoryReplSet } from "mongodb-memory-server";
 import { MongoClient } from "mongodb";
 import { EmbeddedContent } from "./EmbeddedContent";
+import { MONGO_MEMORY_REPLICA_SET_URI } from "../test/constants";
 
 const {
   MONGODB_CONNECTION_URI,
@@ -28,7 +28,6 @@ jest.setTimeout(30000);
 
 describe("MongoDbEmbeddedContentStore", () => {
   let store: MongoDbEmbeddedContentStore | undefined;
-  let mongod: MongoMemoryReplSet | undefined;
   let embeddedContent;
   const page: PersistedPage = {
     action: "created",
@@ -41,7 +40,6 @@ describe("MongoDbEmbeddedContentStore", () => {
     updated: new Date(),
     url: "/x/y/z",
   };
-
   const anotherPage: PersistedPage = {
     action: "created",
     body: "bar",
@@ -54,11 +52,8 @@ describe("MongoDbEmbeddedContentStore", () => {
     url: "/a/b/c",
   };
   const pages = [page, anotherPage];
-  let uri: string;
-  beforeAll(async () => {
-    mongod = await MongoMemoryReplSet.create();
-    uri = mongod.getUri();
-  });
+  const uri = MONGO_MEMORY_REPLICA_SET_URI;
+
   beforeEach(async () => {
     store = makeMongoDbEmbeddedContentStore({
       connectionUri: uri,
@@ -89,10 +84,7 @@ describe("MongoDbEmbeddedContentStore", () => {
 
   afterEach(async () => {
     await store?.drop();
-  });
-  afterAll(async () => {
     await store?.close();
-    await mongod?.stop();
   });
 
   it("has an overridable default collection name", async () => {

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
@@ -2,8 +2,8 @@ import { strict as assert } from "assert";
 import { MongoDbPageStore, makeMongoDbPageStore } from "./MongoDbPageStore";
 import { PersistedPage } from "./Page";
 import "dotenv/config";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient } from "mongodb";
+import { MONGO_MEMORY_SERVER_URI } from "../test/constants";
 
 jest.setTimeout(60000);
 const moviePages: PersistedPage[] = [
@@ -65,29 +65,19 @@ const moviePages: PersistedPage[] = [
 ];
 
 const pageUrls = (pages: PersistedPage[]) => pages.map(({ url }) => url);
+const uri = MONGO_MEMORY_SERVER_URI;
 
 describe("MongoDbPageStore", () => {
   let store: MongoDbPageStore | undefined;
-  let mongoServer: MongoMemoryServer;
-  let uri: string;
-  beforeAll(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    uri = mongoServer.getUri();
-  });
   beforeEach(async () => {
     store = await makeMongoDbPageStore({
       connectionUri: uri,
       databaseName: "test-database",
     });
   });
-
   afterEach(async () => {
-    assert(store);
-    await store.drop();
-    await store.close();
-  });
-  afterAll(async () => {
-    await mongoServer.stop();
+    await store?.drop();
+    await store?.close();
   });
 
   it("handles pages", async () => {

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.test.ts
@@ -69,7 +69,7 @@ const uri = MONGO_MEMORY_SERVER_URI;
 
 describe("MongoDbPageStore", () => {
   let store: MongoDbPageStore | undefined;
-  beforeEach(async () => {
+  beforeAll(async () => {
     store = await makeMongoDbPageStore({
       connectionUri: uri,
       databaseName: "test-database",
@@ -77,6 +77,8 @@ describe("MongoDbPageStore", () => {
   });
   afterEach(async () => {
     await store?.drop();
+  });
+  afterAll(async () => {
     await store?.close();
   });
 

--- a/packages/mongodb-rag-core/src/test/constants.ts
+++ b/packages/mongodb-rag-core/src/test/constants.ts
@@ -1,0 +1,13 @@
+const IP = "127.0.0.1";
+const REPLICA_SET_PORT = 27018;
+const SERVER_PORT = 27017;
+const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset` 
+const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`
+
+export {
+  IP,
+  REPLICA_SET_PORT,
+  SERVER_PORT,
+  MONGO_MEMORY_REPLICA_SET_URI,
+  MONGO_MEMORY_SERVER_URI,
+}

--- a/packages/mongodb-rag-core/src/test/constants.ts
+++ b/packages/mongodb-rag-core/src/test/constants.ts
@@ -1,8 +1,8 @@
 const IP = "127.0.0.1";
 const REPLICA_SET_PORT = 27018;
 const SERVER_PORT = 27017;
-const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset` 
-const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`
+const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset`;
+const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`;
 
 export {
   IP,
@@ -10,4 +10,4 @@ export {
   SERVER_PORT,
   MONGO_MEMORY_REPLICA_SET_URI,
   MONGO_MEMORY_SERVER_URI,
-}
+};

--- a/packages/mongodb-rag-core/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-core/src/test/globalSetup.ts
@@ -27,5 +27,3 @@ export default async function () {
     throw error;
   }
 }
-
-export {};

--- a/packages/mongodb-rag-core/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-core/src/test/globalSetup.ts
@@ -1,5 +1,5 @@
-import { MongoMemoryServer, MongoMemoryReplSet } from 'mongodb-memory-server';
-import { IP, REPLICA_SET_PORT, SERVER_PORT } from './constants';
+import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
+import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
 
 declare global {
   namespace NodeJS {
@@ -16,7 +16,7 @@ module.exports = async function () {
       instance: {
         port: SERVER_PORT,
         ip: IP,
-      }
+      },
     });
     global.__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
     const uri = mongoMemoryServerInstance.getUri();
@@ -28,12 +28,12 @@ module.exports = async function () {
       ],
       replSet: {
         ip: IP,
-      }
+      },
     });
     global.__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
     const uriReplicaSet = mongoMemoryServerReplicaSet.getUri();
   } catch (error) {
-    console.error('Error in global setup:', error);
+    console.error("Error in global setup:", error);
     throw error;
   }
 };

--- a/packages/mongodb-rag-core/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-core/src/test/globalSetup.ts
@@ -1,12 +1,7 @@
 import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
 import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
 
-declare global {
-  var __MONGO_MEMORY_SERVER_INSTANCE: MongoMemoryServer;
-  var __MONGO_MEMORY_REPLICA_SET: MongoMemoryReplSet;
-}
-
-module.exports = async function () {
+export default async function () {
   try {
     const mongoMemoryServerInstance = await MongoMemoryServer.create({
       instance: {
@@ -14,7 +9,8 @@ module.exports = async function () {
         ip: IP,
       },
     });
-    global.__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+    (global as any).__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+
     const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
       instanceOpts: [
         {
@@ -25,9 +21,11 @@ module.exports = async function () {
         ip: IP,
       },
     });
-    global.__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
+    (global as any).__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
   } catch (error) {
     console.error("Error in global setup:", error);
     throw error;
   }
-};
+}
+
+export {};

--- a/packages/mongodb-rag-core/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-core/src/test/globalSetup.ts
@@ -2,12 +2,8 @@ import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
 import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
 
 declare global {
-  namespace NodeJS {
-    interface Global {
-      __MONGO_MEMORY_SERVER_INSTANCE: MongoMemoryServer;
-      __MONGO_MEMORY_REPLICA_SET: MongoMemoryReplSet;
-    }
-  }
+  var __MONGO_MEMORY_SERVER_INSTANCE: MongoMemoryServer;
+  var __MONGO_MEMORY_REPLICA_SET: MongoMemoryReplSet;
 }
 
 module.exports = async function () {
@@ -19,7 +15,6 @@ module.exports = async function () {
       },
     });
     global.__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
-    const uri = mongoMemoryServerInstance.getUri();
     const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
       instanceOpts: [
         {
@@ -31,7 +26,6 @@ module.exports = async function () {
       },
     });
     global.__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
-    const uriReplicaSet = mongoMemoryServerReplicaSet.getUri();
   } catch (error) {
     console.error("Error in global setup:", error);
     throw error;

--- a/packages/mongodb-rag-core/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-core/src/test/globalSetup.ts
@@ -1,0 +1,39 @@
+import { MongoMemoryServer, MongoMemoryReplSet } from 'mongodb-memory-server';
+import { IP, REPLICA_SET_PORT, SERVER_PORT } from './constants';
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      __MONGO_MEMORY_SERVER_INSTANCE: MongoMemoryServer;
+      __MONGO_MEMORY_REPLICA_SET: MongoMemoryReplSet;
+    }
+  }
+}
+
+module.exports = async function () {
+  try {
+    const mongoMemoryServerInstance = await MongoMemoryServer.create({
+      instance: {
+        port: SERVER_PORT,
+        ip: IP,
+      }
+    });
+    global.__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+    const uri = mongoMemoryServerInstance.getUri();
+    const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
+      instanceOpts: [
+        {
+          port: REPLICA_SET_PORT,
+        },
+      ],
+      replSet: {
+        ip: IP,
+      }
+    });
+    global.__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
+    const uriReplicaSet = mongoMemoryServerReplicaSet.getUri();
+  } catch (error) {
+    console.error('Error in global setup:', error);
+    throw error;
+  }
+};

--- a/packages/mongodb-rag-core/src/test/globalTeardown.ts
+++ b/packages/mongodb-rag-core/src/test/globalTeardown.ts
@@ -1,0 +1,13 @@
+module.exports = async function () {
+  try {    
+    if (global.__MONGO_MEMORY_SERVER_INSTANCE) {
+      await global.__MONGO_MEMORY_SERVER_INSTANCE.stop();
+    }
+    if (global.__MONGO_MEMORY_REPLICA_SET) {
+      await global.__MONGO_MEMORY_REPLICA_SET.stop();
+    }
+  } catch (error) {
+    console.error('Error in global teardown:', error);
+    throw error;
+  }
+};

--- a/packages/mongodb-rag-core/src/test/globalTeardown.ts
+++ b/packages/mongodb-rag-core/src/test/globalTeardown.ts
@@ -1,10 +1,10 @@
 module.exports = async function () {
   try {
-    if (global.__MONGO_MEMORY_SERVER_INSTANCE) {
-      await global.__MONGO_MEMORY_SERVER_INSTANCE.stop();
+    if ((global as any).__MONGO_MEMORY_SERVER_INSTANCE) {
+      await (global as any).__MONGO_MEMORY_SERVER_INSTANCE.stop();
     }
-    if (global.__MONGO_MEMORY_REPLICA_SET) {
-      await global.__MONGO_MEMORY_REPLICA_SET.stop();
+    if ((global as any).__MONGO_MEMORY_REPLICA_SET) {
+      await (global as any).__MONGO_MEMORY_REPLICA_SET.stop();
     }
   } catch (error) {
     console.error("Error in global teardown:", error);

--- a/packages/mongodb-rag-core/src/test/globalTeardown.ts
+++ b/packages/mongodb-rag-core/src/test/globalTeardown.ts
@@ -1,5 +1,5 @@
 module.exports = async function () {
-  try {    
+  try {
     if (global.__MONGO_MEMORY_SERVER_INSTANCE) {
       await global.__MONGO_MEMORY_SERVER_INSTANCE.stop();
     }
@@ -7,7 +7,7 @@ module.exports = async function () {
       await global.__MONGO_MEMORY_REPLICA_SET.stop();
     }
   } catch (error) {
-    console.error('Error in global teardown:', error);
+    console.error("Error in global teardown:", error);
     throw error;
   }
 };

--- a/packages/mongodb-rag-ingest/jest.config.cjs
+++ b/packages/mongodb-rag-ingest/jest.config.cjs
@@ -3,4 +3,6 @@ module.exports = {
   testEnvironment: "node",
   setupFiles: ["<rootDir>/src/test/jestSetUp.ts"],
   testPathIgnorePatterns: ["<rootDir>/build"],
+  globalSetup: "<rootDir>/src/test/globalSetup.ts",
+  globalTeardown: "<rootDir>/src/test/globalTeardown.ts",
 };

--- a/packages/mongodb-rag-ingest/src/test/constants.ts
+++ b/packages/mongodb-rag-ingest/src/test/constants.ts
@@ -1,0 +1,13 @@
+const IP = "127.0.0.1";
+const REPLICA_SET_PORT = 37018;
+const SERVER_PORT = 37017;
+const MONGO_MEMORY_REPLICA_SET_URI = `mongodb://${IP}:${REPLICA_SET_PORT}/?replicaSet=testset`;
+const MONGO_MEMORY_SERVER_URI = `mongodb://${IP}:${SERVER_PORT}/`;
+
+export {
+  IP,
+  REPLICA_SET_PORT,
+  SERVER_PORT,
+  MONGO_MEMORY_REPLICA_SET_URI,
+  MONGO_MEMORY_SERVER_URI,
+};

--- a/packages/mongodb-rag-ingest/src/test/globalSetup.ts
+++ b/packages/mongodb-rag-ingest/src/test/globalSetup.ts
@@ -1,0 +1,29 @@
+import { MongoMemoryServer, MongoMemoryReplSet } from "mongodb-memory-server";
+import { IP, REPLICA_SET_PORT, SERVER_PORT } from "./constants";
+
+export default async function () {
+  try {
+    const mongoMemoryServerInstance = await MongoMemoryServer.create({
+      instance: {
+        port: SERVER_PORT,
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_SERVER_INSTANCE = mongoMemoryServerInstance;
+
+    const mongoMemoryServerReplicaSet = await MongoMemoryReplSet.create({
+      instanceOpts: [
+        {
+          port: REPLICA_SET_PORT,
+        },
+      ],
+      replSet: {
+        ip: IP,
+      },
+    });
+    (global as any).__MONGO_MEMORY_REPLICA_SET = mongoMemoryServerReplicaSet;
+  } catch (error) {
+    console.error("Error in global setup:", error);
+    throw error;
+  }
+}

--- a/packages/mongodb-rag-ingest/src/test/globalTeardown.ts
+++ b/packages/mongodb-rag-ingest/src/test/globalTeardown.ts
@@ -1,0 +1,13 @@
+module.exports = async function () {
+  try {
+    if ((global as any).__MONGO_MEMORY_SERVER_INSTANCE) {
+      await (global as any).__MONGO_MEMORY_SERVER_INSTANCE.stop();
+    }
+    if ((global as any).__MONGO_MEMORY_REPLICA_SET) {
+      await (global as any).__MONGO_MEMORY_REPLICA_SET.stop();
+    }
+  } catch (error) {
+    console.error("Error in global teardown:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-655

## Changes

- instances of mongo memory server and mongo memory replica set are created in jest globalSetup, and stopped in globalTeardown instead of beforeAll and afterAll hooks in individual test files

## Notes

- globalSetup.ts is run only once. The server instance and replica set are created there with known server port and ip. The uri needed to connect to these can be determined by the ip and port. The uri is used in test files to connect to whichever the test file needs (server instance or replica set).
