### PR TITLE
(EAI-1015): Parse Braintrust results to benchmark reporting service format

### DIFF
--- a/packages/benchmarks/src/nlPromptResponse/NlQuestionAnswerEval.ts
+++ b/packages/benchmarks/src/nlPromptResponse/NlQuestionAnswerEval.ts
@@ -13,7 +13,8 @@ export type NlPromptResponseEvalCaseInput = {
 
 export type NlPromptResponseTag = string;
 
-export type NlPromptResponseMetadata = Record<string, unknown>;
+export type NlPromptResponseMetadata = Record<string, unknown> &
+  Omit<LlmOptions, "openAiClient">;
 
 export interface NlPromptResponseEvalCase
   extends EvalCase<

--- a/packages/benchmarks/src/nlPromptResponse/NlQuestionAnswerEval.ts
+++ b/packages/benchmarks/src/nlPromptResponse/NlQuestionAnswerEval.ts
@@ -14,7 +14,7 @@ export type NlPromptResponseEvalCaseInput = {
 export type NlPromptResponseTag = string;
 
 export type NlPromptResponseMetadata = Record<string, unknown> &
-  Omit<LlmOptions, "openAiClient">;
+  Partial<Omit<LlmOptions, "openAiClient">>;
 
 export interface NlPromptResponseEvalCase
   extends EvalCase<

--- a/packages/benchmarks/src/nlPromptResponse/bin/techSupport/techSupportPromptCompletionBenchmark.ts
+++ b/packages/benchmarks/src/nlPromptResponse/bin/techSupport/techSupportPromptCompletionBenchmark.ts
@@ -69,6 +69,7 @@ async function main() {
         additionalMetadata: {
           judgeModelsConfig,
           ...staticLlmOptions,
+          model: model.label,
         },
         task: makeNlPromptCompletionTask({
           llmOptions,

--- a/packages/benchmarks/src/reporting/EvalCases.ts
+++ b/packages/benchmarks/src/reporting/EvalCases.ts
@@ -13,7 +13,7 @@ export type BaseCase<
   /*
   A unique identifier for the prompt.
   */
-  id: ObjectId;
+  _id: ObjectId;
 
   /*
   The type of prompt. This determines the format of the prompt, its expected response, and the type of metrics we use to evaluate the results.
@@ -63,7 +63,7 @@ type Result<
   The name of the model that was used to generate the result.
   */
   model: string;
-  
+
   /*
   The name of the company/lab that created the model.
   */

--- a/packages/benchmarks/src/reporting/EvalCases.ts
+++ b/packages/benchmarks/src/reporting/EvalCases.ts
@@ -6,10 +6,7 @@ type ChatCompletionMessageParam = OpenAI.Chat.ChatCompletionMessageParam;
 /**
  This represents a single prompt that we pass to models for evaluation.
 */
-export type BaseCase<
-  CaseMetadata extends Record<string, unknown> = Record<string, unknown>,
-  CaseResult extends Result = Result
-> = {
+export type BaseCase = {
   /*
   A unique identifier for the prompt.
   */
@@ -28,7 +25,7 @@ export type BaseCase<
   /*
   Metadata about the prompt.
   */
-  metadata?: CaseMetadata;
+  metadata?: Record<string, unknown>;
 
   /*
   A human readable label for the case. For most cases this will just be the natural language query.
@@ -49,16 +46,14 @@ export type BaseCase<
    A list of results for the prompt.
    */
   results: {
-    [modelName: string]: CaseResult;
+    [modelName: string]: Result;
   };
 };
 
 /**
  This represents the result of running a prompt through a specific model.
 */
-type Result<
-  Metadata extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type Result = {
   /*
   The name of the model that was used to generate the result.
   */
@@ -82,7 +77,7 @@ type Result<
   /*
   Additional metadata about the result. For example, we could use this to map results back to their experiment name in Braintrust
   */
-  metadata?: Metadata;
+  metadata?: Record<string, unknown>;
 
   /*
   A list of evaluation metrics that we use to judge the quality of the result.

--- a/packages/benchmarks/src/reporting/EvalCases.ts
+++ b/packages/benchmarks/src/reporting/EvalCases.ts
@@ -63,6 +63,11 @@ type Result<
   The name of the model that was used to generate the result.
   */
   model: string;
+  
+  /*
+  The name of the company/lab that created the model.
+  */
+  provider: string;
 
   /*
   The date and time the result was generated.

--- a/packages/benchmarks/src/reporting/EvalCases.ts
+++ b/packages/benchmarks/src/reporting/EvalCases.ts
@@ -1,0 +1,126 @@
+import { ObjectId } from "mongodb-rag-core/mongodb";
+import { OpenAI } from "mongodb-rag-core/openai";
+
+type ChatCompletionMessageParam = OpenAI.Chat.ChatCompletionMessageParam;
+
+/**
+ This represents a single prompt that we pass to models for evaluation.
+*/
+export type BaseCase<
+  CaseMetadata extends Record<string, unknown> = Record<string, unknown>,
+  CaseResult extends Result = Result
+> = {
+  /*
+  A unique identifier for the prompt.
+  */
+  id: ObjectId;
+
+  /*
+  The type of prompt. This determines the format of the prompt, its expected response, and the type of metrics we use to evaluate the results.
+  */
+  type: string;
+
+  /*
+  A list of tags for the prompt that we can filter by.
+  */
+  tags: string[];
+
+  /*
+  Metadata about the prompt.
+  */
+  metadata?: CaseMetadata;
+
+  /*
+  A human readable label for the case. For most cases this will just be the natural language query.
+  */
+  name: string;
+
+  /*
+  The prompt messages that we pass to the model.
+  */
+  prompt: ChatCompletionMessageParam[];
+
+  /*
+  The expected response from the model. The format of this depends on the type of prompt.
+  */
+  expected: string;
+
+  /*
+   A list of results for the prompt.
+   */
+  results: {
+    [modelName: string]: CaseResult;
+  };
+};
+
+/**
+ This represents the result of running a prompt through a specific model.
+*/
+type Result<
+  Metadata extends Record<string, unknown> = Record<string, unknown>
+> = {
+  /*
+  The name of the model that was used to generate the result.
+  */
+  model: string;
+
+  /*
+  The date and time the result was generated.
+  */
+  date: Date;
+
+  /*
+  The response returned from the model.
+  */
+  response: string;
+
+  /*
+  Additional metadata about the result. For example, we could use this to map results back to their experiment name in Braintrust
+  */
+  metadata?: Metadata;
+
+  /*
+  A list of evaluation metrics that we use to judge the quality of the result.
+  */
+  metrics: {
+    [metricName: string]: number;
+  };
+};
+
+/**
+ This represents a multiple choice prompt. Used for evaluating models that can choose from a list of options.
+ For example, the prompt may be an individual MongoDB University quiz question or skill assessment question.
+ The response is a string containing one or more choices that correspond to the correct answer.
+*/
+export type MultipleChoiceCase = BaseCase & {
+  type: "multiple_choice";
+};
+
+/**
+ This represents a natural language prompt. Used for evaluating models that can generate text.
+ For example, the prompt may be a technical support question, product knowledge question, or general awareness question.
+ The response is a single string that, ideally, matches the expected answer.
+*/
+export type NaturalLanguageCase = BaseCase & {
+  type: "natural_language";
+};
+
+/**
+ This represents a code generation prompt. Used for evaluating models that can generate code.
+ For example, the prompt may be a user query on a specific collection, with or without additional context like schemas, indexes, etc.
+ The response is code representing a valid MongoDB query that returns the expected results.
+*/
+export type NaturalLanguageToCodeCase = BaseCase & {
+  type: "natural_language_to_code";
+  results: (Result & {
+    /*
+     The type of code we're generating, e.g. mongosh, Java Driver, etc.
+    */
+    target: string;
+
+    /*
+    The value returned after executing the generated code
+    */
+    codeResult: unknown;
+  })[];
+};

--- a/packages/benchmarks/src/reporting/bin/reportMultipleChoiceBenchmarkResults.ts
+++ b/packages/benchmarks/src/reporting/bin/reportMultipleChoiceBenchmarkResults.ts
@@ -7,19 +7,23 @@ import { BSON } from "mongodb-rag-core/mongodb";
 const { EJSON } = BSON;
 
 async function main() {
-  const pathOut = path.join("testData", "tech_support_results.json");
+  const pathOut = path.join(
+    __dirname,
+    "testData",
+    "multiple_choice_results.json"
+  );
 
-  console.log(`Reporting tech support benchmark results to ${pathOut}`);
+  console.log(`Reporting multiple choice benchmark results to ${pathOut}`);
 
   const apiKey = process.env.BRAINTRUST_API_KEY;
   assert(apiKey, "must have BRAINTRUST_API_KEY set");
 
-  const projectName = "tech-support-prompt-completion";
+  const projectName = "mongodb-multiple-choice";
 
   const cases = await reportBenchmarkResults({
     apiKey,
     projectName,
-    experimentType: "prompt_response",
+    experimentType: "multiple_choice",
   });
   console.log(`Reported ${cases.length} cases`);
   fs.writeFileSync(pathOut, EJSON.stringify(cases));

--- a/packages/benchmarks/src/reporting/bin/reportTechSupportBenchmarkResults.ts
+++ b/packages/benchmarks/src/reporting/bin/reportTechSupportBenchmarkResults.ts
@@ -1,0 +1,20 @@
+import { reportBenchmarkResults } from "../reportBenchmarkResults";
+import { strict as assert } from "assert";
+import fs from "fs";
+import "dotenv/config";
+
+async function main() {
+  console.log("Reporting tech support benchmark results");
+  const apiKey = process.env.BRAINTRUST_API_KEY;
+  assert(apiKey, "must have BRAINTRUST_API_KEY set");
+  const projectName = "tech-support-prompt-completion";
+  const cases = await reportBenchmarkResults({
+    apiKey,
+    projectName,
+    experimentType: "prompt_response",
+  });
+  console.log(`Reported ${cases.length} cases`);
+  fs.writeFileSync("tech_support_results.json", JSON.stringify(cases, null, 2));
+}
+
+main();

--- a/packages/benchmarks/src/reporting/bin/reportTechSupportBenchmarkResults.ts
+++ b/packages/benchmarks/src/reporting/bin/reportTechSupportBenchmarkResults.ts
@@ -1,20 +1,26 @@
 import { reportBenchmarkResults } from "../reportBenchmarkResults";
 import { strict as assert } from "assert";
 import fs from "fs";
+import path from "path";
 import "dotenv/config";
 
 async function main() {
-  console.log("Reporting tech support benchmark results");
+  const pathOut = path.join("testData", "tech_support_results.json");
+
+  console.log(`Reporting tech support benchmark results to ${pathOut}`);
+
   const apiKey = process.env.BRAINTRUST_API_KEY;
   assert(apiKey, "must have BRAINTRUST_API_KEY set");
+
   const projectName = "tech-support-prompt-completion";
+
   const cases = await reportBenchmarkResults({
     apiKey,
     projectName,
     experimentType: "prompt_response",
   });
   console.log(`Reported ${cases.length} cases`);
-  fs.writeFileSync("tech_support_results.json", JSON.stringify(cases, null, 2));
+  fs.writeFileSync(pathOut, JSON.stringify(cases, null, 2));
 }
 
 main();

--- a/packages/benchmarks/src/reporting/getBraintrustExperimentSummary.ts
+++ b/packages/benchmarks/src/reporting/getBraintrustExperimentSummary.ts
@@ -10,7 +10,7 @@ export async function getBraintrustExperimentSummary({
   projectName,
   experimentName,
   apiKey,
-}: GetBraintrustExperimentSummary): Promise<unknown> {
+}: GetBraintrustExperimentSummary) {
   const experiment = await init(projectName, {
     experiment: experimentName,
     apiKey,

--- a/packages/benchmarks/src/reporting/listBraintrustExperiments.ts
+++ b/packages/benchmarks/src/reporting/listBraintrustExperiments.ts
@@ -15,7 +15,7 @@ interface ListBraintrustExperimentsParams {
 export async function listBraintrustExperiments({
   apiKey,
   queryParams,
-}: ListBraintrustExperimentsParams): Promise<unknown> {
+}: ListBraintrustExperimentsParams): Promise<Experiment[]> {
   const url = new URL(`https://api.braintrust.dev/v1/experiment/`);
   if (queryParams) {
     for (const [key, value] of Object.entries(queryParams)) {
@@ -35,7 +35,7 @@ export async function listBraintrustExperiments({
     throw new Error(`Failed to list experiments: ${res.status}`);
   }
   const json = await res.json();
-  return json as ListBraintrustExperimentsResponse;
+  return (json as ListBraintrustExperimentsResponse).objects;
 }
 
 /**

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
@@ -1,0 +1,170 @@
+import { ObjectId } from "mongodb-rag-core/mongodb";
+import { BaseCase } from "./EvalCases";
+import { materializeExperimentResultsByCase } from "./materializeExperimentResultsByCase";
+import { ResultsByExperiment } from "./reportBenchmarkResults";
+
+describe("materializeExperimentResultsByCase", () => {
+  // Create valid ObjectId hex strings (24 characters)
+  const mockId1 = "507f1f77bcf86cd799439011";
+  const mockId2 = "507f1f77bcf86cd799439012";
+
+  // Create mock experiment results
+  const mockResultsByExperiment: ResultsByExperiment = {
+    experiment1: [
+      {
+        id: mockId1,
+        input: "test input 1",
+        expected: "expected output 1",
+        tags: ["tag1", "tag2"],
+        output: "actual output 1",
+        metadata: {},
+        scores: {
+          accuracy: 0.8,
+          relevance: 0.9,
+        },
+      },
+      {
+        id: mockId2,
+        input: "test input 2",
+        expected: "expected output 2",
+        tags: ["tag2", "tag3"],
+        output: "actual output 2",
+        metadata: {},
+        scores: {
+          accuracy: 0.7,
+          relevance: 0.85,
+        },
+      },
+    ],
+    experiment2: [
+      {
+        id: mockId1,
+        input: "test input 1",
+        expected: "expected output 1",
+        tags: ["tag1", "tag2"],
+        output: "different output for experiment 2",
+        metadata: {},
+        scores: {
+          accuracy: 0.75,
+          relevance: 0.95,
+        },
+      },
+      {
+        id: mockId2,
+        input: "test input 2",
+        expected: "expected output 2",
+        tags: ["tag2", "tag3"],
+        output: "different output for experiment 2",
+        metadata: {},
+        scores: {
+          accuracy: 0.65,
+          relevance: 0.8,
+        },
+      },
+    ],
+  };
+
+  it("should group results by case id", () => {
+    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
+
+    // Should return the correct number of cases
+    expect(results.length).toBe(2);
+
+    // Find the cases by id
+    const case1 = results.find((c) => c.id.toString() === mockId1);
+    const case2 = results.find((c) => c.id.toString() === mockId2);
+
+    // Verify both cases exist
+    expect(case1).toBeDefined();
+    expect(case2).toBeDefined();
+
+    // Verify case1 has results from both experiments
+    expect(Object.keys(case1!.results)).toHaveLength(2);
+    expect(case1!.results).toHaveProperty("experiment1");
+    expect(case1!.results).toHaveProperty("experiment2");
+
+    // Verify case2 has results from both experiments
+    expect(Object.keys(case2!.results)).toHaveLength(2);
+    expect(case2!.results).toHaveProperty("experiment1");
+    expect(case2!.results).toHaveProperty("experiment2");
+  });
+
+  it("should correctly map experiment outputs to case results", () => {
+    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
+
+    // Find the cases by id
+    const case1 = results.find((c) => c.id.toString() === mockId1);
+
+    // Verify experiment1 results for case1
+    expect(case1!.results.experiment1.model).toBe("experiment1");
+    expect(case1!.results.experiment1.response).toBe(
+      JSON.stringify("actual output 1")
+    );
+    expect(case1!.results.experiment1.metrics).toEqual({
+      accuracy: 0.8,
+      relevance: 0.9,
+    });
+
+    // Verify experiment2 results for case1
+    expect(case1!.results.experiment2.model).toBe("experiment2");
+    expect(case1!.results.experiment2.response).toBe(
+      JSON.stringify("different output for experiment 2")
+    );
+    expect(case1!.results.experiment2.metrics).toEqual({
+      accuracy: 0.75,
+      relevance: 0.95,
+    });
+  });
+
+  it("should correctly handle scores", () => {
+    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
+
+    // Find the cases by id
+    const case2 = results.find((c) => c.id.toString() === mockId2);
+
+    // Check metrics are correctly extracted from scores
+    expect(case2!.results.experiment1.metrics).toEqual({
+      accuracy: 0.7,
+      relevance: 0.85,
+    });
+
+    expect(case2!.results.experiment2.metrics).toEqual({
+      accuracy: 0.65,
+      relevance: 0.8,
+    });
+  });
+
+  it("should handle missing or null values", () => {
+    // Create mock with missing and null values
+    const mockWithMissingValues: ResultsByExperiment = {
+      experiment3: [
+        {
+          id: "507f1f77bcf86cd799439013", // Valid ObjectId
+          input: "test input 3",
+          expected: null as any,
+          tags: undefined,
+          output: undefined,
+          metadata: {},
+          scores: {
+            accuracy: null,
+            relevance: 0.5,
+          },
+        },
+      ],
+    };
+
+    const results = materializeExperimentResultsByCase(mockWithMissingValues);
+    expect(results.length).toBe(1);
+
+    const case3 = results[0];
+    expect(case3.expected).toBe("");
+    expect(case3.tags).toEqual([]);
+    expect(case3.results.experiment3.response).toBe("");
+
+    // Should only include numeric scores
+    expect(case3.results.experiment3.metrics).toEqual({
+      relevance: 0.5,
+    });
+    expect(case3.results.experiment3.metrics).not.toHaveProperty("accuracy");
+  });
+});

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
@@ -2,7 +2,7 @@ import {
   materializeExperimentResultsByCase,
   providerFromModel,
 } from "./materializeExperimentResultsByCase";
-import { ResultsByExperiment } from "./reportBenchmarkResults";
+import { ExperimentType, ResultsByExperiment } from "./reportBenchmarkResults";
 import { ExperimentResult } from "./getBraintrustExperimentResults";
 import {
   NlPromptResponseEvalCase,
@@ -230,13 +230,13 @@ describe("materializeExperimentResultsByCase", () => {
     });
   });
   it("should throw for unsupported experiment types", () => {
-    const multipleChoiceType = "multiple_choice";
+    const fakeExperimentType = "invalid_experiment_type";
     expect(() =>
       materializeExperimentResultsByCase(
         mockResultsByExperiment,
-        multipleChoiceType
+        fakeExperimentType as ExperimentType
       )
-    ).toThrow(`Unsupported experiment type: ${multipleChoiceType}`);
+    ).toThrow(`Unsupported experiment type: ${fakeExperimentType}`);
     const naturalLanguageToCodeType = "natural_language_to_code";
     expect(() =>
       materializeExperimentResultsByCase(

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
@@ -1,170 +1,245 @@
-import { ObjectId } from "mongodb-rag-core/mongodb";
-import { BaseCase } from "./EvalCases";
 import { materializeExperimentResultsByCase } from "./materializeExperimentResultsByCase";
 import { ResultsByExperiment } from "./reportBenchmarkResults";
+import { ExperimentResult } from "./getBraintrustExperimentResults";
+import {
+  NlPromptResponseEvalCase,
+  NlPromptResponseTaskOutput,
+} from "../nlPromptResponse/NlQuestionAnswerEval";
 
 describe("materializeExperimentResultsByCase", () => {
   // Create valid ObjectId hex strings (24 characters)
-  const mockId1 = "507f1f77bcf86cd799439011";
-  const mockId2 = "507f1f77bcf86cd799439012";
+  const mockId1 = "123";
+  const mockId2 = "456";
+
+  const mockInput1Text = "test input 1";
+  const mockInput2Text = "test input 2";
 
   // Create mock experiment results
-  const mockResultsByExperiment: ResultsByExperiment = {
-    experiment1: [
-      {
-        id: mockId1,
-        input: "test input 1",
-        expected: "expected output 1",
-        tags: ["tag1", "tag2"],
-        output: "actual output 1",
-        metadata: {},
-        scores: {
-          accuracy: 0.8,
-          relevance: 0.9,
-        },
+  const mockResultsByExperiment: ResultsByExperiment<
+    ExperimentResult<
+      NlPromptResponseEvalCase,
+      NlPromptResponseTaskOutput,
+      string[]
+    >
+  > = {
+    experiment1: {
+      metadata: {
+        id: "experiment1",
+        project_id: "project1",
+        name: "experiment1",
+        public: false,
       },
-      {
-        id: mockId2,
-        input: "test input 2",
-        expected: "expected output 2",
-        tags: ["tag2", "tag3"],
-        output: "actual output 2",
-        metadata: {},
-        scores: {
-          accuracy: 0.7,
-          relevance: 0.85,
-        },
-      },
-    ],
-    experiment2: [
-      {
-        id: mockId1,
-        input: "test input 1",
-        expected: "expected output 1",
-        tags: ["tag1", "tag2"],
-        output: "different output for experiment 2",
-        metadata: {},
-        scores: {
-          accuracy: 0.75,
-          relevance: 0.95,
-        },
-      },
-      {
-        id: mockId2,
-        input: "test input 2",
-        expected: "expected output 2",
-        tags: ["tag2", "tag3"],
-        output: "different output for experiment 2",
-        metadata: {},
-        scores: {
-          accuracy: 0.65,
-          relevance: 0.8,
-        },
-      },
-    ],
-  };
-
-  it("should group results by case id", () => {
-    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
-
-    // Should return the correct number of cases
-    expect(results.length).toBe(2);
-
-    // Find the cases by id
-    const case1 = results.find((c) => c.id.toString() === mockId1);
-    const case2 = results.find((c) => c.id.toString() === mockId2);
-
-    // Verify both cases exist
-    expect(case1).toBeDefined();
-    expect(case2).toBeDefined();
-
-    // Verify case1 has results from both experiments
-    expect(Object.keys(case1!.results)).toHaveLength(2);
-    expect(case1!.results).toHaveProperty("experiment1");
-    expect(case1!.results).toHaveProperty("experiment2");
-
-    // Verify case2 has results from both experiments
-    expect(Object.keys(case2!.results)).toHaveLength(2);
-    expect(case2!.results).toHaveProperty("experiment1");
-    expect(case2!.results).toHaveProperty("experiment2");
-  });
-
-  it("should correctly map experiment outputs to case results", () => {
-    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
-
-    // Find the cases by id
-    const case1 = results.find((c) => c.id.toString() === mockId1);
-
-    // Verify experiment1 results for case1
-    expect(case1!.results.experiment1.model).toBe("experiment1");
-    expect(case1!.results.experiment1.response).toBe(
-      JSON.stringify("actual output 1")
-    );
-    expect(case1!.results.experiment1.metrics).toEqual({
-      accuracy: 0.8,
-      relevance: 0.9,
-    });
-
-    // Verify experiment2 results for case1
-    expect(case1!.results.experiment2.model).toBe("experiment2");
-    expect(case1!.results.experiment2.response).toBe(
-      JSON.stringify("different output for experiment 2")
-    );
-    expect(case1!.results.experiment2.metrics).toEqual({
-      accuracy: 0.75,
-      relevance: 0.95,
-    });
-  });
-
-  it("should correctly handle scores", () => {
-    const results = materializeExperimentResultsByCase(mockResultsByExperiment);
-
-    // Find the cases by id
-    const case2 = results.find((c) => c.id.toString() === mockId2);
-
-    // Check metrics are correctly extracted from scores
-    expect(case2!.results.experiment1.metrics).toEqual({
-      accuracy: 0.7,
-      relevance: 0.85,
-    });
-
-    expect(case2!.results.experiment2.metrics).toEqual({
-      accuracy: 0.65,
-      relevance: 0.8,
-    });
-  });
-
-  it("should handle missing or null values", () => {
-    // Create mock with missing and null values
-    const mockWithMissingValues: ResultsByExperiment = {
-      experiment3: [
+      results: [
         {
-          id: "507f1f77bcf86cd799439013", // Valid ObjectId
-          input: "test input 3",
-          expected: null as any,
-          tags: undefined,
-          output: undefined,
-          metadata: {},
+          id: mockId1,
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: mockInput1Text,
+              },
+            ],
+          },
+          expected: {
+            reference: "expected output 1",
+            links: [],
+          },
+          tags: ["tag1", "tag2"],
+          output: {
+            response: "actual output 1",
+          },
+          metadata: {
+            model: "model1",
+          },
           scores: {
-            accuracy: null,
-            relevance: 0.5,
+            accuracy: 0.8,
+            relevance: 0.9,
+          },
+        },
+        {
+          id: mockId2,
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: mockInput2Text,
+              },
+            ],
+          },
+          expected: {
+            reference: "expected output 2",
+            links: [],
+          },
+          tags: ["tag2", "tag3"],
+          output: {
+            response: "actual output 2",
+          },
+          metadata: {
+            model: "model2",
+          },
+          scores: {
+            accuracy: 0.7,
+            relevance: 0.85,
           },
         },
       ],
-    };
+    },
+    experiment2: {
+      metadata: {
+        id: "experiment2",
+        project_id: "project1",
+        name: "experiment2",
+        public: false,
+      },
+      results: [
+        {
+          id: mockId1,
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: mockInput1Text,
+              },
+            ],
+          },
+          expected: {
+            reference: "expected output 1",
+            links: [],
+          },
+          tags: ["tag1", "tag2"],
+          output: {
+            response: "different output for experiment 2",
+          },
+          metadata: {
+            model: "model2",
+          },
+          scores: {
+            accuracy: 0.75,
+            relevance: 0.95,
+          },
+        },
+        {
+          id: mockId2,
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: mockInput2Text,
+              },
+            ],
+          },
+          expected: {
+            reference: "expected output 2",
+            links: [],
+          },
+          tags: ["tag2", "tag3"],
+          output: {
+            response: "different output for experiment 2",
+          },
+          metadata: {
+            model: "model2",
+          },
+          scores: {
+            accuracy: 0.65,
+            relevance: 0.8,
+          },
+        },
+      ],
+    },
+  };
 
-    const results = materializeExperimentResultsByCase(mockWithMissingValues);
-    expect(results.length).toBe(1);
+  describe("prompt_response type", () => {
+    it("should group results by case id", () => {
+      const results = materializeExperimentResultsByCase(
+        mockResultsByExperiment,
+        "prompt_response"
+      );
 
-    const case3 = results[0];
-    expect(case3.expected).toBe("");
-    expect(case3.tags).toEqual([]);
-    expect(case3.results.experiment3.response).toBe("");
+      // Should return the correct number of cases
+      expect(results.length).toBe(2);
 
-    // Should only include numeric scores
-    expect(case3.results.experiment3.metrics).toEqual({
-      relevance: 0.5,
+      // Find the cases by id
+      const case1 = results.find((c) => c.name === mockInput1Text);
+      const case2 = results.find((c) => c.name === mockInput2Text);
+
+      // Verify both cases exist
+      expect(case1).toBeDefined();
+      expect(case2).toBeDefined();
+
+      // Verify case1 has results from both experiments
+      expect(Object.keys(case1!.results)).toHaveLength(2);
+      expect(case1!.results).toHaveProperty("experiment1");
+      expect(case1!.results).toHaveProperty("experiment2");
+
+      // Verify case2 has results from both experiments
+      expect(Object.keys(case2!.results)).toHaveLength(2);
+      expect(case2!.results).toHaveProperty("experiment1");
+      expect(case2!.results).toHaveProperty("experiment2");
     });
-    expect(case3.results.experiment3.metrics).not.toHaveProperty("accuracy");
+
+    it("should correctly map experiment outputs to case results", () => {
+      const results = materializeExperimentResultsByCase(
+        mockResultsByExperiment,
+        "prompt_response"
+      );
+
+      // Find the cases by id
+      const case1 = results.find((c) => c.name === mockInput1Text);
+
+      // Verify experiment1 results for case1
+      expect(case1!.results.experiment1.model).toBe("experiment1");
+      expect(case1!.results.experiment1.response).toBe("actual output 1");
+      expect(case1!.results.experiment1.metrics).toEqual({
+        accuracy: 0.8,
+        relevance: 0.9,
+      });
+
+      // Verify experiment2 results for case1
+      expect(case1!.results.experiment2.model).toBe("experiment2");
+      expect(case1!.results.experiment2.response).toBe(
+        "different output for experiment 2"
+      );
+      expect(case1!.results.experiment2.metrics).toEqual({
+        accuracy: 0.75,
+        relevance: 0.95,
+      });
+    });
+
+    it("should correctly handle scores", () => {
+      const results = materializeExperimentResultsByCase(
+        mockResultsByExperiment,
+        "prompt_response"
+      );
+
+      // Find the cases by id
+      const case2 = results.find((c) => c.name === mockInput2Text);
+
+      // Check metrics are correctly extracted from scores
+      expect(case2!.results.experiment1.metrics).toEqual({
+        accuracy: 0.7,
+        relevance: 0.85,
+      });
+
+      expect(case2!.results.experiment2.metrics).toEqual({
+        accuracy: 0.65,
+        relevance: 0.8,
+      });
+    });
+  });
+  it("should throw for unsupported experiment types", () => {
+    const multipleChoiceType = "multiple_choice";
+    expect(() =>
+      materializeExperimentResultsByCase(
+        mockResultsByExperiment,
+        multipleChoiceType
+      )
+    ).toThrow(`Unsupported experiment type: ${multipleChoiceType}`);
+    const naturalLanguageToCodeType = "natural_language_to_code";
+    expect(() =>
+      materializeExperimentResultsByCase(
+        mockResultsByExperiment,
+        naturalLanguageToCodeType
+      )
+    ).toThrow(`Unsupported experiment type: ${naturalLanguageToCodeType}`);
   });
 });

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.test.ts
@@ -1,4 +1,7 @@
-import { materializeExperimentResultsByCase } from "./materializeExperimentResultsByCase";
+import {
+  materializeExperimentResultsByCase,
+  providerFromModel,
+} from "./materializeExperimentResultsByCase";
 import { ResultsByExperiment } from "./reportBenchmarkResults";
 import { ExperimentResult } from "./getBraintrustExperimentResults";
 import {
@@ -241,5 +244,59 @@ describe("materializeExperimentResultsByCase", () => {
         naturalLanguageToCodeType
       )
     ).toThrow(`Unsupported experiment type: ${naturalLanguageToCodeType}`);
+  });
+});
+
+describe("providerFromModel", () => {
+  it("returns the correct provider for OpenAI models", () => {
+    expect(providerFromModel("gpt-4o")).toBe("OpenAI");
+    expect(providerFromModel("gpt-4o-mini")).toBe("OpenAI");
+    expect(providerFromModel("o3-mini")).toBe("OpenAI");
+    expect(providerFromModel("o3-mini-high")).toBe("OpenAI");
+    expect(providerFromModel("o3")).toBe("OpenAI");
+    expect(providerFromModel("o4-mini")).toBe("OpenAI");
+    expect(providerFromModel("gpt-4.1")).toBe("OpenAI");
+    expect(providerFromModel("gpt-4.1-mini")).toBe("OpenAI");
+    expect(providerFromModel("gpt-4.1-nano")).toBe("OpenAI");
+    expect(providerFromModel("gpt-35-turbo-16k")).toBe("OpenAI");
+  });
+  it("returns the correct provider for Anthropic models", () => {
+    expect(providerFromModel("claude-3-sonnet")).toBe("Anthropic");
+    expect(providerFromModel("claude-3-haiku")).toBe("Anthropic");
+    expect(providerFromModel("claude-35-sonnet")).toBe("Anthropic");
+    expect(providerFromModel("claude-35-sonnet-v2")).toBe("Anthropic");
+    expect(providerFromModel("claude-37-sonnet")).toBe("Anthropic");
+    expect(providerFromModel("claude-35-haiku")).toBe("Anthropic");
+  });
+  it("returns the correct provider for Meta models", () => {
+    expect(providerFromModel("llama-3-70b")).toBe("Meta");
+    expect(providerFromModel("llama-3.1-70b")).toBe("Meta");
+    expect(providerFromModel("llama-3.2-90b")).toBe("Meta");
+    expect(providerFromModel("llama-3.3-70b")).toBe("Meta");
+  });
+  it("returns the correct provider for Mistral models", () => {
+    expect(providerFromModel("mistral-large-2")).toBe("Mistral");
+    expect(providerFromModel("mistral-small-3-instruct")).toBe("Mistral");
+  });
+  it("returns the correct provider for Amazon models", () => {
+    expect(providerFromModel("nova-lite-v1:0")).toBe("Amazon");
+    expect(providerFromModel("nova-micro-v1:0")).toBe("Amazon");
+    expect(providerFromModel("nova-pro-v1:0")).toBe("Amazon");
+  });
+  it("returns the correct provider for Google models", () => {
+    expect(providerFromModel("gemini-1.5-flash-002")).toBe("Google");
+    expect(providerFromModel("gemini-2-flash")).toBe("Google");
+    expect(providerFromModel("gemini-2.5-flash")).toBe("Google");
+    expect(providerFromModel("gemini-2.0-flash-lite")).toBe("Google");
+    expect(providerFromModel("gemini-2.5-pro-preview-03-25")).toBe("Google");
+    expect(providerFromModel("gemini-1.0-pro-002")).toBe("Google");
+    expect(providerFromModel("gemini-1.5-pro-002")).toBe("Google");
+  });
+  it("returns the correct provider for DeepSeek models", () => {
+    expect(providerFromModel("deepseek-coder")).toBe("DeepSeek");
+    expect(providerFromModel("deepseek-r1")).toBe("DeepSeek");
+  });
+  it("returns the correct provider for Alibaba models", () => {
+    expect(providerFromModel("qwen-2.5-72b-instruct")).toBe("Alibaba");
   });
 });

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
@@ -62,6 +62,7 @@ export function materializeExperimentResultsByCase<
           // Store the model output and metrics in the results object
           baseCase.results[model] = {
             model,
+            provider: providerFromModel(model),
             date: new Date(),
             response: evalCase.output ? evalCase.output.response : "",
             metrics: {},
@@ -117,4 +118,32 @@ function parseModelFromExperimentName(experimentName: string): string {
 
   // Return the model name (either without hash or the original if no hash was found)
   return modelName;
+}
+
+export function providerFromModel(model: string) {
+  if (model.includes('claude')) {
+    return 'Anthropic';
+  }
+  if (model.includes('qwen')) {
+    return 'Qwen';
+  }
+  if (model.includes('deepseek')) {
+    return 'DeepSeek';
+  }
+  if (model.includes('llama')) {
+    return 'Meta';
+  }
+  if (model.includes('mistral')) {
+    return 'Mistral';
+  }
+  if (model.includes('gemini') || model.includes('gemma')) {
+    return 'Google';
+  }
+  if (model.includes('nova')) {
+    return 'Amazon';
+  }
+  if (model.includes('gpt') || model.match(/o\d/)) {
+    return 'OpenAI';
+  }
+  return 'Unknown';
 }

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
@@ -39,12 +39,16 @@ export function materializeExperimentResultsByCase<
           // If this case hasn't been seen before, create a new BaseCase
           if (!caseMap.has(caseId)) {
             const baseCase: BaseCase = {
-              id: new ObjectId(),
+              _id: new ObjectId(),
               type,
               tags: evalCase.tags ?? [],
               name: evalCase.input.messages[0].content,
               prompt: evalCase.input.messages,
               expected: evalCase.expected.reference ?? "",
+              metadata: {
+                ...evalCase.metadata,
+                caseId,
+              },
               // Populate results subsequently
               results: {},
             };
@@ -121,29 +125,29 @@ function parseModelFromExperimentName(experimentName: string): string {
 }
 
 export function providerFromModel(model: string) {
-  if (model.includes('claude')) {
-    return 'Anthropic';
+  if (model.includes("gpt") || model.match(/o\d/)) {
+    return "OpenAI";
   }
-  if (model.includes('qwen')) {
-    return 'Qwen';
+  if (model.includes("claude")) {
+    return "Anthropic";
   }
-  if (model.includes('deepseek')) {
-    return 'DeepSeek';
+  if (model.includes("gemini") || model.includes("gemma")) {
+    return "Google";
   }
-  if (model.includes('llama')) {
-    return 'Meta';
+  if (model.includes("llama")) {
+    return "Meta";
   }
-  if (model.includes('mistral')) {
-    return 'Mistral';
+  if (model.includes("nova")) {
+    return "Amazon";
   }
-  if (model.includes('gemini') || model.includes('gemma')) {
-    return 'Google';
+  if (model.includes("qwen")) {
+    return "Alibaba";
   }
-  if (model.includes('nova')) {
-    return 'Amazon';
+  if (model.includes("deepseek")) {
+    return "DeepSeek";
   }
-  if (model.includes('gpt') || model.match(/o\d/)) {
-    return 'OpenAI';
+  if (model.includes("mistral")) {
+    return "Mistral";
   }
-  return 'Unknown';
+  return "Unknown";
 }

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
@@ -12,18 +12,21 @@ import {
 Accepts the results of multiple experiments in a project. Groups them by the eval case so that results for different models are grouped together for the same case.
  */
 export function materializeExperimentResultsByCase<Case extends BaseCase>(
-  results: ResultsByExperiment,
-  type: ExperimentType
+  resultsByExperiment: ResultsByExperiment,
+  type: ExperimentType,
+  metadata?: Record<string, unknown>
 ): Case[] {
   // Create a map to group results by case ID
   const caseMap = new Map<string, Case>();
 
   // Process each experiment result
-  for (const [experimentName, experimentResults] of Object.entries(results)) {
+  for (const [experimentName, { results }] of Object.entries(
+    resultsByExperiment
+  )) {
     // Process each case in the experiment
     switch (type) {
       case "prompt_response":
-        for (const evalCase of experimentResults as ExperimentResult<
+        for (const evalCase of results as ExperimentResult<
           NlPromptResponseEvalCase,
           NlPromptResponseTaskOutput,
           string[]
@@ -86,6 +89,9 @@ export function materializeExperimentResultsByCase<Case extends BaseCase>(
 function parseModelFromExperimentName(experimentName: string): string {
   // Try to extract model from URL query parameter format
   const modelMatch = experimentName.match(/[?&]model=([^&]+)/);
+  if (!modelMatch) {
+    return experimentName;
+  }
   const modelName =
     modelMatch && modelMatch[1] ? modelMatch[1] : experimentName;
 

--- a/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
+++ b/packages/benchmarks/src/reporting/materializeExperimentResultsByCase.ts
@@ -1,0 +1,100 @@
+import { EvalCase } from "mongodb-rag-core/braintrust";
+import { BaseCase } from "./EvalCases";
+import { ExperimentResult } from "./getBraintrustExperimentResults";
+import { ObjectId } from "mongodb-rag-core/mongodb";
+import { ExperimentType, ResultsByExperiment } from "./reportBenchmarkResults";
+import {
+  NlPromptResponseEvalCase,
+  NlPromptResponseTaskOutput,
+} from "../nlPromptResponse/NlQuestionAnswerEval";
+
+/**
+Accepts the results of multiple experiments in a project. Groups them by the eval case so that results for different models are grouped together for the same case.
+ */
+export function materializeExperimentResultsByCase<Case extends BaseCase>(
+  results: ResultsByExperiment,
+  type: ExperimentType
+): Case[] {
+  // Create a map to group results by case ID
+  const caseMap = new Map<string, Case>();
+
+  // Process each experiment result
+  for (const [experimentName, experimentResults] of Object.entries(results)) {
+    // Process each case in the experiment
+    switch (type) {
+      case "prompt_response":
+        for (const evalCase of experimentResults as ExperimentResult<
+          NlPromptResponseEvalCase,
+          NlPromptResponseTaskOutput,
+          string[]
+        >[]) {
+          // ExperimentResult is an extension of EvalCase, so we can access id directly
+          const caseId = evalCase.id ?? JSON.stringify(evalCase.input);
+
+          // If this case hasn't been seen before, create a new BaseCase
+          if (!caseMap.has(caseId)) {
+            // Create an ObjectId - safely handle non-standard ID formats
+            const id = new ObjectId();
+
+            const baseCase: BaseCase = {
+              id,
+              // Use appropriate fallbacks for required fields
+              type,
+              tags: evalCase.tags ?? [],
+              name: evalCase.input.messages[0].content,
+              prompt: evalCase.input.messages,
+              expected: evalCase.expected.reference ?? "",
+              results: {},
+            };
+            caseMap.set(caseId, baseCase as Case);
+          }
+
+          // Add this model's output to the case
+          const baseCase = caseMap.get(caseId)! as Case;
+
+          const model = parseModelFromExperimentName(experimentName);
+
+          // Store the model output and metrics in the results object
+          baseCase.results[model] = {
+            model,
+            date: new Date(),
+            response: evalCase.output ? evalCase.output.response : "",
+            metrics: {},
+          };
+
+          // Store the scores for this model
+          if (evalCase.scores) {
+            const metrics: Record<string, number> = {};
+            for (const [scoreName, scoreValue] of Object.entries(
+              evalCase.scores
+            )) {
+              if (scoreValue !== null && typeof scoreValue === "number") {
+                metrics[scoreName] = scoreValue;
+              }
+            }
+
+            baseCase.results[model].metrics = metrics;
+          }
+        }
+    }
+  }
+
+  // Convert map to array for return
+  return Array.from(caseMap.values());
+}
+
+function parseModelFromExperimentName(experimentName: string): string {
+  // Try to extract model from URL query parameter format
+  const modelMatch = experimentName.match(/[?&]model=([^&]+)/);
+  const modelName =
+    modelMatch && modelMatch[1] ? modelMatch[1] : experimentName;
+
+  // Strip any git hash suffix if present (typically 8+ hex characters at the end)
+  const hashSuffixMatch = modelName.match(/(.+)-[a-f0-9]{7,}$/);
+  if (hashSuffixMatch && hashSuffixMatch[1]) {
+    return hashSuffixMatch[1]; // Return the model name without the hash
+  }
+
+  // Return the model name (either without hash or the original if no hash was found)
+  return modelName;
+}

--- a/packages/benchmarks/src/reporting/reportBenchmarkResults.ts
+++ b/packages/benchmarks/src/reporting/reportBenchmarkResults.ts
@@ -1,0 +1,53 @@
+import { EvalCase } from "mongodb-rag-core/braintrust";
+import { BaseCase } from "./EvalCases";
+import {
+  ExperimentResult,
+  getBraintrustExperimentResults,
+} from "./getBraintrustExperimentResults";
+import { listBraintrustExperiments } from "./listBraintrustExperiments";
+import { materializeExperimentResultsByCase } from "./materializeExperimentResultsByCase";
+
+export type ExperimentType =
+  | "prompt_response"
+  | "natural_language_to_code"
+  | "multiple_choice";
+
+export interface ReportBenchmarkResultsParams {
+  apiKey: string;
+  projectName: string;
+  experimentType: ExperimentType;
+}
+
+export type ResultsByExperiment = Record<
+  string,
+  ExperimentResult<EvalCase<unknown, unknown, unknown>, unknown, string[]>[]
+>;
+
+export async function reportBenchmarkResults<Case extends BaseCase>({
+  apiKey,
+  projectName,
+  experimentType,
+}: ReportBenchmarkResultsParams): Promise<Case[]> {
+  const experiments = await listBraintrustExperiments({
+    apiKey,
+    queryParams: {
+      project_name: projectName,
+    },
+  });
+  const allExperimentResults: Record<
+    string,
+    ExperimentResult<EvalCase<unknown, unknown, unknown>, unknown, string[]>[]
+  > = {};
+  for (const experiment of experiments) {
+    const results = await getBraintrustExperimentResults({
+      apiKey,
+      experimentName: experiment.name,
+      projectName,
+    });
+    allExperimentResults[experiment.name] = results;
+  }
+  return materializeExperimentResultsByCase<Case>(
+    allExperimentResults,
+    experimentType
+  );
+}

--- a/packages/benchmarks/src/reporting/reportBenchmarkResults.ts
+++ b/packages/benchmarks/src/reporting/reportBenchmarkResults.ts
@@ -11,10 +11,12 @@ import {
   GetExperimentMetadataResponse,
 } from "./getBraintrustExperimentSummary";
 
-export type ExperimentType =
-  | "prompt_response"
-  | "natural_language_to_code"
-  | "multiple_choice";
+export const experimentTypes = [
+  "prompt_response",
+  "natural_language_to_code",
+  "multiple_choice",
+] as const;
+export type ExperimentType = (typeof experimentTypes)[number];
 
 export interface ReportBenchmarkResultsParams {
   apiKey: string;


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1015

## Changes

- Parse Braintrust results to benchmark reporting service format
  - Implement for "prompt_response" style benchmarks

## Notes

- Generate results for the tech support benchmark. shared in slack. 
