### PR TITLE
Fix race condition in CI

### DIFF
--- a/packages/benchmarks/src/textToDriver/executeGeneratedDriverCode.test.ts
+++ b/packages/benchmarks/src/textToDriver/executeGeneratedDriverCode.test.ts
@@ -12,7 +12,7 @@ describe("executeGeneratedDriverCode", () => {
   let mongoClient: MongoClient;
   let db: Db;
   let collection: Collection<Document>;
-  const databaseName = "testdb";
+  const databaseName = "executeGeneratedDriverCode";
   const collectionName = "testCollection";
 
   beforeAll(async () => {

--- a/packages/benchmarks/src/textToDriver/generateDriverCode/makeGenerateDriverCode.test.ts
+++ b/packages/benchmarks/src/textToDriver/generateDriverCode/makeGenerateDriverCode.test.ts
@@ -20,7 +20,7 @@ describe("makeGenerateDriverCode", () => {
   let mongoClient: MongoClient;
   let db: Db;
   let collection: Collection<Document>;
-  const databaseName = "testdb";
+  const databaseName = "makeGenerateDriverCode";
   const collectionName = "testCollection";
 
   beforeAll(async () => {


### PR DESCRIPTION
Jira: n/a

## Changes

- Rename the DBs in the benchmarking suite to fix potential race condition with reading/writing to collections that'd been causing CI failures (see https://drone.corp.mongodb.com/mongodb/chatbot/4411/1/2)
-

## Notes

-
