### PR TITLE
(EAI-857) Create rST meta description import tool

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,6 +9,7 @@
     "createQualityTestsYaml-sept-2023": "npm run build && node ./build/createSept2023QualityTestsYaml.js",
     "scrubMessages": "npm run build && node ./build/scrubMessages.js",
     "sampleAndSaveMarkdownPages": "npm run build && node ./build/sampleAndSaveMarkdownPages.js",
+    "upsertMetaDirective": "npm run build && node ./build/upsertMetaDirective.js",
     "analyzeMessages": "npm run build && node ./build/analyzeMessages.js",
     "findFaq": "npm run build && node ./build/main/findFaqMain.js",
     "upgradeFaqEntries": "npm run build && node ./build/main/upgradeFaqEntriesMain.js",

--- a/packages/scripts/src/meta2rst.test.ts
+++ b/packages/scripts/src/meta2rst.test.ts
@@ -218,8 +218,10 @@ This Is The Page Title
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. meta::
-   :keywords: This is a keyword.
-   :description: This is a description.`;
+   :keywords: code example
+   :description: This is the original description.
+
+Some more text`;
 
     const updatedPageContent = upsertMetaDirective(rstContent, {
       keywords: null,
@@ -232,7 +234,9 @@ This Is The Page Title
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. meta::
-   :keywords: This is a keyword.
-   :description: This is the updated description.`);
+   :keywords: code example
+   :description: This is the updated description.
+
+Some more text`);
   });
 });

--- a/packages/scripts/src/meta2rst.test.ts
+++ b/packages/scripts/src/meta2rst.test.ts
@@ -4,6 +4,7 @@ import {
   hasMetaDirective,
   constructMetaDirective,
   findRstPageTitle,
+  upsertMetaDirective,
 } from "./meta2rst";
 
 const rstContent = `Some content here.
@@ -184,5 +185,54 @@ This Is The Page Title
       findRstPageTitle(`This Is The Page Title
 ----------------------`)
     ).toEqual(2);
+  });
+});
+
+describe("upsertMetaDirective", () => {
+  it("adds a meta directive to a page that doesn't have one", () => {
+    const rstContent = `.. _this-is-a-page-anchor:
+
+~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~`;
+
+    const updatedPageContent = upsertMetaDirective(rstContent, {
+      description: "This is a description.",
+      keywords: "This is a keyword.",
+    });
+    expect(updatedPageContent).toEqual(
+      rstContent +
+        "\n\n" +
+        `.. meta::
+   :keywords: This is a keyword.
+   :description: This is a description.
+`
+    );
+  });
+
+  it("updates a meta directive on a page that already has one", () => {
+    const rstContent = `.. _this-is-a-page-anchor:
+
+~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. meta::
+   :keywords: This is a keyword.
+   :description: This is a description.`;
+
+    const updatedPageContent = upsertMetaDirective(rstContent, {
+      keywords: null,
+      description: "This is the updated description.",
+    });
+    expect(updatedPageContent).toEqual(`.. _this-is-a-page-anchor:
+
+~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. meta::
+   :keywords: This is a keyword.
+   :description: This is the updated description.`);
   });
 });

--- a/packages/scripts/src/meta2rst.test.ts
+++ b/packages/scripts/src/meta2rst.test.ts
@@ -193,6 +193,26 @@ This Is The Page Title
 ----------------------`)
     ).toEqual(2);
   });
