### PR TITLE
(EAI-523) Server supports clientContext passed in requests

### DIFF
--- a/packages/mongodb-chatbot-server/src/processors/GenerateUserPromptFunc.ts
+++ b/packages/mongodb-chatbot-server/src/processors/GenerateUserPromptFunc.ts
@@ -18,6 +18,14 @@ export type GenerateUserPromptFuncParams = {
   conversation?: Conversation;
 
   /**
+    Additional contextual information provided by the user's client. This can
+    include arbitrary data that might be useful for generating a response. For
+    example, this could include the user's location, the device they are using,
+    their preferred programming language, etc.
+   */
+  clientContext?: Record<string, unknown>;
+
+  /**
     String Id for request
    */
   reqId: string;

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
@@ -44,6 +44,7 @@ export const DEFAULT_MAX_USER_MESSAGES_IN_CONVERSATION = 7; // magic number for 
 export type AddMessageRequestBody = z.infer<typeof AddMessageRequestBody>;
 export const AddMessageRequestBody = z.object({
   message: z.string(),
+  clientContext: z.object({}).passthrough().optional(),
 });
 
 export const AddMessageRequest = SomeExpressRequest.merge(
@@ -103,6 +104,7 @@ export interface AddMessageToConversationRouteParams {
 type MakeTracedResponseParams = Pick<
   GenerateResponseParams,
   | "latestMessageText"
+  | "clientContext"
   | "customData"
   | "dataStreamer"
   | "shouldStream"
@@ -123,6 +125,7 @@ export function makeAddMessageToConversationRoute({
 }: AddMessageToConversationRouteParams) {
   const generateResponseTraced = function ({
     latestMessageText,
+    clientContext,
     customData,
     dataStreamer,
     shouldStream,
@@ -133,6 +136,7 @@ export function makeAddMessageToConversationRoute({
     const tracedFunc = wrapTraced(
       ({
         latestMessageText,
+        clientContext,
         customData,
         dataStreamer,
         shouldStream,
@@ -141,6 +145,7 @@ export function makeAddMessageToConversationRoute({
       }: MakeTracedResponseParams) => {
         return generateResponse({
           latestMessageText,
+          clientContext,
           customData,
           dataStreamer,
           shouldStream,
@@ -167,6 +172,7 @@ export function makeAddMessageToConversationRoute({
     );
     return tracedFunc({
       latestMessageText,
+      clientContext,
       customData,
       dataStreamer,
       shouldStream,
@@ -183,7 +189,7 @@ export function makeAddMessageToConversationRoute({
     try {
       const {
         params: { conversationId: conversationIdString },
-        body: { message },
+        body: { message, clientContext },
         query: { stream },
         ip,
       } = req;
@@ -273,6 +279,7 @@ export function makeAddMessageToConversationRoute({
       const { messages } = await generateResponseTraced({
         conversation: traceConversation,
         latestMessageText,
+        clientContext,
         customData,
         dataStreamer,
         shouldStream,

--- a/packages/mongodb-chatbot-server/src/routes/generateResponse.ts
+++ b/packages/mongodb-chatbot-server/src/routes/generateResponse.ts
@@ -16,10 +16,13 @@ import { strict as assert } from "assert";
 import { GenerateUserPromptFunc } from "../processors/GenerateUserPromptFunc";
 import { FilterPreviousMessages } from "../processors/FilterPreviousMessages";
 
+export type ClientContext = Record<string, unknown>;
+
 export interface GenerateResponseParams {
   shouldStream: boolean;
   llm: ChatLlm;
   latestMessageText: string;
+  clientContext?: ClientContext;
   customData?: ConversationCustomData;
   dataStreamer?: DataStreamer;
   generateUserPrompt?: GenerateUserPromptFunc;
@@ -49,6 +52,7 @@ export async function generateResponse({
   shouldStream,
   llm,
   latestMessageText,
+  clientContext,
   customData,
   generateUserPrompt,
   filterPreviousMessages,
@@ -63,6 +67,7 @@ export async function generateResponse({
     await (generateUserPrompt
       ? generateUserPrompt({
           userMessageText: latestMessageText,
+          clientContext,
           conversation,
           reqId,
           customData,


### PR DESCRIPTION
Jira: (EAI-523) Server supports clientContext passed in requests

## Changes

- Adds a new, optional `clientContext` request body parameter for `addMessage` requests
- If defined, this value is passed as an arg to `generateUserPrompt`

## Notes

- This PR adds support in the framework but does not modify our server implementation. For that, we'll want to do some light eval work + handle specific data from clients.
