### PR TITLE
(EAI-968) ingest multiple versions

### DIFF
--- a/packages/ingest-mongodb-public/src/meta.config.ts
+++ b/packages/ingest-mongodb-public/src/meta.config.ts
@@ -71,7 +71,7 @@ export const standardConfig = {
   }),
   dataSources: async () => {
     const source = makeSnootyDataSource({
-      name: `snooty-${metaSnootyProject.name}`,
+      name: metaSnootyProject.name,
       project: {
         ...metaSnootyProject,
         currentBranch: metaSnootyProject.currentBranch,

--- a/packages/ingest-mongodb-public/src/meta.config.ts
+++ b/packages/ingest-mongodb-public/src/meta.config.ts
@@ -74,9 +74,7 @@ export const standardConfig = {
       name: metaSnootyProject.name,
       project: {
         ...metaSnootyProject,
-        currentBranch: metaSnootyProject.currentBranch,
         type: "snooty",
-        baseUrl: metaSnootyProject.baseUrl?.replace(/\/?$/, "/"),
       },
       snootyDataApiBaseUrl,
     });

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
@@ -226,7 +226,7 @@ describe("handlePage()", () => {
       sourceName: "sample-source",
       baseUrl: "https://example.com",
       tags: ["a"],
-      version: "1.0",
+      version: {label: "1.0", isCurrent: true},
     });
     expect(result).toMatchObject({
       format: "openapi-yaml",
@@ -248,7 +248,7 @@ describe("handlePage()", () => {
       sourceName: "sample-source",
       baseUrl: "https://example.com",
       tags: ["a"],
-      version: "1.0",
+      version: {label: "1.0", isCurrent: true},
     });
     expect(result).toMatchObject({
       format: "md",

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
@@ -19,10 +19,17 @@ describe("SnootyDataSource", () => {
   const project: SnootyProjectConfig = {
     type: "snooty",
     name: "docs",
-    currentBranch: "v6.0",
     tags: ["docs", "manual"],
-    baseUrl: "https://mongodb.com/docs/v6.0/",
     version: "version_name",
+    branches: [
+      {
+        gitBranchName: "v6.0",
+        label: "v6.0 (current)",
+        active: true,
+        fullUrl: "https://mongodb.com/docs/v6.0/", 
+        isStableBranch: true,
+      },
+    ],
   };
   const snootyDataApiBaseUrl = "https://snooty-data-api.mongodb.com/prod/";
   describe("makeSnootyDataSource()", () => {
@@ -40,7 +47,7 @@ describe("SnootyDataSource", () => {
     const baseMock = nock(snootyDataApiBaseUrl);
     beforeEach(() => {
       baseMock
-        .get(`/projects/${project.name}/${project.currentBranch}/documents`)
+        .get(`/projects/${project.name}/v6.0/documents`)
         .reply(200, () => {
           return fs.createReadStream(sampleDataPath);
         });
@@ -49,7 +56,7 @@ describe("SnootyDataSource", () => {
     afterEach(() => {
       nock.cleanAll();
     });
-    it("successfully loads pages", async () => {
+    it("successfully loads pages for active branches", async () => {
       const source = await makeSnootyDataSource({
         name: `snooty-test`,
         project,
@@ -76,6 +83,27 @@ describe("SnootyDataSource", () => {
         body: firstPageText,
       });
     });
+    it("should skip inactive branches", async () => {
+      const inactiveProject: SnootyProjectConfig = {
+        ...project,
+        branches: [{
+          gitBranchName: 'v5.0',
+          label: 'v5.0',
+          active: false,
+          fullUrl: 'https://mongodb.com/docs/v5.0/',
+          isStableBranch: false
+        }]
+      };
+  
+      const source = makeSnootyDataSource({
+        name: "test-source", 
+        project: inactiveProject,
+        snootyDataApiBaseUrl: "https://snooty-api.example.com"
+      });
+  
+      const pages = await source.fetchPages();
+      expect(pages).toHaveLength(0);
+    });
     it("removes 'index' from page_id", async () => {
       const source = await makeSnootyDataSource({
         name: "snooty-docs",
@@ -101,7 +129,10 @@ describe("SnootyDataSource", () => {
         sourceName: "snooty-docs",
         metadata: {
           tags: ["docs", "manual"],
-          version: "version_name",
+          version: {
+            isCurrent: true,
+            label: "v6.0 (current)",
+          },
         },
         url: "https://mongodb.com/docs/v6.0/administration/analyzing-mongodb-performance/index/",
       });
@@ -112,7 +143,10 @@ describe("SnootyDataSource", () => {
         sourceName: "snooty-docs",
         metadata: {
           tags: ["docs", "manual"],
-          version: "version_name",
+          version: {
+            isCurrent: true,
+            label: "v6.0 (current)",
+          },
         },
         url: "https://mongodb.com/docs/v6.0/administration/index/backup-sharded-clusters/",
       });
@@ -123,7 +157,10 @@ describe("SnootyDataSource", () => {
         sourceName: "snooty-docs",
         metadata: {
           tags: ["docs", "manual"],
-          version: "version_name",
+          version: {
+            isCurrent: true,
+            label: "v6.0 (current)",
+          },
         },
         url: "https://mongodb.com/docs/v6.0/administration/change-streams-production-recommendations/how-to-index/",
       });
@@ -138,6 +175,7 @@ describe("SnootyDataSource", () => {
       const pages = await source.fetchPages();
       for (const page of pages) {
         expect(page.metadata?.siteTitle).toBeDefined();
+        expect(page.metadata?.version).toStrictEqual({ label: 'v6.0 (current)', isCurrent: true },);
       }
     });
 
@@ -158,7 +196,7 @@ describe("SnootyDataSource", () => {
       // Hot swap the mocked backend's data source. The sample data now has one marked deleted.
       nock.cleanAll();
       baseMock
-        .get(`/projects/${project.name}/${project.currentBranch}/documents`)
+        .get(`/projects/${project.name}/v6.0/documents`)
         .reply(200, () => {
           return fs.createReadStream(
             Path.resolve(
@@ -186,7 +224,7 @@ describe("SnootyDataSource", () => {
         snootyDataApiBaseUrl: mockUrl,
       });
       noIndexMock
-        .get(`/projects/${project.name}/${project.currentBranch}/documents`)
+        .get(`/projects/${project.name}/v6.0/documents`)
         .reply(200, () => {
           const noIndexAst = jsonLify(
             Path.resolve(SRC_ROOT, "../testData/noindex.json")
@@ -233,7 +271,7 @@ describe("handlePage()", () => {
       title: "Atlas App Services Data API",
       metadata: {
         tags: ["a", "openapi"],
-        version: "1.0",
+        version: {label: "1.0", isCurrent: true},
       },
     });
   });
@@ -255,7 +293,7 @@ describe("handlePage()", () => {
       title: "$merge (aggregation)",
       metadata: {
         tags: ["a"],
-        version: "1.0",
+        version: {label: "1.0", isCurrent: true},
       },
     });
     expect(result?.body).toContain("# $merge (aggregation)");

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -191,6 +191,9 @@ export const makeSnootyDataSource = ({
       // now we can just accept the memory cost.
       const pagesForAllBranches: Page[] = [];
       for (const branch of branches ?? []) {
+        if (!branch.active) {
+          continue;
+        }
         const getBranchDocumentsUrl = new URL(
           `projects/${snootyProjectName}/${branch.gitBranchName}/documents`,
           snootyDataApiBaseUrl)

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -108,19 +108,7 @@ export type SnootyMetadata = {
 
 export type SnootyProjectConfig = ProjectBase & {
   type: "snooty";
-
-  /**
-    Git branch name for the current (search indexed) version of the site.
-    @example "v4.10"
-   */
-  currentBranch: string;
-
   branches?: Branch[];
-
-  /**
-    The base URL of pages within the project site.
-   */
-  baseUrl: string;
 };
 
 /**
@@ -131,13 +119,8 @@ export type SnootyProjectConfig = ProjectBase & {
   in the Snooty Data API. `currentBranch` will be the name of the first branch
   entry with `isStableBranch` set to true in the Data API response.
  */
-export type LocallySpecifiedSnootyProjectConfig = Omit<
-  SnootyProjectConfig,
-  "baseUrl" | "currentBranch" | "version"
-> & {
-  baseUrl?: string;
-  currentBranch?: string;
-  versionNameOverride?: string;
+export type LocallySpecifiedSnootyProjectConfig = SnootyProjectConfig & {
+  currentVersionOverride?: string;
 };
 
 export type MakeSnootyDataSourceArgs = {
@@ -155,35 +138,20 @@ export type MakeSnootyDataSourceArgs = {
     The base URL for Snooty Data API requests.
    */
   snootyDataApiBaseUrl: string;
-
-  version?: string;
 };
 
 export const makeSnootyDataSource = ({
   name: sourceName,
   project,
   snootyDataApiBaseUrl,
-}: MakeSnootyDataSourceArgs): DataSource & {
-  _baseUrl: string;
-  _currentBranch: string;
-  _snootyProjectName: string;
-  _version?: string;
-} => {
+}: MakeSnootyDataSourceArgs): DataSource => {
   const {
-    baseUrl,
-    currentBranch,
     branches,
     name: snootyProjectName,
     tags,
     productName,
-    version,
   } = project;
   return {
-    // Additional members for testing purposes
-    _baseUrl: baseUrl,
-    _currentBranch: currentBranch,
-    _snootyProjectName: snootyProjectName,
-    _version: version,
     name: sourceName,
     async fetchPages() {
       // TODO: The manifest can be quite large (>100MB) so this could stand to

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -113,13 +113,13 @@ export type SnootyProjectConfig = ProjectBase & {
 
 /**
   Specifies a locally-overrideable Snooty project configuration.
-
-  `baseUrl` and `currentBranch`, if undefined, will be filled in by the Snooty
-  Data API GET projects endpoint. You can set them yourself to override the data
-  in the Snooty Data API. `currentBranch` will be the name of the first branch
-  entry with `isStableBranch` set to true in the Data API response.
  */
 export type LocallySpecifiedSnootyProjectConfig = SnootyProjectConfig & {
+  /**
+    Can be set to a branch label to override the current version of the
+    project. Available branche labels can be found in the Snooty Data API
+    response for the project. https://snooty-data-api.mongodb.com/prod/projects  
+   */
   currentVersionOverride?: string;
 };
 

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyProjectsInfo.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyProjectsInfo.ts
@@ -14,16 +14,6 @@ export type GetSnootyProjectsResponse = {
 };
 
 export type SnootyProjectsInfo = {
-  getBaseUrl(args: {
-    projectName: string;
-    branchName: string;
-  }): Promise<string>;
-
-  getCurrentBranch(args: { projectName: string }): Promise<Branch>;
-
-  getCurrentVersionName(args: {
-    projectName: string;
-  }): Promise<string | undefined>;
 
   getAllBranches(args: {
     projectName: string
@@ -62,29 +52,6 @@ export const makeSnootyProjectsInfo = async ({
   return {
     _data: data,
 
-    async getBaseUrl({ projectName, branchName }) {
-      const metadata = projectMap.get(projectName);
-      const branchMetaData = metadata?.branches.find(
-        (branch) => branch.active && branch.gitBranchName === branchName
-      );
-      // Make sure there is an active branch at the specified branch name
-      if (branchMetaData === undefined) {
-        throw new Error(
-          `For project '${projectName}', no active branch found for '${branchName}'.`
-        );
-      }
-      return branchMetaData.fullUrl.replace("http://", "https://");
-    },
-
-    async getCurrentBranch({ projectName }) {
-      return await getCurrentBranch(data, projectName);
-    },
-    async getCurrentVersionName({ projectName }) {
-      const currentBranch = await getCurrentBranch(data, projectName);
-      if (currentBranch.gitBranchName !== "master") {
-        return currentBranch.gitBranchName;
-      } else return;
-    },
     async getAllBranches({ projectName }) {
       const project = projectMap.get(projectName);
       return project?.branches;
@@ -92,21 +59,6 @@ export const makeSnootyProjectsInfo = async ({
   };
 };
 
-/**
-  Helper function used in methods of makeSnootyProjectsInfo()
- */
-async function getCurrentBranch(data: SnootyProject[], projectName: string) {
-  const metadata = data.find(({ project }) => project === projectName);
-  const currentBranch = metadata?.branches.find(
-    ({ active, isStableBranch }) => active && isStableBranch
-  );
-  if (currentBranch === undefined) {
-    throw new Error(
-      `For project '${projectName}', no active branch found with isStableBranch == true.`
-    );
-  }
-  return currentBranch;
-}
 /**
   Fill the details of the defined Snooty data sources with the info in the
   Snooty Data API projects endpoint.
@@ -130,14 +82,9 @@ export const prepareSnootySources = async ({
         }) as Branch[];
         // modify branches if there is a currentVersionOverride
         if (project.currentVersionOverride) {
-          branches = branches.map((branch) => {
-            if (branch.gitBranchName !== project.currentVersionOverride) {
-              return { ...branch, isStableBranch: false };
-            }
-            if (branch.gitBranchName === project.currentVersionOverride) {
-              return { ...branch, isStableBranch: true };
-            }
-            return branch;
+          branches = overrideCurrentVersion({
+            branches,
+            currentVersionOverride: project.currentVersionOverride,
           });
         }
         try {
@@ -162,3 +109,17 @@ export const prepareSnootySources = async ({
   ).map((result) => result.value);
 };
 
+export const overrideCurrentVersion = ({ branches, currentVersionOverride }: {
+  branches: Branch[];
+  currentVersionOverride: string;
+}) => { 
+  return branches.map((branch) => {
+    if (branch.label !== currentVersionOverride) {
+      return { ...branch, isStableBranch: false };
+    }
+    if (branch.label === currentVersionOverride) {
+      return { ...branch, isStableBranch: true };
+    }
+    return branch;
+  });
+}

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyProjectsInfo.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyProjectsInfo.ts
@@ -130,7 +130,7 @@ export const prepareSnootySources = async ({
 
         try {
           return makeSnootyDataSource({
-            name: `snooty-${project.name}`,
+            name: project.name,
             project: {
               ...project,
               currentBranch,

--- a/packages/ingest-mongodb-public/src/sources/snootySources.ts
+++ b/packages/ingest-mongodb-public/src/sources/snootySources.ts
@@ -20,7 +20,6 @@ export const snootyProjectConfig: LocallySpecifiedSnootyProjectConfig[] = [
     name: "docs",
     tags: ["docs", "manual"],
     productName: "MongoDB Server",
-    currentVersionOverride: "v7.0",
   },
   {
     type: "snooty",

--- a/packages/ingest-mongodb-public/src/sources/snootySources.ts
+++ b/packages/ingest-mongodb-public/src/sources/snootySources.ts
@@ -20,7 +20,7 @@ export const snootyProjectConfig: LocallySpecifiedSnootyProjectConfig[] = [
     name: "docs",
     tags: ["docs", "manual"],
     productName: "MongoDB Server",
-    versionNameOverride: "v7.0",
+    currentVersionOverride: "v7.0",
   },
   {
     type: "snooty",

--- a/packages/mongodb-rag-core/src/contentStore/Page.ts
+++ b/packages/mongodb-rag-core/src/contentStore/Page.ts
@@ -28,6 +28,15 @@ export type Page = {
   sourceName: string;
 
   /**
+    The version of the page. This is relevant for versioned docs.
+    If the page is not versioned, this field should be undefined.
+   */
+  version?: {
+    label: string;
+    isCurrent: boolean;
+  }
+
+  /**
     Arbitrary metadata for page.
    */
   metadata?: PageMetadata;


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-968

## Changes

- removed `snooty` prefix from sourceName
- ingesting all active branches for each data source
- inactive branches not ingested
- if pages exist for a branch that has recently become inactive, it will be deleted when ingest runs
- functionality to override what is considered the current version
- removed the override for docs v7.0 as [discussed in slack](https://mongodb.slack.com/archives/C05CE6UBGG5/p1745450845744029)
- updated tests

## Notes
- version is saved on Page on the metadata object. This is a deviation from the [spec doc](https://docs.google.com/document/d/1abwdBxOTxKLEynxSFeFFrrY-XGu4_UIL4XWq4fsVTnA/edit?usp=sharing), where we planned to set version on the root level of the document. I made this choice bc this is where version was previously stored, and only "snooty" pages are versioned.
- When this is approved, I will update the `pages_current` view in prod to filter out all but the current branch by adding the following the to the match stage
```
{
  $or: [
    {
      "metadata.version.isCurrent": true
    },
    {
      "metadata.version.isCurrent": {
        $exists: false
      }
    }
  ]
}
```
DO NOT MERGE to main until retrieval is set up to avoid non current versions. This PR will be merged to the feature branch
