### PR TITLE
(EAI-904) Store the embedding model alongside the vector

### DIFF
--- a/packages/mongodb-artifact-generator/src/vectorSearch.ts
+++ b/packages/mongodb-artifact-generator/src/vectorSearch.ts
@@ -13,6 +13,7 @@ export type FindContentArgs = {
 export type FindContentResult = {
   queryEmbedding: number[];
   content: WithScore<EmbeddedContent>[];
+  embeddingModelName?: string;
 };
 
 export type FindContent = ({

--- a/packages/mongodb-chatbot-server/src/processors/makeRagGenerateUserPrompt.test.ts
+++ b/packages/mongodb-chatbot-server/src/processors/makeRagGenerateUserPrompt.test.ts
@@ -53,6 +53,7 @@ const mockFindContent: FindContentFunc = async () => {
   return {
     queryEmbedding: [0.1, 0.2, 0.3],
     content: mockContent,
+    embeddingModelName: "test-embedding-model",
   };
 };
 
@@ -181,6 +182,22 @@ describe("makeRagGenerateUserPrompt()", () => {
       reqId: "foo",
     });
     expect(calledFunc).toHaveBeenCalled();
+  });
+  test("should include embedding model name in user message when no content found", async () => {
+    const generateUserPromptFunc = makeRagGenerateUserPrompt({
+      ...mockConfig,
+      findContent: async () => ({
+        queryEmbedding: [],
+        content: [],
+        embeddingModelName: "test-embedding-model",
+      }),
+    });
+    const response = await generateUserPromptFunc({
+      userMessageText: "foo",
+      reqId: "foo",
+    });
+    expect(response.rejectQuery).toBe(true);
+    expect(response.userMessage.embeddingModel).toBe("test-embedding-model");
   });
 });
 

