### PR TITLE
(EAI-1001) enable search by type

### DIFF
--- a/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.test.ts
@@ -61,6 +61,7 @@ describe("makeDevCenterPage()", () => {
         tags: ["Realm", "GitHub Actions", "JavaScript"],
         pageDescription: devCenterDoc.description,
         contentType: devCenterDoc.type,
+        pageType: "devcenter",
       },
       url: "https://example.com/developer/products/realm/build-ci-cd-pipelines-realm-apps-github-actions",
     });

--- a/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.test.ts
@@ -57,11 +57,11 @@ describe("makeDevCenterPage()", () => {
       }),
       format: "md",
       sourceName: "devcenter",
+      sourceType: "devcenter",
       metadata: {
         tags: ["Realm", "GitHub Actions", "JavaScript"],
         pageDescription: devCenterDoc.description,
         contentType: devCenterDoc.type,
-        pageType: "devcenter",
       },
       url: "https://example.com/developer/products/realm/build-ci-cd-pipelines-realm-apps-github-actions",
     });

--- a/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
@@ -83,6 +83,7 @@ export function makeDevCenterPage(
       tags: extractTags(document.tags),
       pageDescription: document.description,
       contentType: document.type,
+      pageType: "devcenter",
     },
     url: /^https?:\/\//.test(document.calculated_slug)
       ? document.calculated_slug

--- a/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
@@ -79,11 +79,11 @@ export function makeDevCenterPage(
     }),
     format: "md",
     sourceName: name,
