### PR TITLE
(EAI-901) check that reference urls are ingested

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/eval/bin/generateEvalCasesYamlFromCSV.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/bin/generateEvalCasesYamlFromCSV.ts
@@ -81,12 +81,23 @@ const transformationMap: Record<
   // Add more transformation functions here as needed
 };
 
+/**
+ * Normalizes a URL by removing the protocol (http/https) and 'www.' prefix
+ * normalizeUrl('https://www.example.com') // returns 'example.com'
+ * normalizeUrl('http://example.com') // returns 'example.com'
+ */
+function normalizeUrl(url: string): string {
+  return url.replace(/^https?:\/\/(www\.)?/i, '');
+}
+
 const findMissingResources = async (
   expectedUrls: string[]
 ): Promise<string[]> => {
   const results = await Promise.all(
     expectedUrls.map(async (url) => {
-      const pageExists = await db.collection("pages").findOne({ url });
+      const pageExists = await db.collection("pages").findOne({
+        url: { $regex: new RegExp(normalizeUrl(url))}
+      });
       return !pageExists ? url : null;
     })
   );

--- a/packages/chatbot-server-mongodb-public/src/eval/bin/generateEvalCasesYamlFromCSV.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/bin/generateEvalCasesYamlFromCSV.ts
@@ -82,12 +82,12 @@ const transformationMap: Record<
 };
 
 /**
- * Normalizes a URL by removing the protocol (http/https) and 'www.' prefix
- * normalizeUrl('https://www.example.com') // returns 'example.com'
- * normalizeUrl('http://example.com') // returns 'example.com'
+ Normalizes a URL by removing the protocol (http/https) and 'www.' prefix
+ normalizeUrl('https://www.example.com') // returns 'example.com'
+ normalizeUrl('http://example.com') // returns 'example.com'
  */
 function normalizeUrl(url: string): string {
-  return url.replace(/^https?:\/\/(www\.)?/i, '');
+  return url.replace(/^https?:\/\/(www\.)?/i, "");
 }
 
 const findMissingResources = async (
@@ -96,7 +96,7 @@ const findMissingResources = async (
   const results = await Promise.all(
     expectedUrls.map(async (url) => {
       const pageExists = await db.collection("pages").findOne({
-        url: { $regex: new RegExp(normalizeUrl(url))}
+        url: { $regex: new RegExp(normalizeUrl(url)) },
       });
       return !pageExists ? url : null;
     })
@@ -149,7 +149,6 @@ async function main({
   const yamlContent = yaml.stringify(evalCases);
   await fs.promises.writeFile(yamlFilePath, yamlContent, "utf8");
   console.log("YAML file written successfully");
-
 }
 
 // Checks if the script is being run directly (not imported as a module) and handles command-line arguments.

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbPageStore.ts
@@ -16,6 +16,9 @@ export type MongoDbPageStore = DatabaseConnection &
   // We omit loadPages so that the generic override below works
   Omit<PageStore, "loadPages"> & {
     queryType: "mongodb";
+    loadPage(
+      args?: LoadPagesArgs<Filter<PersistedPage>>
+    ): Promise<PersistedPage | null>;
     loadPages(
       args?: LoadPagesArgs<Filter<PersistedPage>>
     ): Promise<PersistedPage[]>;
@@ -57,6 +60,12 @@ export function makeMongoDbPageStore({
     metadata: {
       databaseName,
       collectionName,
+    },
+    async loadPage(args) {
+      const filter: Filter<PersistedPage> = args
+        ? createQueryFilterFromLoadPagesArgs(args)
+        : {};
+      return pagesCollection.findOne(filter);
     },
     async loadPages(args) {
       const filter: Filter<PersistedPage> = args

--- a/packages/mongodb-rag-core/src/eval/getConversationEvalCasesFromCSV.ts
+++ b/packages/mongodb-rag-core/src/eval/getConversationEvalCasesFromCSV.ts
@@ -23,19 +23,19 @@ export const getConversationEvalCasesFromCSV = async (
     const formattedRecord: ConversationEvalCase = {
       name: question,
       messages: [
-      {
-        role: "user" as const,
-        content: question,
-      },
+        {
+          role: "user" as const,
+          content: question,
+        },
       ],
       reference: idealAnswer,
       expectedLinks: expectedSources
-      ? expectedSources
-        // Split by one or more whitespace characters or commas (some entries may have commas, some may not)
-        .split(/[\s,]+/)
-        .map((link: string) => link.trim())
-        .filter((link: string) => link.length > 0)
-      : [],
+        ? expectedSources
+            // Split by one or more whitespace characters or commas (some entries may have commas, some may not)
+            .split(/[\s,]+/)
+            .map((link: string) => link.trim())
+            .filter((link: string) => link.length > 0)
+        : [],
     };
     records.push(formattedRecord);
   }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-901

## Changes

- log out urls listed in input CSV as references that do not exist on the pages collection

## Notes

- script output with warnings about missing resources

```
npm run generate-eval-cases /Users/alla.yakubova/Downloads/DotcomChatbotEvalQs.csv dotcom_chatbot_evaluation_questions_test

> chatbot-server-mongodb-public@0.15.2 generate-eval-cases
> ts-node src/eval/bin/generateEvalCasesYamlFromCSV.ts /Users/alla.yakubova/Downloads/DotcomChatbotEvalQs.csv dotcom_chatbot_evaluation_questions_test

Reading from: /Users/alla.yakubova/Downloads/DotcomChatbotEvalQs.csv
(node:64547) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Warning: 22/86 URLs are expected to be referenced by the chatbot, but have not been ingested:
  - https://www.mongodb.com/developer/languages/javascript/mongoose-versus-nodejs-driver/
  - https://www.mongodb.com/developer/products/mongodb/mongodb-orms-odms-libraries/
  - https://github.com/langchain-ai/langgraph/tree/main/libs/checkpoint
  - https://github.com/langchain-ai/langchain-mongodb/blob/main/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/__init__.py
  - https://github.com/langchain-ai/langchain-mongodb/blob/main/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
  - https://search-playground.mongodb.com/tools/search-demo-builder
  - https://search-playground.mongodb.com/tools/search-demo-builder/snapshots/new
  - https://search-playground.mongodb.com/tools/code-sandbox/snapshots/new
  - https://cloud.mongodb.com/ecosystem
  - https://docs.google.com/document/d/1lZCG-l0Y7e7crzVHb4MvtQabyLY5Y1Ahx_e8OKxOHE0/edit?tab=t.0#heading=h.m4z4fgczts1p
  - https://docs.google.com/document/d/1YIWdSHnXNh-kuJ1OUupde3cX36LrZ1i6_Zlgv05DUsw/edit?tab=t.0
  - https://learn.microsoft.com/en-us/azure/architecture/data-guide/scenarios/time-series
  - https://www.mongodb.com/cloud/atlas/register
  - https://www.mongodb.com/cloud/security
  - https://www.mongodb.com/solutions/customer-case-studies?industries=retail
  - https://www.mongodb.com/solutions/customer-case-studies?industries=telecommunications
  - https://www.mongodb.com/solutions/customer-case-studies?industries=manufacturing-and-mobility
  - https://www.mongodb.com/solutions/customer-case-studies?industries=financial-services
  - https://www.mongodb.com/solutions/customer-case-studies?industries=healthcare
  - https://www.mongodb.com/solutions/customer-case-studies?industries=insurance
  - https://www.mongodb.com/solutions/customer-case-studies?industries=media
  - https://www.mongodb.com/solutions/customer-case-studies?industries=energy-and-environmental
Writing to: /Users/alla.yakubova/mongodb/chatbot/packages/chatbot-server-mongodb-public/evalCases/dotcom_chatbot_evaluation_questions_test.yml
YAML file written successfully
```
