### PR TITLE
(EAI-998): Low-hanging improvements to existing tracing metrics

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
@@ -63,6 +63,9 @@ export function extractTracingData(
     tags.push("llm_does_not_know");
   }
 
+  const rating = evalAssistantMessage?.rating;
+  const comment = evalAssistantMessage?.userComment;
+
   return {
     tags,
     rejectQuery,
@@ -71,6 +74,8 @@ export function extractTracingData(
     numRetrievedChunks,
     userMessage: previousUserMessage,
     assistantMessage: evalAssistantMessage,
+    rating,
+    comment,
   };
 }
 

--- a/packages/chatbot-server-mongodb-public/src/tracing/getLlmAsAJudgeScores.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/getLlmAsAJudgeScores.test.ts
@@ -49,6 +49,8 @@ describe("getLlmAsAJudgeScores", () => {
     llmDoesNotKnow: false,
     numRetrievedChunks: 1,
     rejectQuery: false,
+    rating: undefined,
+    comment: undefined,
   } satisfies Parameters<typeof getLlmAsAJudgeScores>[1];
 
   it("shouldn't judge verified answer", async () => {

--- a/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
@@ -126,9 +126,9 @@ function getTracingScores(
   k: number
 ) {
   return {
-    AcceptedQuery: tracingData.rejectQuery === true ? 0 : 1,
+    InputGuardrailPass: tracingData.rejectQuery === true ? 0 : 1,
     VerifiedAnswer: tracingData.isVerifiedAnswer === true ? 1 : 0,
-    LlmAnswered: tracingData.llmDoesNotKnow === true ? 0 : 1,
+    LlmAnswerAttempted: tracingData.llmDoesNotKnow === true ? 0 : 1,
     HasRating: tracingData.rating !== undefined ? 1 : 0,
     HasComment: tracingData.comment !== undefined ? 1 : 0,
     [`RetrievedChunksOver${k}`]:

--- a/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
@@ -126,15 +126,25 @@ function getTracingScores(
   k: number
 ) {
   return {
-    InputGuardrailPass: tracingData.rejectQuery === true ? 0 : 1,
-    VerifiedAnswer: tracingData.isVerifiedAnswer === true ? 1 : 0,
-    LlmAnswerAttempted: tracingData.llmDoesNotKnow === true ? 0 : 1,
+    // These metrics should start at 0,
+    // and are updated in other update trace handlers as needed
     HasRating: tracingData.rating !== undefined ? 1 : 0,
     HasComment: tracingData.comment !== undefined ? 1 : 0,
-    [`RetrievedChunksOver${k}`]:
-      tracingData.isVerifiedAnswer !== true
-        ? tracingData.numRetrievedChunks / k
-        : null,
+    VerifiedAnswer: tracingData.isVerifiedAnswer === true ? 1 : 0,
+    // Only calculate these metrics if the answer is not verified
+    InputGuardrailPass: tracingData.isVerifiedAnswer
+      ? null
+      : tracingData.rejectQuery === true
+      ? 0
+      : 1,
+    LlmAnswerAttempted: tracingData.isVerifiedAnswer
+      ? null
+      : tracingData.llmDoesNotKnow === true
+      ? 0
+      : 1,
+    [`RetrievedChunksOver${k}`]: tracingData.isVerifiedAnswer
+      ? null
+      : tracingData.numRetrievedChunks / k,
   };
 }
 

--- a/packages/mongodb-chatbot-server/src/routes/conversations/commentMessage.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/commentMessage.ts
@@ -150,9 +150,6 @@ export function makeCommentMessageRoute({
         braintrustLogger.logFeedback({
           id: traceId,
           comment,
-          scores: {
-            HasComment: 1,
-          },
         });
         await updateTraceIfExists({
           updateTrace,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-998

## Changes

- Add new metrics to conversation tracing
  - Track if message is rated (0 if not, 1 if so)
  - Track if message is commented (0 if not, 1 if so)
- Update existing metrics to compute across all traces
  - Redo `RejectedQuery` as InputGuardrailPass`. 1 if passes guardrail, 0 if not.
  - Redo `LlmDoesNotKnow` as `LlmAnswerAttempted`. 1 if attempts answer (not the canned idk response), 0 if canned answer
  - `VerifiedAnswer` now calculates 1 if verified answer, 0 if not. Previously was only calculated if it was a verified answer. 

## Notes

- This gives us better top-line numbers to view in braintrust logs, as the metrics are now across all messages, rather than just the ones where there was a pass. 