+    sourceType: "devcenter",
     metadata: {
       tags: extractTags(document.tags),
       pageDescription: document.description,
       contentType: document.type,
-      pageType: "devcenter",
     },
     url: /^https?:\/\//.test(document.calculated_slug)
       ? document.calculated_slug

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -173,12 +173,7 @@ export const makeSnootyDataSource = ({
   snootyDataApiBaseUrl,
   links,
 }: MakeSnootyDataSourceArgs): DataSource => {
-  const {
-    branches,
-    name: snootyProjectName,
-    tags,
-    productName,
-  } = project;
+  const { branches, name: snootyProjectName, tags, productName } = project;
   return {
     name: sourceName,
     async fetchPages() {
@@ -192,11 +187,12 @@ export const makeSnootyDataSource = ({
         }
         const getBranchDocumentsUrl = new URL(
           `projects/${snootyProjectName}/${branch.gitBranchName}/documents`,
-          snootyDataApiBaseUrl)
+          snootyDataApiBaseUrl
+        );
         const version = {
           label: branch.label,
           isCurrent: branch.isStableBranch,
-        }
+        };
         const branchUrl = branch.fullUrl.replace("http://", "https://");
         const { body } = await fetch(getBranchDocumentsUrl);
         if (body === null) {
@@ -410,6 +406,7 @@ export const handlePage = async (
       tags,
       productName,
       version,
+      pageType: "tech-docs",
     },
   };
 };

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -173,7 +173,12 @@ export const makeSnootyDataSource = ({
   snootyDataApiBaseUrl,
   links,
 }: MakeSnootyDataSourceArgs): DataSource => {
-  const { branches, name: snootyProjectName, tags, productName } = project;
+  const {
+    branches,
+    name: snootyProjectName,
+    tags,
+    productName,
+  } = project;
   return {
     name: sourceName,
     async fetchPages() {
@@ -187,12 +192,11 @@ export const makeSnootyDataSource = ({
         }
         const getBranchDocumentsUrl = new URL(
           `projects/${snootyProjectName}/${branch.gitBranchName}/documents`,
-          snootyDataApiBaseUrl
-        );
+          snootyDataApiBaseUrl)
         const version = {
           label: branch.label,
           isCurrent: branch.isStableBranch,
-        };
+        }
         const branchUrl = branch.fullUrl.replace("http://", "https://");
         const { body } = await fetch(getBranchDocumentsUrl);
         if (body === null) {
@@ -401,12 +405,12 @@ export const handlePage = async (
     title,
     body: truncateEmbeddings(body),
     format,
+    sourceType: "tech-docs",
     metadata: {
       page: pageMetadata,
       tags,
       productName,
       version,
-      pageType: "tech-docs",
     },
   };
 };

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -38,6 +38,11 @@ export interface EmbeddedContent {
   updated: Date;
 
   /**
+    The source type indicates where the page was loaded from.
+   */
+  sourceType?: Page["sourceType"];
+
+  /**
     Arbitrary metadata associated with the content. If the content text has
     metadata in Front Matter format, this metadata should match that metadata.
    */
@@ -49,7 +54,6 @@ export interface EmbeddedContent {
       isCurrent: boolean;
       label: string;
     };
-    pageType?: string;
   };
 
   /**
@@ -89,7 +93,7 @@ export type QueryFilters = {
     current?: boolean;
     label?: string;
   };
-  pageType?: string;
+  sourceType?: string;
 };
 
 /**

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -49,6 +49,7 @@ export interface EmbeddedContent {
       isCurrent: boolean;
       label: string;
     };
+    pageType?: string;
   };
 
   /**
@@ -88,6 +89,7 @@ export type QueryFilters = {
     current?: boolean;
     label?: string;
   };
+  pageType?: string;
 };
 
 /**

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -93,7 +93,7 @@ export type QueryFilters = {
     current?: boolean;
     label?: string;
   };
-  sourceType?: string;
+  sourceType?: Page["sourceType"];
 };
 
 /**

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -335,6 +335,25 @@ describe("nearest neighbor search", () => {
     ).toHaveLength(5);
   });
 
+  it("Should filter content to pageType requested", async () => {
+    assert(store);
+    const query = "db.collection.insertOne()";
+    const filter = {
+      pageType: "tech-docs",
+    };
+    const { embedding } = await embedder.embed({
+      text: query,
+    });
+
+    const matches = await store.findNearestNeighbors(embedding, {
+      ...findNearestNeighborOptions,
+      filter,
+    });
+    expect(
+      matches.filter((match) => match.metadata?.pageType === "tech-docs")
+    ).toHaveLength(5);
+  });
+
   it("does not find nearest neighbors for irrelevant embedding", async () => {
     assert(store);
 
@@ -400,6 +419,7 @@ describe("initialized DB", () => {
     expect(indexes?.some((el) => el.name === "metadata.version.label_1")).toBe(
       true
     );
+    expect(indexes?.some((el) => el.name === "metadata.pageType_1")).toBe(true);
 
     const vectorIndexes = await coll?.listSearchIndexes().toArray();
     if (!vectorIndexes) return;
@@ -420,5 +440,6 @@ describe("initialized DB", () => {
     expect(filterPaths).toContain("sourceName");
     expect(filterPaths).toContain("metadata.version.label");
     expect(filterPaths).toContain("metadata.version.isCurrent");
+    expect(filterPaths).toContain("metadata.pageType");
   });
 });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -335,11 +335,11 @@ describe("nearest neighbor search", () => {
     ).toHaveLength(5);
   });
 
-  it("Should filter content to pageType requested", async () => {
+  it("Should filter content to sourceType requested", async () => {
     assert(store);
     const query = "db.collection.insertOne()";
     const filter = {
-      pageType: "tech-docs",
+      sourceType: "tech-docs",
     };
     const { embedding } = await embedder.embed({
       text: query,
@@ -350,7 +350,7 @@ describe("nearest neighbor search", () => {
       filter,
     });
     expect(
-      matches.filter((match) => match.metadata?.pageType === "tech-docs")
+      matches.filter((match) => match.sourceType === "tech-docs")
     ).toHaveLength(5);
   });
 
@@ -419,7 +419,7 @@ describe("initialized DB", () => {
     expect(indexes?.some((el) => el.name === "metadata.version.label_1")).toBe(
       true
     );
-    expect(indexes?.some((el) => el.name === "metadata.pageType_1")).toBe(true);
+    expect(indexes?.some((el) => el.name === "sourceType_1")).toBe(true);
 
     const vectorIndexes = await coll?.listSearchIndexes().toArray();
     if (!vectorIndexes) return;
@@ -440,6 +440,6 @@ describe("initialized DB", () => {
     expect(filterPaths).toContain("sourceName");
     expect(filterPaths).toContain("metadata.version.label");
     expect(filterPaths).toContain("metadata.version.isCurrent");
-    expect(filterPaths).toContain("metadata.pageType");
+    expect(filterPaths).toContain("sourceType");
   });
 });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
@@ -83,7 +83,7 @@ export function makeMongoDbEmbeddedContentStore({
       },
       {
         type: "filter",
-        path: "metadata.pageType",
+        path: "sourceType",
       },
     ],
     name = "vector_index",
@@ -226,7 +226,7 @@ export function makeMongoDbEmbeddedContentStore({
         "metadata.version.label": 1,
       });
       await embeddedContentCollection.createIndex({
-        "metadata.pageType": 1,
+        "sourceType": 1,
       });
 
       try {
@@ -267,7 +267,7 @@ type MongoDbAtlasVectorSearchFilter = {
   $or?: {
     "metadata.version.isCurrent": boolean | null;
   }[];
-  "metadata.pageType"?: string;
+  "sourceType"?: string;
 };
 
 const handleFilters = (
@@ -277,8 +277,8 @@ const handleFilters = (
   if (filter.sourceName) {
     vectorSearchFilter["sourceName"] = filter.sourceName;
   }
-  if (filter.pageType) {
-    vectorSearchFilter["metadata.pageType"] = filter.pageType;
+  if (filter.sourceType) {
+    vectorSearchFilter["sourceType"] = filter.sourceType;
   }
   // Handle version filter. Note: unversioned embeddings (isCurrent: null) are treated as current
   const { current, label } = filter.version ?? {};

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
@@ -81,6 +81,10 @@ export function makeMongoDbEmbeddedContentStore({
         type: "filter",
         path: "metadata.version.isCurrent",
       },
+      {
+        type: "filter",
+        path: "metadata.pageType",
+      },
     ],
     name = "vector_index",
   },
@@ -221,6 +225,9 @@ export function makeMongoDbEmbeddedContentStore({
       await embeddedContentCollection.createIndex({
         "metadata.version.label": 1,
       });
+      await embeddedContentCollection.createIndex({
+        "metadata.pageType": 1,
+      });
 
       try {
         const searchIndex = {
@@ -260,6 +267,7 @@ type MongoDbAtlasVectorSearchFilter = {
   $or?: {
     "metadata.version.isCurrent": boolean | null;
   }[];
+  "metadata.pageType"?: string;
 };
 
 const handleFilters = (
@@ -268,6 +276,9 @@ const handleFilters = (
   const vectorSearchFilter: MongoDbAtlasVectorSearchFilter = {};
   if (filter.sourceName) {
     vectorSearchFilter["sourceName"] = filter.sourceName;
+  }
+  if (filter.pageType) {
+    vectorSearchFilter["metadata.pageType"] = filter.pageType;
   }
   // Handle version filter. Note: unversioned embeddings (isCurrent: null) are treated as current
   const { current, label } = filter.version ?? {};

--- a/packages/mongodb-rag-core/src/contentStore/Page.ts
+++ b/packages/mongodb-rag-core/src/contentStore/Page.ts
@@ -28,11 +28,10 @@ export type Page = {
   sourceName: string;
 
   /**
-    The source type. Other types may be added in the future. 
-    "tech-docs" indicates documents from the mongodb.com/docs site. SnootyDataSource has this type
-    "devcenter" indicates documents from the mongodb.com/developer site. DevCenterDataSource has this type
+    The source type indicates where the page was loaded from. 
+    @example "tech-docs" indicates documents from the mongodb.com/docs site. SnootyDataSource has this type
    */
-  sourceType?: "tech-docs" | "devcenter";
+  sourceType?: string;
 
   /**
     Arbitrary metadata for page.

--- a/packages/mongodb-rag-core/src/contentStore/Page.ts
+++ b/packages/mongodb-rag-core/src/contentStore/Page.ts
@@ -49,6 +49,12 @@ export type PageMetadata = {
    */
   version?: VersionInfo;
   /**
+    The page type. Other types may be added in the future. 
+    "tech-docs" indicates documents from the mongodb.com/docs site. SnootyDataSource has this type
+    "devcenter" indicates documents from the mongodb.com/developer site. DevCenterDataSource has this type
+   */
+  pageType?: "tech-docs" | "devcenter";
+  /**
     Page-level metadata. Should not be chunked.
    */
   page?: Record<string, unknown>;

--- a/packages/mongodb-rag-core/src/contentStore/Page.ts
+++ b/packages/mongodb-rag-core/src/contentStore/Page.ts
@@ -28,6 +28,13 @@ export type Page = {
   sourceName: string;
 
   /**
+    The source type. Other types may be added in the future. 
+    "tech-docs" indicates documents from the mongodb.com/docs site. SnootyDataSource has this type
+    "devcenter" indicates documents from the mongodb.com/developer site. DevCenterDataSource has this type
+   */
+  sourceType?: "tech-docs" | "devcenter";
+
+  /**
     Arbitrary metadata for page.
    */
   metadata?: PageMetadata;
@@ -48,12 +55,6 @@ export type PageMetadata = {
     If the page is not versioned, this field should be undefined.
    */
   version?: VersionInfo;
-  /**
-    The page type. Other types may be added in the future. 
-    "tech-docs" indicates documents from the mongodb.com/docs site. SnootyDataSource has this type
-    "devcenter" indicates documents from the mongodb.com/developer site. DevCenterDataSource has this type
-   */
-  pageType?: "tech-docs" | "devcenter";
   /**
     Page-level metadata. Should not be chunked.
    */

--- a/packages/mongodb-rag-core/src/contentStore/updateEmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/updateEmbeddedContent.ts
@@ -161,6 +161,7 @@ export const updateEmbeddedContentForPage = async ({
         },
         updated: new Date(),
         chunkAlgoHash,
+        sourceType: page.sourceType,
       };
     });
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1001

## Changes

- "metadata.pageType" field added
- SnootyDataSource creates pages with `"metadata.pageType": "tech-docs"`
- DevCenterDataSource creates pages with `"metadata.pageType": "devcenter"`
- index created for new field, vector search index updated to include new field


## Notes

- This will allow us to change the filter [here](https://github.com/mongodb/chatbot/blob/EAI-428-feature-versioned-docs/packages/datasets/src/mongoDbDatasetConstants.ts#L19-L22) to find public datasets (snooty or devcenter) by filtering on the "metadata.pageType" field