--- a/packages/mongodb-chatbot-server/src/processors/makeRagGenerateUserPrompt.ts
+++ b/packages/mongodb-chatbot-server/src/processors/makeRagGenerateUserPrompt.ts
@@ -99,7 +99,7 @@ export function makeRagGenerateUserPrompt({
 
     // --- VECTOR SEARCH / RETRIEVAL ---
     const findContentQuery = preprocessedUserMessageContent ?? userMessageText;
-    const { content, queryEmbedding } = await findContent({
+    const { content, queryEmbedding, embeddingModelName } = await findContent({
       query: findContentQuery,
     });
     if (content.length === 0) {
@@ -112,6 +112,7 @@ export function makeRagGenerateUserPrompt({
           role: "user",
           content: userMessageText,
           embedding: queryEmbedding,
+          embeddingModel: embeddingModelName,
         },
         rejectQuery: true,
       };

--- a/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
+++ b/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
@@ -113,6 +113,12 @@ export type UserMessage = MessageBase & {
     The vector representation of the message content.
    */
   embedding?: number[];
+
+  /**
+    The model used to generate the embedding vector.
+    For example: "text-embedding-ada-002" or "text-embedding-3-small"
+   */
+  embeddingModel?: string;
 };
 
 /**

--- a/packages/mongodb-rag-core/src/embed/Embedder.ts
+++ b/packages/mongodb-rag-core/src/embed/Embedder.ts
@@ -18,4 +18,5 @@ export type EmbedResult = {
  */
 export type Embedder = {
   embed(args: EmbedArgs): Promise<EmbedResult>;
+  modelName?: string;
 };

--- a/packages/mongodb-rag-core/src/embed/OpenAiEmbedder.test.ts
+++ b/packages/mongodb-rag-core/src/embed/OpenAiEmbedder.test.ts
@@ -21,6 +21,10 @@ describe("OpenAiEmbedFunc", () => {
     openAiClient,
   });
 
+  test("Should set modelName from deployment parameter", () => {
+    expect(embedder.modelName).toBe(OPENAI_RETRIEVAL_EMBEDDING_DEPLOYMENT);
+  });
+
   test("Should return an array of numbers of length 1536", async () => {
     const { embedding } = await embedder.embed({
       text: "Hello world",

--- a/packages/mongodb-rag-core/src/embed/OpenAiEmbedder.ts
+++ b/packages/mongodb-rag-core/src/embed/OpenAiEmbedder.ts
@@ -37,6 +37,7 @@ export const makeOpenAiEmbedder = ({
 
   const DEFAULT_WAIT_SECONDS = 5;
   return {
+    modelName: deployment,
     async embed({ text }) {
       return backOff(
         async () => {

--- a/packages/mongodb-rag-core/src/findContent/DefaultFindContent.test.ts
+++ b/packages/mongodb-rag-core/src/findContent/DefaultFindContent.test.ts
@@ -78,4 +78,21 @@ describe("makeDefaultFindContent()", () => {
     expect(content).toBeDefined();
     expect(content.length).toBe(0);
   });
+
+  test("Should include embeddingModelName from embedder", async () => {
+    const findContent = makeDefaultFindContent({
+      embedder,
+      store: embeddedContentStore,
+      findNearestNeighborsOptions: {
+        minScore: 0.1,
+      },
+    });
+    const query = "MongoDB Atlas";
+    const { content, embeddingModelName } = await findContent({
+      query,
+    });
+    expect(content).toBeDefined();
+    expect(content.length).toBeGreaterThan(0);
+    expect(embeddingModelName).toBe(OPENAI_RETRIEVAL_EMBEDDING_DEPLOYMENT);
+  });
 });

--- a/packages/mongodb-rag-core/src/findContent/DefaultFindContent.ts
+++ b/packages/mongodb-rag-core/src/findContent/DefaultFindContent.ts
@@ -39,6 +39,10 @@ export const makeDefaultFindContent = ({
         });
       }
     }
-    return { queryEmbedding: embedding, content };
+    return {
+      queryEmbedding: embedding,
+      content,
+      embeddingModelName: embedder.modelName,
+    };
   };
 };

--- a/packages/mongodb-rag-core/src/findContent/FindContentFunc.ts
+++ b/packages/mongodb-rag-core/src/findContent/FindContentFunc.ts
@@ -12,4 +12,5 @@ export type FindContentFunc = (
 export type FindContentResult = {
   queryEmbedding: number[];
   content: WithScore<EmbeddedContent>[];
+  embeddingModelName?: string;
 };

--- a/packages/scripts/src/ScrubbedMessage.ts
+++ b/packages/scripts/src/ScrubbedMessage.ts
@@ -47,4 +47,9 @@ export type ScrubbedMessage = Omit<
     and false otherwise.
    */
   userCommented?: boolean;
+
+  /**
+    The name of the embedding model used to generate the embedding for this message.
+   */
+  embeddingModelName?: string;
 };

--- a/packages/scripts/src/scrubMessages.test.ts
+++ b/packages/scripts/src/scrubMessages.test.ts
@@ -272,6 +272,41 @@ describe("scrubMessages", () => {
     expect(scrubbedMessage?.customData).toEqual(customData);
   });
 
+  it("should preserve embeddingModelName in messages", async () => {
+    // Arrange: Create a conversation with a message containing embeddingModelName
+    const conversationId = new ObjectId();
+    const messageId = new ObjectId();
+    const embeddingModelName = "test-embedding-model";
+
+    const conversation: Partial<Conversation> = {
+      _id: conversationId,
+      messages: [
+        {
+          id: messageId,
+          role: "user",
+          content: "Message with embedding model name",
+          createdAt: new Date(),
+          embeddingModelName,
+        } as Message,
+      ],
+    };
+
+    await db
+      .collection<Conversation>("conversations")
+      .insertOne(conversation as Conversation);
+
+    // Act: Run the scrubMessages function
+    await scrubMessages({ db });
+
+    // Assert: embeddingModelName should be preserved in the scrubbed message
+    const scrubbedMessage = await db
+      .collection<ScrubbedMessage>("scrubbed_messages")
+      .findOne({ _id: messageId });
+
+    expect(scrubbedMessage).toBeDefined();
+    expect(scrubbedMessage?.embeddingModelName).toBe(embeddingModelName);
+  });
+
   it("should handle system messages correctly", async () => {
     // Arrange: Create a conversation with a system message
     const conversationId = new ObjectId();

--- a/packages/scripts/src/scrubMessages.ts
+++ b/packages/scripts/src/scrubMessages.ts
@@ -66,6 +66,7 @@ export const scrubMessages = async ({ db }: { db: Db }) => {
         createdAt: "$messages.createdAt",
         role: "$messages.role",
         embedding: "$messages.embedding",
+        embeddingModelName: "$messages.embeddingModelName",
         rating: "$messages.rating",
         references: "$messages.references",
         rejectQuery: "$messages.rejectQuery",
@@ -101,8 +102,10 @@ export const scrubMessages = async ({ db }: { db: Db }) => {
             | "preprocessedContent"
             | "userComment"
             | "contextContent"
+            | "embeddingModel"
           >
-        | "userCommented",
+        | "userCommented"
+        | "embeddingModelName",
         string | number | object | boolean
       >,
     },


### PR DESCRIPTION
Jira: (EAI-904) Store the embedding model alongside the vector

## Changes

- The core `Embedder` now optionally exposes the model/deployment it uses as the `modelName` field
  - The `OpenAiEmbedder` implementation does this by default
- Server stores the `embeddingModel` in each user message
- Scrubbed messages also include the `embeddingModel` field
