### PR TITLE
(EAI-911) fix bug causeing BinaryNdcgAt5 errors

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.test.ts
@@ -64,7 +64,7 @@ describe("fuzzyLinkMatch", () => {
     expect(fuzzyLinkMatch(expected, actual)).toBe(false);
   });
 
-  test("actual url has not path, but expected does", () => {
+  test("expected url has path, but actual does not", () => {
     const expected = "https://example.com/path/to/resource";
     const actual = "https://example.com";
     expect(fuzzyLinkMatch(expected, actual)).toBe(false);

--- a/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.test.ts
@@ -43,7 +43,7 @@ describe("fuzzyLinkMatch", () => {
   test("expected path is empty string", () => {
     const expected = "";
     const actual = "/path/to/resource";
-    expect(fuzzyLinkMatch(expected, actual)).toBe(true); // Every string includes an empty string
+    expect(fuzzyLinkMatch(expected, actual)).toBe(false);
   });
 
   test("expected path does not exist in actual path", () => {
@@ -56,5 +56,17 @@ describe("fuzzyLinkMatch", () => {
     const expected = "/path";
     const actual = "https://anotherdomain.com/path/";
     expect(fuzzyLinkMatch(expected, actual)).toBe(true);
+  });
+
+  test("expected url has no path, but actual does", () => {
+    const expected = "https://example.com";
+    const actual = "https://example.com/path/to/resource";
+    expect(fuzzyLinkMatch(expected, actual)).toBe(false);
+  });
+
+  test("actual url has not path, but expected does", () => {
+    const expected = "https://example.com/path/to/resource";
+    const actual = "https://example.com";
+    expect(fuzzyLinkMatch(expected, actual)).toBe(false);
   });
 });

--- a/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
@@ -21,7 +21,7 @@ export function fuzzyLinkMatch(expected: string, actual: string) {
   if (cleanActualPath && cleanExpectedPath) {
     return cleanActualPath.endsWith(cleanExpectedPath);
   } else {
-    // compare full normalized paths
+    // compare normalized full URLs
     const normalizedActual = normalizeUrl(actual);
     const normalizedExpected = normalizeUrl(expected);
     return normalizedActual === normalizedExpected;

--- a/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
@@ -1,20 +1,40 @@
 /**
-  Performs a case-insensitive, partial match
-  that the `expected` link or link fragment
-  ends with the `actual` link or link fragment.
-  Removes trailing `/` from paths.
-  Checks based solely on path, ignoring domain, query, and fragment.
-
-  If either input is not a valid URL,
-  it treats the input as a plain string
-  and performs a substring match.
-
-  @param expected - The expected link or link fragment to match within `actual`.
-  @param actual - The actual link or link fragment where the search is performed.
-  @returns `true` if the `expected` link or link fragment is found within `actual`, `false` otherwise.
+  Performs a case-insensitive match between two URLs or URL fragments.
+  
+  First attempts to match based on paths:
+  - Removes trailing slashes
+  - Checks if actual path ends with expected path (ignoring domain, query, and fragment)
+  
+  If either path is empty/invalid, falls back to exact match of normalized URLs:
+  - Removes protocol (http/https)
+  - Removes 'www.' prefix
+  
+  @param expected - The expected URL or URL fragment
+  @param actual - The actual URL or URL fragment to compare against
+  @returns true if URLs match according to above rules, false otherwise
  */
 export function fuzzyLinkMatch(expected: string, actual: string) {
-  return getCleanPath(actual).endsWith(getCleanPath(expected));
+  const cleanActualPath = getCleanPath(actual);
+  const cleanExpectedPath = getCleanPath(expected);
+
+  // if cleaned path is not an empty string, compare cleaned paths
+  if (cleanActualPath && cleanExpectedPath) {
+    return cleanActualPath.endsWith(cleanExpectedPath);
+  } else {
+    // compare full normalized paths
+    const normalizedActual = normalizeUrl(actual);
+    const normalizedExpected = normalizeUrl(expected);
+    return normalizedActual === normalizedExpected;
+  }
+}
+
+/**
+ Normalizes a URL by removing the protocol (http/https) and 'www.' prefix
+ normalizeUrl('https://www.example.com') // returns 'example.com'
+ normalizeUrl('http://example.com') // returns 'example.com'
+ */
+function normalizeUrl(url: string): string {
+  return url.replace(/^https?:\/\/(www\.)?/i, "");
 }
 
 function cleanPath(path: string) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-911

## Changes

- fix fuzzy match for case where one of the urls has no path. This was causing more matches than possible, leading to a score > 1, when the score must be between 0 and 1
- fixed an existing test case
- added an additional test case

## Notes

- tested this with some evals, not seeing BinaryNdcgAt5 errors anymore
