### PR TITLE
Segment fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22363,6 +22363,13 @@
       "version": "0.16.8",
       "license": "MIT"
     },
+    "node_modules/@types/segment-analytics": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@types/segment-analytics/-/segment-analytics-0.0.38.tgz",
+      "integrity": "sha512-0clAuA7t6HxtpyXl4veE/oNVdcQFhlxnxgYlk0LeEYSoW3s3zZV5xa6DVHcOtozUO4u15Ipet5TdP88GbwKHvg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.7",
       "dev": true,
@@ -56533,6 +56540,7 @@
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
         "@types/react-transition-group": "^4.4.6",
+        "@types/segment-analytics": "^0.0.38",
         "@types/unist": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",

--- a/packages/mongodb-chatbot-ui/package.json
+++ b/packages/mongodb-chatbot-ui/package.json
@@ -125,6 +125,7 @@
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/react-transition-group": "^4.4.6",
+    "@types/segment-analytics": "^0.0.38",
     "@types/unist": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",

--- a/packages/mongodb-chatbot-ui/src/App.tsx
+++ b/packages/mongodb-chatbot-ui/src/App.tsx
@@ -69,7 +69,10 @@ function App() {
           serverBaseUrl={serverBaseUrl}
           shouldStream={shouldStream}
           darkMode={darkMode}
-          fetchOptions={{ credentials: "include" }}
+          fetchOptions={() => ({
+            credentials: "include",
+            headers: getSegmentIdHeaders(),
+          })}
           onOpen={() => {
             console.log("Docs Chatbot opened");
           }}
@@ -85,10 +88,10 @@ function App() {
           serverBaseUrl={serverBaseUrl}
           shouldStream={shouldStream}
           darkMode={darkMode}
-          fetchOptions={{
+          fetchOptions={() => ({
             credentials: "include",
             headers: getSegmentIdHeaders(),
-          }}
+          })}
           getClientContext={() => ({
             user: "test-user-pls-ignore",
           })}

--- a/packages/mongodb-chatbot-ui/src/segment.ts
+++ b/packages/mongodb-chatbot-ui/src/segment.ts
@@ -1,9 +1,22 @@
+function stripLiteralQuotes(str?: string) {
+  return str?.replace(/^"|"$/g, "");
+}
+
 /**
  * Get Segment IDs from the browser's local storage.
  */
 export function getSegmentIds() {
-  const userId = localStorage.getItem("ajs_user_id") ?? undefined;
-  const anonymousId = localStorage.getItem("ajs_anonymous_id") ?? undefined;
+  const analytics =
+    typeof window !== "undefined" && window.analytics ? window.analytics : null;
+
+  const userId = stripLiteralQuotes(
+    analytics?.user().id() ?? localStorage.getItem("ajs_user_id") ?? undefined
+  );
+  const anonymousId = stripLiteralQuotes(
+    analytics?.user().anonymousId() ??
+      localStorage.getItem("ajs_anonymous_id") ??
+      undefined
+  );
   return {
     userId,
     anonymousId,

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -4,7 +4,6 @@ import {
   ConversationFetchOptions,
   AssistantMessageMetadata,
   MessageData,
-  ConversationServiceConfig,
 } from "./services/conversations";
 import createMessage, { createMessageId } from "./createMessage";
 import { countRegexMatches, canUseServerSentEvents } from "./utils";

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -4,6 +4,7 @@ import {
   ConversationFetchOptions,
   AssistantMessageMetadata,
   MessageData,
+  ConversationServiceConfig,
 } from "./services/conversations";
 import createMessage, { createMessageId } from "./createMessage";
 import { countRegexMatches, canUseServerSentEvents } from "./utils";
@@ -31,7 +32,7 @@ export type UseConversationParams = {
   serverBaseUrl: string;
   shouldStream?: boolean;
   sortMessageReferences?: SortReferences;
-  fetchOptions?: ConversationFetchOptions;
+  fetchOptions?: ConversationFetchOptions | (() => ConversationFetchOptions);
   getClientContext?: () => Record<string, unknown>;
 };
 

--- a/packages/mongodb-chatbot-ui/src/useConversation.tsx
+++ b/packages/mongodb-chatbot-ui/src/useConversation.tsx
@@ -31,6 +31,11 @@ export type UseConversationParams = {
   serverBaseUrl: string;
   shouldStream?: boolean;
   sortMessageReferences?: SortReferences;
+  /**
+   * Optional fetch options for the ConversationService. Can be either a static
+   * `ConversationFetchOptions` object for all request or a function that
+   * dynamically returns a new `ConversationFetchOptions` object for each request.
+   */
   fetchOptions?: ConversationFetchOptions | (() => ConversationFetchOptions);
   getClientContext?: () => Record<string, unknown>;
 };


### PR DESCRIPTION
Jira: (EAI-997) [UI] Segment fixes

## Changes

- Strips literal quotes from segment ids (if present)
- Supports dynamic fetchOptions in conversations service
  - This lets us pull the segment headers on every request. Useful if they're not set until after the chatbot renders.

