### PR TITLE
support azure foundry models through braintrust proxy

### DIFF
--- a/packages/mongodb-rag-core/src/models/models.test.ts
+++ b/packages/mongodb-rag-core/src/models/models.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(60000);
 // NOTE: due to this issue https://github.com/nodejs/node/issues/39964,
 // you must run the tests with a Node version >= 20.0.0
 
-describe.skip("Braintrust models", () => {
+describe("Braintrust models", () => {
   test.each(models.filter((m) => m.provider === "braintrust"))(
     "'$label' model should generate data",
     async (model) => {

--- a/packages/mongodb-rag-core/src/models/models.ts
+++ b/packages/mongodb-rag-core/src/models/models.ts
@@ -6,7 +6,9 @@ export type ModelDeveloper =
   | "Mistral"
   | "Amazon"
   | "DeepSeek"
-  | "Alibaba Cloud";
+  | "Alibaba Cloud"
+  | "xAI"
+  | "Microsoft";
 
 export type ModelProvider = "braintrust" | "gcp_vertex_ai";
 
@@ -214,6 +216,22 @@ const allModels = [
     authorized: true,
   },
   {
+    label: "mistral-medium-2505",
+    deployment: "mistral-medium-2505",
+    developer: "Mistral",
+    maxConcurrency: 15,
+    provider: "braintrust",
+    authorized: true,
+  },
+  {
+    label: "mistral-small-2503",
+    deployment: "mistral-small-2503",
+    developer: "Mistral",
+    maxConcurrency: 15,
+    provider: "braintrust",
+    authorized: true,
+  },
+  {
     label: "llama-3.1-70b",
     deployment: "us.meta.llama3-1-70b-instruct-v1:0",
     developer: "Meta",
@@ -319,33 +337,43 @@ const allModels = [
   },
   {
     label: "deepseek-r1",
-    deployment: "us.deepseek.r1-v1:0",
+    deployment: "DeepSeek-R1",
     developer: "DeepSeek",
     provider: "braintrust",
     authorized: true,
-    maxConcurrency: 5,
+    maxConcurrency: 10,
   },
   {
-    label: "mistral-small-3-instruct",
-    deployment: "accounts/fireworks/models/mistral-small-24b-instruct-2501",
-    developer: "Mistral",
+    label: "deepseek-v3-0324",
+    deployment: "DeepSeek-V3-0324",
+    developer: "DeepSeek",
     provider: "braintrust",
-    authorized: false,
-    maxConcurrency: 5,
-    metadata: {
-      host: "Fireworks",
-    },
+    authorized: true,
+    maxConcurrency: 10,
   },
   {
-    label: "qwen-2.5-72b-instruct",
-    deployment: "accounts/fireworks/models/qwen2p5-72b-instruct",
-    developer: "Alibaba Cloud",
+    label: "grok-3",
+    deployment: "grok-3",
+    developer: "xAI",
     provider: "braintrust",
-    authorized: false,
-    maxConcurrency: 5,
-    metadata: {
-      host: "Fireworks",
-    },
+    authorized: true,
+    maxConcurrency: 10,
+  },
+  {
+    label: "phi-4",
+    deployment: "Phi-4",
+    developer: "Microsoft",
+    provider: "braintrust",
+    authorized: true,
+    maxConcurrency: 10,
+  },
+  {
+    label: "model-router",
+    deployment: "model-router",
+    developer: "Microsoft",
+    provider: "braintrust",
+    authorized: true,
+    maxConcurrency: 10,
   },
 ] as const satisfies ModelConfig[];
 


### PR DESCRIPTION
Jira: n/a
## Changes

- Add models supported by Azure AI Foundry resource
  - Includes grok-3, some Mistral, some Deepseek, some MSFT
- Remove the currently unsupported models in our list from Fireworks

## Notes

- Blocked til Braintrust resolves https://github.com/braintrustdata/braintrust-proxy/issues/230
