### PR TITLE
Update stats materialized view script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63138,7 +63138,8 @@
         "mongodb-chatbot-server": "*",
         "mongodb-rag-core": "*",
         "typechat": "^0.1.1",
-        "yaml": "^2.3.4"
+        "yaml": "^2.3.4",
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7",
@@ -63157,6 +63158,40 @@
         "release-it": "^16",
         "ts-jest": "^29.1.0",
         "typescript": "^5"
+      }
+    },
+    "packages/scripts/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/scripts/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "packages/scripts/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/scripts/node_modules/typechat": {
@@ -63182,11 +63217,55 @@
         }
       }
     },
+    "packages/scripts/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "packages/scripts/node_modules/yaml": {
       "version": "2.3.4",
       "license": "ISC",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "packages/scripts/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/scripts/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,6 +14,7 @@
     "findFaq": "npm run build && node ./build/main/findFaqMain.js",
     "upgradeFaqEntries": "npm run build && node ./build/main/upgradeFaqEntriesMain.js",
     "materializeScrubbedMessagesStats:all": "npm run build && node ./build/main/materializeScrubbedMessagesStats.js --all",
+    "materializeScrubbedMessagesStats:since": "npm run build && node ./build/main/materializeScrubbedMessagesStats.js --since",
     "materializeScrubbedMessagesStats:latest": "npm run build && node ./build/main/materializeScrubbedMessagesStats.js",
     "createView/messages_by_rating": "npm run build && node ./build/createView/messages_by_rating.js",
     "createView/top_250_references": "npm run build && node ./build/createView/top_250_references.js",
@@ -47,7 +48,8 @@
     "mongodb-chatbot-server": "*",
     "mongodb-rag-core": "*",
     "typechat": "^0.1.1",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7",

