### PR TITLE
(EAI-926) UI supports clientContext

### DIFF
--- a/docs/docs/ui.md
+++ b/docs/docs/ui.md
@@ -39,7 +39,15 @@ function MyApp() {
   ];
   return (
     <div>
-      <Chatbot name="MongoDB AI" maxInputCharacters={300}>
+      <Chatbot
+        name="MongoDB AI"
+        maxInputCharacters={300}
+        getClientContext={() => ({
+          // Example: Include user info or app state that might be helpful for the server
+          userId: "user-123",
+          preferredLanguage: "JavaScript"
+        })}
+      >
         <InputBarTrigger
           bottomContent={<MongoDbLegalDisclosure />}
           suggestedPrompts={suggestedPrompts}
@@ -70,6 +78,7 @@ The `<Chatbot />` component is effectively a React context provider that wraps y
 | `children`              | `ReactElement \| ReactElement[]`                | Trigger and View components for the chatbot, e.g. `FloatingActionButtonTrigger` and `ModalView`.                                                                                                                                                                                                        |                                                        |
 | `darkMode`              | `boolean?`                                      | If `true`, the UI renders in dark mode. This overrides any theme `darkMode` setting.                                                                                                                                                                                                                    | The user's OS preference or theme value of `darkMode`. |
 | `fetchOptions`          | `ConversationFetchOptions?`                     | If set, the provided options are included with every fetch request to the server. For more information on the available fetch options, refer to [Supplying request options](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options) in the MDN documentation. |                                                        |
+| `getClientContext`      | `(() => Record<string, unknown>)?`              | A function that returns an object with client-side context data to be sent with each message. This context is included in message requests to help the server understand the client's state.                                                                                                            |                                                        |
 | `isExperimental`        | `boolean?`                                      | If `true`, the UI includes EXPERIMENTAL badges throughout.                                                                                                                                                                                                                                              | `true`                                                 |
 | `maxCommentCharacters`  | `number?`                                       | The maximum number of characters allowed in a user's comment on an assistant message.                                                                                                                                                                                                                   | `500`                                                  |
 | `maxInputCharacters`    | `number?`                                       | The maximum number of characters allowed in a user message.                                                                                                                                                                                                                                             | `300`                                                  |

--- a/packages/mongodb-chatbot-ui/src/App.tsx
+++ b/packages/mongodb-chatbot-ui/src/App.tsx
@@ -85,6 +85,9 @@ function App() {
           shouldStream={shouldStream}
           darkMode={darkMode}
           fetchOptions={{ credentials: "include" }}
+          getClientContext={() => ({
+            user: "test-user-pls-ignore",
+          })}
           onOpen={() => {
             console.log("Dev Center Chatbot opened");
           }}

--- a/packages/mongodb-chatbot-ui/src/Chatbot.tsx
+++ b/packages/mongodb-chatbot-ui/src/Chatbot.tsx
@@ -29,6 +29,7 @@ export function Chatbot({
   onOpen,
   onClose,
   sortMessageReferences,
+  getClientContext,
   ...props
 }: ChatbotProps) {
   const { darkMode } = useDarkMode(props.darkMode);
@@ -50,6 +51,7 @@ export function Chatbot({
           <UserProvider user={user}>
             <InnerChatbot
               fetchOptions={fetchOptions}
+              getClientContext={getClientContext}
               isExperimental={isExperimental}
               maxCommentCharacters={maxCommentCharacters}
               maxInputCharacters={maxInputCharacters}
@@ -73,6 +75,7 @@ type InnerChatbotProps = Pick<
   ChatbotProps,
   | "children"
   | "fetchOptions"
+  | "getClientContext"
   | "isExperimental"
   | "maxCommentCharacters"
   | "maxInputCharacters"

--- a/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
+++ b/packages/mongodb-chatbot-ui/src/services/conversations.test.ts
@@ -209,6 +209,31 @@ describe("ConversationService", () => {
       expect(awaitedMessage.references).toEqual(mockMessage.references);
       expect(awaitedMessage.metadata?.conversationId).toBeDefined();
     });
+
+    it("includes client context (if provided) when adding messages", async () => {
+      const conversationId = "650b4b260f975ef031016c8b";
+      const mockMessage = {
+        id: "650b4be0d5a57dd66be2ccb8",
+        role: "assistant",
+        content: "I'm sorry, I don't know how to help with that.",
+        createdAt: new Date().getTime(),
+        references: [],
+      };
+      const getLastRequestOptions = mockFetchResponse({ data: mockMessage });
+
+      const clientContext = { userId: "123", sessionId: "456" };
+      await conversationService.addMessage({
+        conversationId,
+        message: "Hello world!",
+        clientContext,
+      });
+
+      const options = getLastRequestOptions();
+      const requestBody = JSON.parse(
+        (options as unknown as { body: string }).body
+      );
+      expect(requestBody.clientContext).toEqual(clientContext);
+    });
   });
 
   describe("addMessage (streaming)", () => {
@@ -423,110 +448,155 @@ describe("ConversationService", () => {
       expect(streamedConversationId).toBeDefined();
       expect(finishedStreaming).toEqual(true);
     });
-  });
 
-  it("gracefully handles unknown stream event types", async () => {
-    const conversationId = "650b4b260f975ef031016c8d";
-    type PotentiallyUnknownStreamEvent =
-      | ConversationStreamEvent
-      | UnknownStreamEvent;
-    const mockedEvents =
-      mockFetchEventSourceResponse<PotentiallyUnknownStreamEvent>(
+    it("includes client context (if provided) when streaming messages", async () => {
+      const conversationId = "650b4b260f975ef031016c8c";
+      const mockStreamedMessageId = "651466eecffc98fe887000da";
+      const clientContext = { userId: "123", sessionId: "456" };
+
+      mockFetchEventSourceResponse<ConversationStreamEvent>(
         {
           id: undefined,
           type: undefined,
-          data: { type: "unknown123", data: "Hello world!" },
+          data: { type: "delta", data: "Hello" },
         },
         {
           id: undefined,
           type: undefined,
-          data: {
-            type: "delta",
-            data: "Once upon a time there was a very long string.",
-          },
-        },
-        {
-          id: undefined,
-          type: undefined,
-          data: { type: "unknownABC", data: null },
-        },
-        {
-          id: undefined,
-          type: undefined,
-          data: {
-            type: "references",
-            data: [
-              { title: "Title 1", url: "https://example.com/1" },
-              { title: "Title 2", url: "https://example.com/2" },
-            ],
-          },
-        },
-        {
-          id: undefined,
-          type: undefined,
-          data: { type: "unknown", data: 42 },
-        },
-        {
-          id: undefined,
-          type: undefined,
-          data: { type: "finished", data: "650b4be0d5a57dd66be2ccb9" },
+          data: { type: "finished", data: mockStreamedMessageId },
         }
       );
 
-    const deltas: string[] = [];
-    const references: References[] = [];
-    const metadatas: AssistantMessageMetadata[] = [];
-    let streamedMessageId: string | undefined;
-    let finishedStreaming = false;
-    await conversationService.addMessageStreaming({
-      conversationId,
-      message: "Hello world!",
-      maxRetries: 0,
-      onResponseDelta: async (data: string) => {
-        console.log("onResponseDelta", data);
-        deltas.push(data);
-      },
-      onResponseFinished: async (messageId: string) => {
-        console.log("onResponseFinished", messageId);
-        streamedMessageId = messageId;
-        finishedStreaming = true;
-      },
-      onReferences: async (refs) => {
-        console.log("onReferences", refs);
-        references.push(refs);
-      },
-      onMetadata: async (metadata) => {
-        console.log("onMetadata", metadata);
-        metadatas.push(metadata);
-      },
+      let lastRequestOptions: { body: string } = { body: "" };
+      (FetchEventSource.fetchEventSource as jest.Mock).mockImplementation(
+        async (_url, options) => {
+          lastRequestOptions = options;
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "text/event-stream" }),
+          };
+        }
+      );
+
+      await conversationService.addMessageStreaming({
+        conversationId,
+        message: "Hello world!",
+        clientContext,
+        maxRetries: 0,
+        onResponseDelta: () => undefined,
+        onResponseFinished: () => undefined,
+        onReferences: () => undefined,
+        onMetadata: () => undefined,
+      });
+
+      const requestBody = JSON.parse(lastRequestOptions.body);
+      expect(requestBody.clientContext).toEqual(clientContext);
     });
 
-    const filterableMockedEvents =
-      mockedEvents as FetchEventSource.MockEvent<ConversationStreamEvent>[];
+    it("gracefully handles unknown stream event types", async () => {
+      const conversationId = "650b4b260f975ef031016c8d";
+      type PotentiallyUnknownStreamEvent =
+        | ConversationStreamEvent
+        | UnknownStreamEvent;
+      const mockedEvents =
+        mockFetchEventSourceResponse<PotentiallyUnknownStreamEvent>(
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "unknown123", data: "Hello world!" },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "delta",
+              data: "Once upon a time there was a very long string.",
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "unknownABC", data: null },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: {
+              type: "references",
+              data: [
+                { title: "Title 1", url: "https://example.com/1" },
+                { title: "Title 2", url: "https://example.com/2" },
+              ],
+            },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "unknown", data: 42 },
+          },
+          {
+            id: undefined,
+            type: undefined,
+            data: { type: "finished", data: "650b4be0d5a57dd66be2ccb9" },
+          }
+        );
 
-    expect(deltas).toEqual(
-      filterMockedConversationEventsData<DeltaStreamEvent>(
-        filterableMockedEvents,
-        "delta"
-      )
-    );
+      const deltas: string[] = [];
+      const references: References[] = [];
+      const metadatas: AssistantMessageMetadata[] = [];
+      let streamedMessageId: string | undefined;
+      let finishedStreaming = false;
+      await conversationService.addMessageStreaming({
+        conversationId,
+        message: "Hello world!",
+        maxRetries: 0,
+        onResponseDelta: async (data: string) => {
+          console.log("onResponseDelta", data);
+          deltas.push(data);
+        },
+        onResponseFinished: async (messageId: string) => {
+          console.log("onResponseFinished", messageId);
+          streamedMessageId = messageId;
+          finishedStreaming = true;
+        },
+        onReferences: async (refs) => {
+          console.log("onReferences", refs);
+          references.push(refs);
+        },
+        onMetadata: async (metadata) => {
+          console.log("onMetadata", metadata);
+          metadatas.push(metadata);
+        },
+      });
 
-    expect(references).toEqual(
-      filterMockedConversationEventsData<ReferencesStreamEvent>(
-        filterableMockedEvents,
-        "references"
-      )
-    );
+      const filterableMockedEvents =
+        mockedEvents as FetchEventSource.MockEvent<ConversationStreamEvent>[];
 
-    expect(metadatas).toEqual(
-      filterMockedConversationEventsData<MetadataStreamEvent>(
-        filterableMockedEvents,
-        "metadata"
-      )
-    );
+      expect(deltas).toEqual(
+        filterMockedConversationEventsData<DeltaStreamEvent>(
+          filterableMockedEvents,
+          "delta"
+        )
+      );
 
-    expect(streamedMessageId).toEqual("650b4be0d5a57dd66be2ccb9");
-    expect(finishedStreaming).toEqual(true);
+      expect(references).toEqual(
+        filterMockedConversationEventsData<ReferencesStreamEvent>(
+          filterableMockedEvents,
+          "references"
+        )
+      );
+
+      expect(metadatas).toEqual(
+        filterMockedConversationEventsData<MetadataStreamEvent>(
+          filterableMockedEvents,
+          "metadata"
+        )
+      );
+
+      expect(streamedMessageId).toEqual("650b4be0d5a57dd66be2ccb9");
+      expect(finishedStreaming).toEqual(true);
+    });
   });
 
   it("rates messages", async () => {

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -32,6 +32,7 @@ export type UseConversationParams = {
   shouldStream?: boolean;
   sortMessageReferences?: SortReferences;
   fetchOptions?: ConversationFetchOptions;
+  getClientContext?: () => Record<string, unknown>;
 };
 
 export function useConversation(params: UseConversationParams) {
@@ -134,6 +135,7 @@ export function useConversation(params: UseConversationParams) {
         await conversationService.addMessageStreaming({
           conversationId: state.conversationId ?? "null",
           message: content,
+          clientContext: params.getClientContext?.(),
           maxRetries: 0,
           onResponseDelta: async (data: string) => {
             bufferedTokens = [...bufferedTokens, data];
@@ -168,6 +170,7 @@ export function useConversation(params: UseConversationParams) {
         const response = await conversationService.addMessage({
           conversationId: state.conversationId ?? "null",
           message: content,
+          clientContext: params.getClientContext?.(),
         });
         if (response.metadata?.conversationId) {
           state.api.setConversationId(response.metadata.conversationId);


### PR DESCRIPTION
Jira: (EAI-926) UI supports clientContext

## Changes

- Adds a `getClientContext` prop to `Chatbot` that allows clients to send arbitrary data to the server
- Updates the conversations service to accept & pass `clientContext`