+
+  it("works if there's a frontmatter field list", () => {
+    const rstContent = `:template: product-landing
+:hidefeedback: header
+:noprevnext:
+
+.. _this-is-a-page-anchor:
+
+~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+This is some content`;
+    const lineNumber = findRstPageTitle(rstContent);
+    expect(lineNumber).toEqual(9);
+  });
 });
 
 describe("upsertMetaDirective", () => {

--- a/packages/scripts/src/meta2rst.test.ts
+++ b/packages/scripts/src/meta2rst.test.ts
@@ -1,0 +1,188 @@
+import {
+  updateMetaDescription,
+  getMetaField,
+  hasMetaDirective,
+  constructMetaDirective,
+  findRstPageTitle,
+} from "./meta2rst";
+
+const rstContent = `Some content here.
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to improve the performance of an application.
+
+More content here.`;
+
+describe("hasMetaDirective", () => {
+  it("returns true if the meta directive exists", () => {
+    expect(hasMetaDirective(rstContent)).toBe(true);
+  });
+
+  it("returns false if the meta directive does not exist", () => {
+    const rstContent = `Some content here.
+
+More content here.`;
+    expect(hasMetaDirective(rstContent)).toBe(false);
+  });
+});
+
+describe("getMetaField", () => {
+  it("returns the description field if it exists", () => {
+    const description = getMetaField(rstContent, "description");
+    expect(description).toEqual(
+      "Learn how to improve the performance of an application."
+    );
+  });
+
+  it("returns the keywords field if it exists", () => {
+    const keywords = getMetaField(rstContent, "keywords");
+    expect(keywords).toEqual("code example");
+  });
+
+  it("returns null if the field is not found", () => {
+    const rstContent = `Some content here.
+
+.. meta::
+   :keywords: code example
+
+More content here.`;
+    const descriptionField = getMetaField(rstContent, "description");
+    expect(descriptionField).toBeNull();
+  });
+});
+
+describe("updateMetaDescription", () => {
+  it("adds a description to an existing meta directive that doesn't have one", () => {
+    const rstContent = `Some content here.
+
+.. meta::
+   :keywords: code example
+
+More content here.`;
+
+    const updatedContent = updateMetaDescription(
+      rstContent,
+      "Learn how to improve the performance of an application."
+    );
+    console.log(updatedContent);
+
+    const expectedUpdatedContent = `Some content here.
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to improve the performance of an application.
+
+More content here.`;
+    expect(updatedContent).toEqual(expectedUpdatedContent);
+  });
+
+  it("updates a description on an existing meta directive that already has one", () => {
+    const updatedContent = updateMetaDescription(
+      rstContent,
+      "This is the updated description."
+    );
+    console.log(updatedContent);
+
+    const expectedUpdatedContent = `Some content here.
+
+.. meta::
+   :keywords: code example
+   :description: This is the updated description.
+
+More content here.`;
+    expect(updatedContent).toEqual(expectedUpdatedContent);
+  });
+});
+
+describe("constructMetaDirective", () => {
+  it("returns an empty string if both description and keywords are null", () => {
+    const metaDirective = constructMetaDirective({
+      description: null,
+      keywords: null,
+    });
+    expect(metaDirective).toEqual("");
+  });
+
+  it("returns a meta directive with a description field if only description is provided", () => {
+    const metaDirective = constructMetaDirective({
+      description: "This is a description.",
+      keywords: null,
+    });
+    expect(metaDirective).toEqual(`.. meta::
+   :description: This is a description.`);
+  });
+
+  it("returns a meta directive with a keywords field if only keywords are provided", () => {
+    const metaDirective = constructMetaDirective({
+      description: null,
+      keywords: "This is a keyword.",
+    });
+    expect(metaDirective).toEqual(`.. meta::
+   :keywords: This is a keyword.`);
+  });
+
+  it("returns a meta directive with both description and keywords fields if both are provided", () => {
+    const metaDirective = constructMetaDirective({
+      description: "This is a description.",
+      keywords: "This is a keyword.",
+    });
+    expect(metaDirective).toEqual(`.. meta::
+   :keywords: This is a keyword.
+   :description: This is a description.`);
+  });
+});
+
+describe("findRstPageTitle", () => {
+  it("returns the line number of the page title if it exists", () => {
+    const rstContent = `.. _this-is-a-page-anchor:
+
+~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+This is some content`;
+    const lineNumber = findRstPageTitle(rstContent);
+    expect(lineNumber).toEqual(5);
+  });
+
+  it("returns -1 if no page title is found", () => {
+    const lineNumber = findRstPageTitle(rstContent);
+    expect(lineNumber).toEqual(-1);
+  });
+
+  it("works for all the valid title formats", () => {
+    expect(
+      findRstPageTitle(`~~~~~~~~~~~~~~~~~~~~~~
+This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~`)
+    ).toEqual(3);
+    expect(
+      findRstPageTitle(`======================
+This Is The Page Title
+======================`)
+    ).toEqual(3);
+    expect(
+      findRstPageTitle(`----------------------
+This Is The Page Title
+----------------------`)
+    ).toEqual(3);
+
+    expect(
+      findRstPageTitle(`This Is The Page Title
+~~~~~~~~~~~~~~~~~~~~~~`)
+    ).toEqual(2);
+    expect(
+      findRstPageTitle(`This Is The Page Title
+======================`)
+    ).toEqual(2);
+    expect(
+      findRstPageTitle(`This Is The Page Title
+----------------------`)
+    ).toEqual(2);
+  });
+});

--- a/packages/scripts/src/meta2rst.ts
+++ b/packages/scripts/src/meta2rst.ts
@@ -80,11 +80,13 @@ export function findRstPageTitle(content: string): number {
   // Look for title pattern (line followed by adornment of same length)
   // We need to check for both underline-only and overline-underline patterns
 
-  // Skip any frontmatter (comments, directives, etc.)
+  // Skip any frontmatter (comments, directives, field lists, etc.)
   let i = 0;
   while (
     i < lines.length &&
-    (lines[i].trim().startsWith("..") || lines[i].trim() === "")
+    (lines[i].trim().startsWith("..") ||
+      lines[i].trim() === "" ||
+      lines[i].trim().startsWith(":")) // Add this condition to skip field lists
   ) {
     i++;
   }

--- a/packages/scripts/src/meta2rst.ts
+++ b/packages/scripts/src/meta2rst.ts
@@ -1,0 +1,132 @@
+// Match the entire meta directive block
+const metaDirectiveRegex = /(?:^|\n)(.. meta::\s*\n(?:\s+:[^:]+:[^\n]*\n)*)/g;
+// To find specific fields within the matched directive
+const descriptionFieldRegex = /(\s+):description:([^\n]*)\n/;
+const keywordsFieldRegex = /(\s+):keywords:([^\n]*)\n/;
+
+export function hasMetaDirective(content: string): boolean {
+  return metaDirectiveRegex.test(content);
+}
+
+export function updateMetaDescription(
+  content: string,
+  newDescription: string
+): string {
+  return content.replace(metaDirectiveRegex, (match) => {
+    // Check if description field exists
+    if (descriptionFieldRegex.test(match)) {
+      // Replace existing description
+      console.log("Replacing description field");
+      return match.replace(
+        descriptionFieldRegex,
+        `$1:description: ${newDescription}\n`
+      );
+    } else {
+      console.log("Adding description field");
+      // Add description field (preserve the final newline)
+      return match.replace(/(\n)$/, `\n   :description: ${newDescription}$1`);
+    }
+  });
+}
+
+export function getMetaField(
+  content: string,
+  fieldName: "description" | "keywords"
+): string | null {
+  const fieldRegex =
+    fieldName === "description" ? descriptionFieldRegex : keywordsFieldRegex;
+  const metaMatch = content.match(metaDirectiveRegex);
+
+  if (!metaMatch) return null;
+
+  const fieldMatch = metaMatch[0].match(fieldRegex);
+  return fieldMatch ? fieldMatch[2].trim() : null;
+}
+
+export function constructMetaDirective(args: {
+  description: string | null;
+  keywords: string | null;
+}): string {
+  if (args.description === null && args.keywords === null) {
+    return "";
+  }
+
+  const metaDirectiveParts = [`.. meta::`];
+
+  if (args.keywords) {
+    metaDirectiveParts.push(`   :keywords: ${args.keywords}`);
+  }
+
+  if (args.description) {
+    metaDirectiveParts.push(`   :description: ${args.description}`);
+  }
+
+  return metaDirectiveParts.join("\n");
+}
+
+/**
+ Find the page title of a reStructuredText file and return the line number
+ where the title definition ends.
+
+ @param content - The content of the reStructuredText file as a string
+ @returns The line number where the title definition ends, or -1 if no title is found
+ */
+export function findRstPageTitle(content: string): number {
+  // Split the content into lines
+  const lines = content.split("\n");
+
+  // Look for title pattern (line followed by adornment of same length)
+  // We need to check for both underline-only and overline-underline patterns
+
+  // Skip any frontmatter (comments, directives, etc.)
+  let i = 0;
+  while (
+    i < lines.length &&
+    (lines[i].trim().startsWith("..") || lines[i].trim() === "")
+  ) {
+    i++;
+  }
+
+  // Check for overline-title-underline pattern
+  if (i + 2 < lines.length) {
+    const possibleOverline = lines[i].trim();
+    const possibleTitle = lines[i + 1].trim();
+    const possibleUnderline = lines[i + 2].trim();
+
+    // Check if adornment characters are valid
+    const validAdornmentChars = /^[=\-`:'\"~^\\_*+#<>]+$/;
+
+    if (
+      possibleOverline.length > 0 &&
+      validAdornmentChars.test(possibleOverline) &&
+      possibleTitle.length > 0 &&
+      possibleUnderline === possibleOverline &&
+      possibleOverline.length >= possibleTitle.length
+    ) {
+      // Found overline-title-underline pattern
+      return i + 3; // Line number (1-based) of the underline
+    }
+  }
+
+  // Check for title-underline pattern
+  if (i + 1 < lines.length) {
+    const possibleTitle = lines[i].trim();
+    const possibleUnderline = lines[i + 1].trim();
+
+    // Check if adornment characters are valid
+    const validAdornmentChars = /^[=\-`:'\"~^\\_*+#<>]+$/;
+
+    if (
+      possibleTitle.length > 0 &&
+      possibleUnderline.length > 0 &&
+      validAdornmentChars.test(possibleUnderline) &&
+      possibleUnderline.length >= possibleTitle.length
+    ) {
+      // Found title-underline pattern
+      return i + 2; // Line number (1-based) of the underline
+    }
+  }
+
+  // No title found
+  return -1;
+}

--- a/packages/scripts/src/meta2rst.ts
+++ b/packages/scripts/src/meta2rst.ts
@@ -15,17 +15,14 @@ export function updateMetaDescription(
   newDescription: string
 ): string {
   return content.replace(metaDirectiveRegex, (match) => {
-    console.log("meta directive match", match);
     // Check if description field exists
     if (descriptionFieldRegex.test(match)) {
       // Replace existing description
-      console.log("Replacing description field");
       return match.replace(
         descriptionFieldRegex,
         `$1:description: ${newDescription}\n`
       );
     } else {
-      console.log("Adding description field");
       // Add description field (preserve the final newline)
       return match.replace(/(\n)$/, `\n   :description: ${newDescription}$1`);
     }
@@ -75,6 +72,8 @@ export function constructMetaDirective(args: {
  @returns The line number where the title definition ends, or -1 if no title is found
  */
 export function findRstPageTitle(content: string): number {
+  const validAdornmentChars = /^[=\-`:'"~^\\_*+#<>]+$/;
+
   // Split the content into lines
   const lines = content.split("\n");
 
@@ -96,9 +95,6 @@ export function findRstPageTitle(content: string): number {
     const possibleTitle = lines[i + 1].trim();
     const possibleUnderline = lines[i + 2].trim();
 
-    // Check if adornment characters are valid
-    const validAdornmentChars = /^[=\-`:'\"~^\\_*+#<>]+$/;
-
     if (
       possibleOverline.length > 0 &&
       validAdornmentChars.test(possibleOverline) &&
@@ -115,9 +111,6 @@ export function findRstPageTitle(content: string): number {
   if (i + 1 < lines.length) {
     const possibleTitle = lines[i].trim();
     const possibleUnderline = lines[i + 1].trim();
-
-    // Check if adornment characters are valid
-    const validAdornmentChars = /^[=\-`:'\"~^\\_*+#<>]+$/;
 
     if (
       possibleTitle.length > 0 &&

--- a/packages/scripts/src/upsertMetaDirective.ts
+++ b/packages/scripts/src/upsertMetaDirective.ts
@@ -5,18 +5,25 @@
 import path from "path";
 import fs from "fs";
 import { upsertMetaDirectiveInFile } from "./meta2rst";
+import { logger } from "mongodb-rag-core";
 
 const args = process.argv.slice(2);
 
-const filePath = path.resolve(args[0]);
+const filePathArg = args[0];
+if (!filePathArg) {
+  logger.error("File path is required");
+  process.exit(1);
+}
+
+const filePath = path.resolve(filePathArg);
 if (!fs.existsSync(filePath)) {
-  console.error(`File does not exist: ${filePath}`);
+  logger.error(`File does not exist: ${filePath}`);
   process.exit(1);
 }
 
 const metaDescription = args[1];
 if (!metaDescription) {
-  console.error("Meta description is required");
+  logger.error("Meta description is required");
   process.exit(1);
 }
 
@@ -25,9 +32,9 @@ try {
     description: metaDescription,
     keywords: null,
   });
-  console.log(`Updated meta description in ${filePath}`);
+  logger.info(`Updated meta description in ${filePath}`);
   process.exit(0);
 } catch (error) {
-  console.error(`Error updating meta description in ${filePath}: ${error}`);
+  logger.error(`Error updating meta description in ${filePath}: ${error}`);
   process.exit(1);
 }

--- a/packages/scripts/src/upsertMetaDirective.ts
+++ b/packages/scripts/src/upsertMetaDirective.ts
@@ -1,0 +1,33 @@
+// A CLI script that accepts a docs rST file path and an updated meta description
+// The script will update the meta description in the rST file in place
+// Usage: node build/upsertMetaDirective.js <path-to-rst-file> <meta-description>
+
+import path from "path";
+import fs from "fs";
+import { upsertMetaDirectiveInFile } from "./meta2rst";
+
+const args = process.argv.slice(2);
+
+const filePath = path.resolve(args[0]);
+if (!fs.existsSync(filePath)) {
+  console.error(`File does not exist: ${filePath}`);
+  process.exit(1);
+}
+
+const metaDescription = args[1];
+if (!metaDescription) {
+  console.error("Meta description is required");
+  process.exit(1);
+}
+
+try {
+  upsertMetaDirectiveInFile(filePath, {
+    description: metaDescription,
+    keywords: null,
+  });
+  console.log(`Updated meta description in ${filePath}`);
+  process.exit(0);
+} catch (error) {
+  console.error(`Error updating meta description in ${filePath}: ${error}`);
+  process.exit(1);
+}

--- a/packages/scripts/testData/meta2rst/no-meta-no-description.rst
+++ b/packages/scripts/testData/meta2rst/no-meta-no-description.rst
@@ -1,0 +1,22 @@
+.. _test-page-no-meta-no-description:
+
+=================================
+Test Page: No Meta No Description
+=================================
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This is a test page with no meta description.
+
+First heading
+------------
+
+This is the first section.

--- a/packages/scripts/testData/meta2rst/yes-meta-no-description.rst
+++ b/packages/scripts/testData/meta2rst/yes-meta-no-description.rst
@@ -1,0 +1,25 @@
+.. _test-page-yes-meta-no-description:
+
+==================================
+Test Page: Yes Meta No Description
+==================================
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. meta::
+   :keywords: code example
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This is a test page with a meta directive but no meta description.
+
+First heading
+------------
+
+This is the first section.

--- a/packages/scripts/testData/meta2rst/yes-meta-yes-description.rst
+++ b/packages/scripts/testData/meta2rst/yes-meta-yes-description.rst
@@ -1,0 +1,26 @@
+.. _test-page-yes-meta-yes-description:
+
+===================================
+Test Page: Yes Meta Yes Description
+===================================
+
+.. meta::
+   :description: Learn how to improve the performance of a MongoDB application.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This is a test page with a meta description.
+
+First heading
+------------
+
+This is the first section.


### PR DESCRIPTION
Jira: (EAI-857) Create rST meta description import tool

## Changes

- Adds two new files (plus tests) to the `scripts` package
  - `meta2rst` contains the implementations that process and update reStructuredText files. The test file is fairly comprehensive and probably easier to review than the arcane implementations.
  - `upsertMetaDirective` which wraps the `meta2rst` functions in a script that we can call from the command line. We make this available via a new package.json script, `npm run upsertMetaDirective -- <path-to-rst-file> <meta-description>`. I tested this manually against some files in `docs-realm` and it seems to work perfectly. I'll probably wrap it up in a `.sh` file for the actual imports so that we can call it multiple time programmatically.
