### PR TITLE
(EAI-861): Benchmark badge questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27578,6 +27578,19 @@
       "version": "5.6.0",
       "license": "MIT"
     },
+    "node_modules/csv-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
+      "integrity": "sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/csv-stringify": {
       "version": "6.5.2",
       "license": "MIT"
@@ -52485,6 +52498,8 @@
         "@types/node-fetch": "^2.6.4",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
+        "chatbot-server-mongodb-public": "*",
+        "csv-parser": "^3.2.0",
         "eslint": "^8",
         "eslint-config-prettier": "^8",
         "eslint-plugin-jsdoc": "^46.4.5",

--- a/packages/benchmarks/.gitignore
+++ b/packages/benchmarks/.gitignore
@@ -126,3 +126,4 @@ build/
 # vscode
 .vscode/
 
+testData/

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -20,6 +20,8 @@
     "textToDriver:makeDatabases": "npm run build && node ./build/textToDriver/makeDatabases/index.js",
     "benchmark:MongoDbDiscovery": "npm run build && node ./build/discovery/mongoDbDiscoveryBenchmark.js",
     "benchmark:MongoDbUniversityQuizQuestion": "npm run build && node ./build/quizQuestions/mongoDbUniversityQuizQuestionBenchmark.js",
+    "benchmark:MongodbUniversityAllQuestionBenchmark": "npm run build && node ./build/quizQuestions/mongodbUniversityAllQuestionBenchmark.js",
+    "benchmark:MongoDbUniversityBadgeQuestionBenchmark": "npm run build && node ./build/quizQuestions/mongoDbUniversityBadgeQuestionBenchmark.js",
     "benchmark:TextToNodeJsDriver": "npm run build && node ./build/textToDriver/nodeJsDriverBenchmark.js"
   },
   "devDependencies": {

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -30,6 +30,8 @@
     "@types/node-fetch": "^2.6.4",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
+    "csv-parser": "^3.2.0",
+    "chatbot-server-mongodb-public": "*",
     "eslint": "^8",
     "eslint-config-prettier": "^8",
     "eslint-plugin-jsdoc": "^46.4.5",

--- a/packages/benchmarks/src/models.ts
+++ b/packages/benchmarks/src/models.ts
@@ -77,7 +77,7 @@ export const models: ModelConfig[] = [
     label: "gpt-4o",
     deployment: "gpt-4o",
     developer: "OpenAI",
-    maxConcurrency: 1,
+    maxConcurrency: 2,
     provider: "azure_openai",
     metadata: {
       modelVersion: "2024-08-06",
@@ -221,6 +221,15 @@ export const models: ModelConfig[] = [
   {
     label: "gemini-1.5-flash-002",
     deployment: "google/gemini-1.5-flash-002",
+    developer: "Google",
+    maxConcurrency: 3,
+    provider: "gcp_vertex_ai",
+    systemMessageAsUserMessage: false,
+    authorized: true,
+  },
+  {
+    label: "gemini-2-flash",
+    deployment: "models/gemini-2.0-flash-001",
     developer: "Google",
     maxConcurrency: 3,
     provider: "gcp_vertex_ai",

--- a/packages/benchmarks/src/quizQuestions/QuizQuestionData.ts
+++ b/packages/benchmarks/src/quizQuestions/QuizQuestionData.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 
 export const QuizQuestionDataSchema = z.object({
-  questionText: z.string(),
-  contentTitle: z.string().optional(),
-  title: z.string().optional(),
-  topicType: z.string().optional(),
-  questionType: z.string().optional(),
+  questionText: z.string().describe("The question text"),
+  contentTitle: z
+    .string()
+    .optional()
+    .describe("The title of the content associated with the assessment"),
+  title: z.string().optional().describe("The title of the assessment"),
+  topicType: z.enum(["quiz", "badge"]).optional(),
+  questionType: z.enum(["multipleCorrect", "singleCorrect"]).optional(),
   answers: z.array(
     z.object({
       answer: z.string(),
@@ -13,6 +16,11 @@ export const QuizQuestionDataSchema = z.object({
       label: z.string(),
     })
   ),
+  explanation: z
+    .string()
+    .optional()
+    .describe("Brief explanation of the answer"),
+  tags: z.array(z.string()).optional(),
 });
 
 export type QuizQuestionData = z.infer<typeof QuizQuestionDataSchema>;

--- a/packages/benchmarks/src/quizQuestions/QuizQuestionEval.ts
+++ b/packages/benchmarks/src/quizQuestions/QuizQuestionEval.ts
@@ -12,12 +12,24 @@ import {
   MakeHelmQuizQuestionPromptParams,
 } from "./makeHelmQuizQuestionPrompt";
 
-export type QuizQuestionEvalCaseInput = QuizQuestionData;
+export type QuizQuestionEvalCaseInput = Pick<
+  QuizQuestionData,
+  "questionText" | "answers" | "questionType"
+>;
 
 export type QuizQuestionTag = string;
 
+export type QuizQuestionMetadata = Pick<
+  QuizQuestionData,
+  "contentTitle" | "explanation" | "title"
+>;
+
 export interface QuizQuestionEvalCase
-  extends EvalCase<QuizQuestionEvalCaseInput, QuizQuestionTaskExpected, void> {
+  extends EvalCase<
+    QuizQuestionEvalCaseInput,
+    QuizQuestionTaskExpected,
+    QuizQuestionMetadata
+  > {
   tags?: QuizQuestionTag[];
 }
 

--- a/packages/benchmarks/src/quizQuestions/getQuizQuestionEvalCasesFromBraintrust.ts
+++ b/packages/benchmarks/src/quizQuestions/getQuizQuestionEvalCasesFromBraintrust.ts
@@ -32,10 +32,22 @@ export async function getQuizQuestionEvalCasesFromBraintrust({
       if (qq.questionType) {
         tags.push(qq.questionType);
       }
+      if (qq.tags) {
+        tags.push(...qq.tags);
+      }
       return {
-        input: qq,
+        input: {
+          questionText: qq.questionText,
+          answers: qq.answers,
+          questionType: qq.questionType,
+        },
         tags: tags.length > 0 ? tags : undefined,
         expected: quizQuestionToHelmAnswer(qq),
+        metadata: {
+          contentTitle: qq.contentTitle,
+          explanation: qq.explanation,
+          title: qq.title,
+        },
       } satisfies QuizQuestionEvalCase;
     });
   return quizQuestionData;

--- a/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.test.ts
+++ b/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.test.ts
@@ -9,8 +9,8 @@ const subject = "food";
 const testQuestion = {
   contentTitle: "Best foods",
   title: "Best foods",
-  topicType: "food",
-  questionType: "multiple_choice",
+  topicType: "quiz",
+  questionType: "multipleCorrect",
   questionText: "What's the best Italian food?",
   answers: [
     {
@@ -106,5 +106,11 @@ describe("makeHelmQuizQuestionPrompt", () => {
         "The following are multiple choice questions (with answers)."
       )
     ).toBe(true);
+  });
+  it("should include few-shot examples", () => {
+    // todo
+  });
+  it("should only include examples with one correct answer for topicType=singleCorrect questions", () => {
+    // todo
   });
 });

--- a/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.test.ts
+++ b/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.test.ts
@@ -25,6 +25,36 @@ const testQuestion = {
     },
     {
       answer: "Sushi",
+      isCorrect: true,
+      label: "C",
+    },
+    {
+      answer: "Enchiladas",
+      isCorrect: false,
+      label: "D",
+    },
+  ],
+} satisfies QuizQuestionData;
+
+const testQuestionSingleCorrect = {
+  contentTitle: "Best foods",
+  title: "Best foods",
+  topicType: "quiz",
+  questionType: "singleCorrect",
+  questionText: "What's the best Italian food?",
+  answers: [
+    {
+      answer: "Tacos",
+      isCorrect: false,
+      label: "A",
+    },
+    {
+      answer: "Pizza",
+      isCorrect: true,
+      label: "B",
+    },
+    {
+      answer: "Sushi",
       isCorrect: false,
       label: "C",
     },
@@ -108,9 +138,66 @@ describe("makeHelmQuizQuestionPrompt", () => {
     ).toBe(true);
   });
   it("should include few-shot examples", () => {
-    // todo
+    const prompt = makeHelmQuizQuestionPrompt({
+      quizQuestion: testQuestion,
+      quizQuestionExamples: [testQuestion],
+      subject,
+    });
+    expect(prompt).toMatchObject([
+      {
+        role: "system",
+        content: expect.any(String),
+      },
+      {
+        content: expect.any(String),
+        role: "user",
+      },
+      {
+        content: expect.any(String),
+        role: "assistant",
+      },
+      {
+        content: expect.any(String),
+        role: "user",
+      },
+    ]);
   });
   it("should only include examples with one correct answer for topicType=singleCorrect questions", () => {
-    // todo
+    const prompt = makeHelmQuizQuestionPrompt({
+      quizQuestion: testQuestionSingleCorrect,
+      quizQuestionExamples: [
+        {
+          ...testQuestion,
+          answers: [
+            ...testQuestion.answers,
+            {
+              answer: "Pasta",
+              isCorrect: true,
+              label: "E",
+            },
+          ],
+        },
+        testQuestionSingleCorrect,
+      ],
+      subject,
+    });
+    expect(prompt).toMatchObject([
+      {
+        role: "system",
+        content: expect.any(String),
+      },
+      {
+        content: expect.any(String),
+        role: "user",
+      },
+      {
+        content: expect.any(String),
+        role: "assistant",
+      },
+      {
+        content: expect.any(String),
+        role: "user",
+      },
+    ]);
   });
 });

--- a/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.ts
+++ b/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.ts
@@ -98,7 +98,7 @@ Only provide the answer the final question using the exact same format as the pr
   const fewShotExamples = quizQuestionExamples
     ?.filter((quizQuestionExample) => {
       // if single correct, only include examples with one correct answer
-      if (quizQuestionExample.questionType === "singleCorrect") {
+      if (quizQuestion.questionType === "singleCorrect") {
         return (
           quizQuestionExample.answers?.filter((answer) => answer.isCorrect)
             .length === 1

--- a/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.ts
+++ b/packages/benchmarks/src/quizQuestions/makeHelmQuizQuestionPrompt.ts
@@ -95,19 +95,33 @@ Only provide the answer the final question using the exact same format as the pr
     role: "system",
     content: systemPromptContent,
   } satisfies ChatMessage;
-  const fewShotExamples = quizQuestionExamples?.map(
-    (quizQuestionExample) =>
-      [
-        {
-          role: "user",
-          content: quizQuestionToHelmPrompt(quizQuestionExample, false),
-        },
-        {
-          role: "assistant",
-          content: quizQuestionToHelmAnswer(quizQuestionExample),
-        },
-      ] satisfies ChatMessage[]
-  );
+  const fewShotExamples = quizQuestionExamples
+    ?.filter((quizQuestionExample) => {
+      // if single correct, only include examples with one correct answer
+      if (quizQuestionExample.questionType === "singleCorrect") {
+        return (
+          quizQuestionExample.answers?.filter((answer) => answer.isCorrect)
+            .length === 1
+        );
+      }
+
+      // if multiple correct, include all examples
+      return true;
+    })
+    ?.map(
+      (quizQuestionExample) =>
+        [
+          {
+            role: "user",
+            content: quizQuestionToHelmPrompt(quizQuestionExample, false),
+          },
+          {
+            role: "assistant",
+            content: quizQuestionToHelmAnswer(quizQuestionExample),
+          },
+        ] satisfies ChatMessage[]
+    );
+
   const currentQuestion = {
     role: "user",
     content: quizQuestionToHelmPrompt(quizQuestion, false),

--- a/packages/benchmarks/src/quizQuestions/mongoDbUniversityBadgeQuestionBenchmark.ts
+++ b/packages/benchmarks/src/quizQuestions/mongoDbUniversityBadgeQuestionBenchmark.ts
@@ -23,21 +23,11 @@ async function main() {
     // Filter to only look at 'badge' questions here
     .filter((d) => d.tags?.includes("badge"));
 
-  const modelsToEvaluate = [
-    "gpt-4o",
-    "claude-35-sonnet-v2",
-    "llama-3.1-70b",
-    "nova-pro-v1:0",
-    "mistral-large-2",
-    "gemini-2-flash",
-  ];
-  const modelExperiments = models.filter((m) =>
-    modelsToEvaluate.includes(m.label)
-  );
+  const modelExperiments = models.filter((m) => m.authorized === true);
 
   // Process models in parallel
   await PromisePool.for(modelExperiments)
-    .withConcurrency(modelsToEvaluate.length)
+    .withConcurrency(6)
 
     .process(async (modelInfo) => {
       let experimentName = modelInfo.label + "-badge";

--- a/packages/benchmarks/src/quizQuestions/mongoDbUniversityBadgeQuestionBenchmark.ts
+++ b/packages/benchmarks/src/quizQuestions/mongoDbUniversityBadgeQuestionBenchmark.ts
@@ -1,0 +1,71 @@
+import { models } from "../models";
+import "dotenv/config";
+import PromisePool from "@supercharge/promise-pool";
+import { runQuizQuestionEval } from "./QuizQuestionEval";
+import { getQuizQuestionEvalCasesFromBraintrust } from "./getQuizQuestionEvalCasesFromBraintrust";
+import { mongoDbQuizQuestionExamples } from "./mongoDbQuizQuestionExamples";
+import { openAiClientFactory } from "../openAiClients";
+
+async function main() {
+  const DEFAULT_MAX_CONCURRENCY = 15;
+
+  const { RUN_ID } = process.env;
+
+  const projectName = "mongodb-multiple-choice";
+  const datasetName = "university-quiz-badge-questions";
+
+  const data = (
+    await getQuizQuestionEvalCasesFromBraintrust({
+      projectName,
+      datasetName,
+    })
+  )
+    // Filter to only look at 'badge' questions here
+    .filter((d) => d.tags?.includes("badge"));
+
+  const modelsToEvaluate = [
+    "gpt-4o",
+    "claude-35-sonnet-v2",
+    "llama-3.1-70b",
+    "nova-pro-v1:0",
+    "mistral-large-2",
+    "gemini-2-flash",
+  ];
+  const modelExperiments = models.filter((m) =>
+    modelsToEvaluate.includes(m.label)
+  );
+
+  // Process models in parallel
+  await PromisePool.for(modelExperiments)
+    .withConcurrency(modelsToEvaluate.length)
+
+    .process(async (modelInfo) => {
+      let experimentName = modelInfo.label + "-badge";
+      if (RUN_ID) {
+        experimentName += `?runId=${RUN_ID}`;
+      }
+      console.log(`Running experiment: ${experimentName}`);
+      try {
+        await runQuizQuestionEval({
+          projectName,
+          model: modelInfo.deployment,
+          openaiClient: openAiClientFactory.makeOpenAiClient(modelInfo),
+          experimentName,
+          additionalMetadata: {
+            ...modelInfo,
+            badgeOnly: true,
+          },
+          maxConcurrency: modelInfo.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+          data,
+          promptOptions: {
+            subject: "MongoDB",
+            quizQuestionExamples: mongoDbQuizQuestionExamples,
+          },
+        });
+      } catch (err) {
+        console.error("Error running Braintrust");
+        console.error(err);
+      }
+    });
+}
+main();

--- a/packages/benchmarks/src/quizQuestions/mongodbUniversityAllQuestionBenchmark.ts
+++ b/packages/benchmarks/src/quizQuestions/mongodbUniversityAllQuestionBenchmark.ts
@@ -1,0 +1,67 @@
+import { models } from "../models";
+import "dotenv/config";
+import PromisePool from "@supercharge/promise-pool";
+import { runQuizQuestionEval } from "./QuizQuestionEval";
+import { getQuizQuestionEvalCasesFromBraintrust } from "./getQuizQuestionEvalCasesFromBraintrust";
+import { mongoDbQuizQuestionExamples } from "./mongoDbQuizQuestionExamples";
+import { openAiClientFactory } from "../openAiClients";
+
+async function main() {
+  const DEFAULT_MAX_CONCURRENCY = 15;
+
+  const { RUN_ID } = process.env;
+
+  const projectName = "mongodb-multiple-choice";
+  const datasetName = "university-quiz-badge-questions";
+
+  const data = await getQuizQuestionEvalCasesFromBraintrust({
+    projectName,
+    datasetName,
+  });
+
+  // These were the requested models to evaluate
+  const modelsToEvaluate = [
+    "gpt-4o",
+    "claude-35-sonnet-v2",
+    "llama-3.1-70b",
+    "nova-pro-v1:0",
+    "mistral-large-2",
+    "gemini-2-flash",
+  ];
+  const modelExperiments = models.filter((m) =>
+    modelsToEvaluate.includes(m.label)
+  );
+
+  // Process models in parallel
+  await PromisePool.for(modelExperiments)
+    .withConcurrency(modelsToEvaluate.length)
+
+    .process(async (modelInfo) => {
+      let experimentName = modelInfo.label;
+      if (RUN_ID) {
+        experimentName += `?runId=${RUN_ID}`;
+      }
+      console.log(`Running experiment: ${experimentName}`);
+      try {
+        await runQuizQuestionEval({
+          projectName,
+          model: modelInfo.deployment,
+          openaiClient: openAiClientFactory.makeOpenAiClient(modelInfo),
+          experimentName,
+          additionalMetadata: {
+            ...modelInfo,
+          },
+          maxConcurrency: modelInfo.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+          data,
+          promptOptions: {
+            subject: "MongoDB",
+            quizQuestionExamples: mongoDbQuizQuestionExamples,
+          },
+        });
+      } catch (err) {
+        console.error("Error running Braintrust");
+        console.error(err);
+      }
+    });
+}
+main();

--- a/packages/benchmarks/src/quizQuestions/scripts/annotateBraintrustQuestions.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/annotateBraintrustQuestions.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import { QuizQuestionData, QuizQuestionDataSchema } from "../QuizQuestionData";
+import { makeTags } from "./makeTags";
+const testDataPath = path.resolve(__dirname, "..", "..", "..", "testData");
+const fileInPath = path.resolve(testDataPath, "university-quiz-questions.json");
+const jsonFileOutPath = path.resolve(
+  testDataPath,
+  "university-quiz-questions-annotated.json"
+);
+
+const augmentJson = (filePath: string): QuizQuestionData[] => {
+  const results: QuizQuestionData[] = [];
+  const qqs = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  for (const qq of qqs) {
+    const quizQuestion = qq.input as QuizQuestionData;
+    quizQuestion.questionType = "multipleCorrect";
+    quizQuestion.tags = makeTags(quizQuestion);
+    results.push(quizQuestion);
+  }
+  return results.map(
+    (qq) => QuizQuestionDataSchema.parse(qq) satisfies QuizQuestionData
+  );
+};
+
+(() => {
+  try {
+    console.log("Parsing file in ", fileInPath);
+    const quizQuestions = augmentJson(fileInPath);
+    fs.writeFileSync(
+      jsonFileOutPath,
+      JSON.stringify(quizQuestions, null, 2),
+      "utf-8"
+    );
+    console.log("Quiz questions written to ", jsonFileOutPath);
+  } catch (error) {
+    console.error("Error parsing CSV:", error);
+  }
+})();

--- a/packages/benchmarks/src/quizQuestions/scripts/annotateBraintrustQuestions.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/annotateBraintrustQuestions.ts
@@ -9,6 +9,9 @@ const jsonFileOutPath = path.resolve(
   "university-quiz-questions-annotated.json"
 );
 
+/**
+   Add metadata such as tags and the correct question type to previous quiz questions.
+ */
 const augmentJson = (filePath: string): QuizQuestionData[] => {
   const results: QuizQuestionData[] = [];
   const qqs = JSON.parse(fs.readFileSync(filePath, "utf-8"));

--- a/packages/benchmarks/src/quizQuestions/scripts/countQuestionsByTag.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/countQuestionsByTag.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+import { QuizQuestionData, QuizQuestionDataSchema } from "../QuizQuestionData";
+const testDataPath = path.resolve(__dirname, "..", "..", "..", "testData");
+const fileInPath = path.resolve(testDataPath, "quiz-badge-questions.json");
+
+const createReportForFile = (filePath: string) => {
+  const qs = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown[];
+  const allQuestions = qs.map(
+    (q) => QuizQuestionDataSchema.parse(q) satisfies QuizQuestionData
+  );
+  const report = makeReport(allQuestions);
+  console.log(report);
+};
+
+function countTags(questions: QuizQuestionData[]): Record<string, number> {
+  return questions.reduce((acc, q) => {
+    q.tags?.forEach((tag) => {
+      acc[tag] = acc[tag] ? acc[tag] + 1 : 1;
+    });
+    return acc;
+  }, {} as Record<string, number>);
+}
+function makeReport(questions: QuizQuestionData[]): string {
+  const tagCounts = countTags(questions);
+  const tags = Object.keys(tagCounts).sort();
+  const counts = tags.map((tag) => `'${tag}': ${tagCounts[tag]}`).join("\n");
+  return `MDBU Question Report
+  
+${counts}
+
+Total number of questions: ${questions.length}`;
+}
+
+createReportForFile(fileInPath);

--- a/packages/benchmarks/src/quizQuestions/scripts/loadBadgeQuizQuestions.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/loadBadgeQuizQuestions.ts
@@ -1,0 +1,57 @@
+import fs from "fs";
+import path from "path";
+import csv from "csv-parser";
+import { QuizQuestionData, QuizQuestionDataSchema } from "../QuizQuestionData";
+import { makeTags } from "./makeTags";
+
+const testDataPath = path.resolve(__dirname, "..", "..", "..", "testData");
+const csvFileInPath = path.resolve(testDataPath, "badge-questions.csv");
+const jsonFileOutPath = path.resolve(testDataPath, "badge-questions.json");
+
+const parseCSV = async (filePath: string): Promise<QuizQuestionData[]> => {
+  return new Promise((resolve, reject) => {
+    const results: QuizQuestionData[] = [];
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on("data", (row) => {
+        try {
+          const answers = ["A", "B", "C", "D"].map((label, index) => ({
+            answer: row[label],
+            isCorrect: row.Answer === (index + 1).toString(),
+            label,
+          }));
+
+          const questionData: QuizQuestionData = QuizQuestionDataSchema.parse({
+            questionText: row["Question Text"],
+            title: row["Assessment"],
+            topicType: "quiz", // Defaulting topic type
+            questionType: "singleCorrect", // Assuming single correct answer
+            answers,
+            explanation: row["Reference"],
+            tags: row["tags"] ? row["tags"].split(",") : [],
+          });
+          questionData.tags = makeTags(questionData);
+          results.push(questionData);
+        } catch (error) {
+          console.error("Validation error:", error);
+        }
+      })
+      .on("end", () => resolve(results))
+      .on("error", (error) => reject(error));
+  });
+};
+
+(async () => {
+  try {
+    console.log("Parsing CSV file ", csvFileInPath);
+    const quizQuestions = await parseCSV(csvFileInPath);
+    fs.writeFileSync(
+      jsonFileOutPath,
+      JSON.stringify(quizQuestions, null, 2),
+      "utf-8"
+    );
+    console.log("Quiz questions written to ", jsonFileOutPath);
+  } catch (error) {
+    console.error("Error parsing CSV:", error);
+  }
+})();

--- a/packages/benchmarks/src/quizQuestions/scripts/loadBadgeQuizQuestions.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/loadBadgeQuizQuestions.ts
@@ -24,7 +24,7 @@ const parseCSV = async (filePath: string): Promise<QuizQuestionData[]> => {
           const questionData: QuizQuestionData = QuizQuestionDataSchema.parse({
             questionText: row["Question Text"],
             title: row["Assessment"],
-            topicType: "quiz", // Defaulting topic type
+            topicType: "badge", // Defaulting topic type
             questionType: "singleCorrect", // Assuming single correct answer
             answers,
             explanation: row["Reference"],

--- a/packages/benchmarks/src/quizQuestions/scripts/makeTags.ts
+++ b/packages/benchmarks/src/quizQuestions/scripts/makeTags.ts
@@ -1,0 +1,79 @@
+import { mongoDbMetadata } from "chatbot-server-mongodb-public";
+import { QuizQuestionData } from "../QuizQuestionData";
+
+const { mongoDbProductNames, mongoDbTopics, mongoDbProgrammingLanguages } =
+  mongoDbMetadata;
+
+const programmingLanguageTags = [
+  ...mongoDbProgrammingLanguages
+    .map((pl) => pl.id)
+    .filter((pl) => pl !== "c" && pl !== "go"),
+  "c#",
+  "c++",
+  "node.js",
+];
+const topicTags = mongoDbTopics.map((t) => t.id);
+
+const productNames = mongoDbProductNames.map((pn) => pn.toLocaleLowerCase());
+
+export function makeTags(qq: QuizQuestionData) {
+  const tags: string[] = qq.tags ?? [];
+  for (const pl of programmingLanguageTags) {
+    if (
+      qq.title?.toLowerCase().includes(pl) ||
+      qq.contentTitle?.toLowerCase().includes(pl)
+    ) {
+      if (pl === "c#") {
+        tags.push("csharp");
+      } else if (pl === "c++") {
+        tags.push("cpp");
+      } else if (pl === "node.js") {
+        tags.push("javascript");
+      } else {
+        tags.push(pl);
+      }
+    }
+  }
+  if (
+    qq.questionText.toLowerCase().includes("C Driver") ||
+    qq.title?.toLowerCase().includes("C Driver") ||
+    qq.contentTitle?.toLowerCase().includes("C Driver")
+  ) {
+    tags.push("c");
+  }
+  if (
+    qq.questionText.toLowerCase().includes("Go Driver") ||
+    qq.title?.toLowerCase().includes("Go Driver") ||
+    qq.contentTitle?.toLowerCase().includes("Go Driver")
+  ) {
+    tags.push("go");
+  }
+  for (const t of topicTags) {
+    if (
+      qq.questionText.toLowerCase().includes(t) ||
+      qq.title?.toLowerCase().includes(t) ||
+      qq.contentTitle?.toLowerCase().includes(t)
+    ) {
+      tags.push(t);
+    }
+  }
+  for (const pn of productNames) {
+    if (
+      qq.questionText.toLowerCase().includes(pn) ||
+      qq.title?.toLowerCase().includes(pn) ||
+      qq.contentTitle?.toLowerCase().includes(pn)
+    ) {
+      tags.push(pn);
+    }
+  }
+  if (
+    qq.title?.toLowerCase().includes("modeling") ||
+    qq.title?.toLowerCase().includes("schema") ||
+    qq.contentTitle?.toLowerCase().includes("schema design")
+  ) {
+    tags.push("data_modeling");
+  }
+  return Array.from(
+    new Set(tags.map((t) => t.toLowerCase().split(" ").join("_")))
+  );
+}

--- a/packages/chatbot-server-mongodb-public/src/lib.ts
+++ b/packages/chatbot-server-mongodb-public/src/lib.ts
@@ -3,3 +3,4 @@
   Export some modules from the implementation for use in things like evaluation.
  */
 export { systemPrompt } from "./systemPrompt";
+export * as mongoDbMetadata from "./mongoDbMetadata";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-861

## Changes

- Add Badge questions to Braintrust
- New benchmark for badge questions on all models
- Benchmark for badge+quiz questions on select models (requested by Chris for presentation to execs)

## Notes

- [Braintrust experiments](https://www.braintrust.dev/app/mdb-test/p/mongodb-multiple-choice/experiments?y=score|CorrectQuizAnswer&ye=metric|duration,metric|llm_duration,metric|prompt_tokens,metric|completion_tokens,metric|total_tokens,metadata|[%22llmOptions%22%252C%22max_tokens%22],metadata|[%22maxConcurrency%22]&v=Badge+Only)
- [Uni badge questions](https://docs.google.com/spreadsheets/d/1WrBdl-KJXgphLZlTu7cohOsl1361h64sOD-sU9Hat0Q/edit?gid=1342745844#gid=1342745844) (not particularly sensitive, but please do not share externally) 
