### PR TITLE
include the authUser in slack msgs

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -31,7 +31,7 @@ import express from "express";
 import { wrapOpenAI, wrapTraced } from "mongodb-rag-core/braintrust";
 import { AzureOpenAI } from "mongodb-rag-core/openai";
 import { MongoClient } from "mongodb-rag-core/mongodb";
-import { SLACK_ENV_VARS, TRACING_ENV_VARS } from "./EnvVars";
+import { TRACING_ENV_VARS } from "./EnvVars";
 import {
   makeAddMessageToConversationUpdateTrace,
   makeCommentMessageUpdateTrace,

--- a/packages/chatbot-server-mongodb-public/src/tracing/postCommentToSlack.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/postCommentToSlack.test.ts
@@ -46,7 +46,7 @@ describe.skip("postCommentToSlack", () => {
             role: "assistant",
             content: "hello",
             rating: true,
-            userComment: "good",
+            userComment: "bahahah i can tag you now :bowser:",
             id,
             createdAt: new Date(),
             references: [
@@ -57,6 +57,9 @@ describe.skip("postCommentToSlack", () => {
             ],
           },
         ],
+        customData: {
+          authUser: "ben.p",
+        },
       },
       messageWithCommentId: id,
       llmAsAJudge: {

--- a/packages/chatbot-server-mongodb-public/src/tracing/postCommentToSlack.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/postCommentToSlack.ts
@@ -149,22 +149,31 @@ ${
     : "No LLM-as-Judge Scores"
 }`;
 
+  const messageBlocks = [
+    Blocks.Section({ text: feedbackMd }),
+    Blocks.Divider(),
+    Blocks.Section({ text: messagesMd }),
+    Blocks.Section({ text: referencesMd }),
+    Blocks.Divider(),
+    Blocks.Section({ text: scoresMd }),
+    Blocks.Divider(),
+    Blocks.Section({ text: messageMetadataMd }),
+    Blocks.Divider(),
+    Blocks.Section({ text: idMetadataMd }),
+  ];
+
+  const maybeAuthUser = conversation.customData?.authUser;
+  if (maybeAuthUser && typeof maybeAuthUser === "string") {
+    messageBlocks.unshift(
+      Blocks.Section({ text: `Auth User: ${Md.user(maybeAuthUser)}` })
+    );
+  }
+
   return BuilderMessage({
     channel: slackConversationId,
     text: "User Feedback",
   })
-    .blocks(
-      Blocks.Section({ text: feedbackMd }),
-      Blocks.Divider(),
-      Blocks.Section({ text: messagesMd }),
-      Blocks.Section({ text: referencesMd }),
-      Blocks.Divider(),
-      Blocks.Section({ text: scoresMd }),
-      Blocks.Divider(),
-      Blocks.Section({ text: messageMetadataMd }),
-      Blocks.Divider(),
-      Blocks.Section({ text: idMetadataMd })
-    )
+    .blocks(...messageBlocks)
     .asUser()
     .buildToObject();
 }

--- a/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
@@ -27,6 +27,11 @@ export const makeAddMessageToConversationUpdateTrace: (
       typeof llmAsAJudge?.percentToJudge === "number" &&
       Math.random() < llmAsAJudge.percentToJudge;
 
+    const maybeAuthUser = conversation.customData?.authUser;
+    if (maybeAuthUser && typeof maybeAuthUser === "string") {
+      tracingData.tags.push(`auth_user`);
+    }
+
     logger.updateSpan({
       id: traceId,
       tags: tracingData.tags,
@@ -35,6 +40,9 @@ export const makeAddMessageToConversationUpdateTrace: (
         ...(shouldJudge
           ? await getLlmAsAJudgeScores(llmAsAJudge, tracingData)
           : undefined),
+      },
+      metadata: {
+        authUser: conversation.customData?.authUser ?? null,
       },
     });
   };


### PR DESCRIPTION
Jira: n/a

## Changes

- When using chatbot behind the MDB CorpSecure (such as staging site https://chat-server.docs.staging.corp.mongodb.com/), we add the `auth_user` cookie to braintrust logs and also post to slack
  - this is useful for manual testing/feedback of chatbot

## Notes

- Note, this won't work w/ the vanity URL staging site https://knowledge.staging.corp.mongodb.com/ b/c this is only behind the firewall, not corpsecure.