--- a/packages/scripts/src/main/materializeScrubbedMessagesStats.ts
+++ b/packages/scripts/src/main/materializeScrubbedMessagesStats.ts
@@ -1,13 +1,42 @@
-import { startOfMonth } from "../materialize/materializedViewUtils";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import {
+  isStartOfMonth,
+  startOfMonth,
+} from "../materialize/materializedViewUtils";
 import { createScrubbedMessageStatsViews } from "../materialize/scrubbed_messages_stats";
 
 async function main() {
-  let since: Date | undefined = startOfMonth(new Date());
-  process.argv.forEach((val) => {
-    if (val === "--all") {
-      since = undefined;
-    }
-  });
+  const args = yargs(hideBin(process.argv))
+    .option("all", {
+      type: "boolean",
+      description: "Materialize all stats",
+    })
+    .option("since", {
+      type: "string",
+      description: "Materialize stats since a specific date (YYYY-MM-DD)",
+      coerce: (value: string) => {
+        if (value === "") {
+          throw new Error("Must provide a date value for --since");
+        }
+        return new Date(value);
+      },
+    })
+    .conflicts("all", "since")
+    .parseSync();
+
+  const since = args.since ?? (args.all ? undefined : startOfMonth(new Date()));
+
+  if (args.all) {
+    console.log("Materializing stats for all time");
+  } else if (isStartOfMonth(since)) {
+    console.log("Materializing stats since", since?.toISOString());
+  } else {
+    throw new Error(
+      `--since must be the first day of the month, e.g. "2024-01-01" or "2024-01-01T00:00:00Z"`
+    );
+  }
+
   await createScrubbedMessageStatsViews({
     granularity: ["daily", "weekly", "monthly"],
     since,

--- a/packages/scripts/src/materialize/materializedViewUtils.test.ts
+++ b/packages/scripts/src/materialize/materializedViewUtils.test.ts
@@ -7,6 +7,7 @@ import {
   startOfMonth,
   startOfWeek,
   startOfDay,
+  isStartOfMonth,
 } from "./materializedViewUtils";
 
 const { MONGODB_CONNECTION_URI } = assertEnvVars({
@@ -117,6 +118,24 @@ describe("Date utils", () => {
     it("returns the first day of the month", () => {
       const date = new Date("2021-01-15T00:00:00Z");
       expect(startOfMonth(date)).toEqual(new Date("2021-01-01T00:00:00Z"));
+    });
+  });
+
+  describe("isStartOfMonth", () => {
+    it("returns true if the date is the first day of the month", () => {
+      // Right date and right time
+      expect(isStartOfMonth("2024-02-01T00:00:00Z")).toBe(true);
+      expect(isStartOfMonth(new Date("2024-02-01T00:00:00Z"))).toBe(true);
+    });
+
+    it("returns false if the date is not the first day of the month", () => {
+      // Wrong date
+      expect(isStartOfMonth("2021-01-02T00:00:00Z")).toBe(false);
+      expect(isStartOfMonth(new Date("2021-01-02T00:00:00Z"))).toBe(false);
+      // Right date but wrong time
+      expect(isStartOfMonth(new Date("2021-01-01T10:00:00Z"))).toBe(false);
+      // Wrong date and wrong time
+      expect(isStartOfMonth("2021-01-02T10:00:00Z")).toBe(false);
     });
   });
 

--- a/packages/scripts/src/materialize/materializedViewUtils.ts
+++ b/packages/scripts/src/materialize/materializedViewUtils.ts
@@ -4,6 +4,8 @@ import {
   MongoClient,
 } from "mongodb-rag-core/mongodb";
 
+import { inspect } from "util";
+
 export type IndexDefinition = {
   spec: IndexSpecification;
   options?: CreateIndexesOptions;
@@ -22,10 +24,16 @@ export async function ensureCollectionWithIndex({
   collectionName,
   ...indexProps
 }: EnsureCollectionWithIndexParams) {
-  console.log("Ensuring collection with index:", {
-    collectionName,
-    ...indexProps,
-  });
+  console.log(
+    "Ensuring collection with index:",
+    inspect(
+      {
+        collectionName,
+        ...indexProps,
+      },
+      { depth: null, colors: false }
+    )
+  );
   await client.connect();
   const db = client.db(databaseName);
   const existingCollections = await db
@@ -78,8 +86,25 @@ export async function ensureIndex({
 }
 
 // Date utils
-export function startOfMonth(date: Date) {
-  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0));
+export function startOfMonth(date: Date | string) {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  return new Date(
+    Date.UTC(dateObj.getFullYear(), dateObj.getMonth(), 1, 0, 0, 0, 0)
+  );
+}
+
+export function isStartOfMonth(date?: Date | string): boolean {
+  if (!date) {
+    return false;
+  }
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  return (
+    dateObj.getUTCDate() === 1 &&
+    dateObj.getUTCHours() === 0 &&
+    dateObj.getUTCMinutes() === 0 &&
+    dateObj.getUTCSeconds() === 0 &&
+    dateObj.getUTCMilliseconds() === 0
+  );
 }
 
 export function startOfWeek(

--- a/packages/scripts/src/materialize/scrubbed_messages_stats.ts
+++ b/packages/scripts/src/materialize/scrubbed_messages_stats.ts
@@ -68,6 +68,9 @@ function makeCreateStatsMaterializedView({
           },
         ],
       });
+      console.log(
+        `Materializing ${granularity} stats for ${databaseName}.${messagesCollectionName} since ${since?.toISOString()}`
+      );
       return await client
         .db(databaseName)
         .collection(messagesCollectionName)
@@ -243,7 +246,6 @@ export async function createScrubbedMessageStatsViews({
 
     if (granularity.includes("daily")) {
       const dailyStart = Date.now();
-      console.log("Creating daily stats view");
       await createStatsMaterializedView<{
         year: number;
         dayOfYear: number;
@@ -288,7 +290,6 @@ export async function createScrubbedMessageStatsViews({
 
     if (granularity.includes("weekly")) {
       const weeklyStart = Date.now();
-      console.log("Creating weekly stats view");
       await createStatsMaterializedView<{
         year: number;
         week: number;
@@ -318,7 +319,6 @@ export async function createScrubbedMessageStatsViews({
 
     if (granularity.includes("monthly")) {
       const monthlyStart = Date.now();
-      console.log("Creating monthly stats view");
       await createStatsMaterializedView<{
         year: number;
         month: number;


### PR DESCRIPTION
This updates the code for our materialized view stats collection that we can use to get historical operational data (e.g. num messages, num conversations) and make charts without needing to re-calculate every time. Instead we _pre-_calculate nightly.