### PR TITLE
Add new relevant bedrock models

### DIFF
--- a/packages/mongodb-rag-core/src/models/models.test.ts
+++ b/packages/mongodb-rag-core/src/models/models.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(60000);
 // NOTE: due to this issue https://github.com/nodejs/node/issues/39964,
 // you must run the tests with a Node version >= 20.0.0
 
-describe.skip("Braintrust models", () => {
+describe("Braintrust models", () => {
   test.each(models.filter((m) => m.provider === "braintrust"))(
     "'$label' model should generate data",
     async (model) => {

--- a/packages/mongodb-rag-core/src/models/models.ts
+++ b/packages/mongodb-rag-core/src/models/models.ts
@@ -214,6 +214,14 @@ const allModels = [
     authorized: true,
   },
   {
+    label: "pixtral-large-25-02",
+    deployment: "us.mistral.pixtral-large-2502-v1:0",
+    developer: "Mistral",
+    maxConcurrency: 3,
+    provider: "braintrust",
+    authorized: true,
+  },
+  {
     label: "llama-3.1-70b",
     deployment: "us.meta.llama3-1-70b-instruct-v1:0",
     developer: "Meta",
@@ -232,6 +240,22 @@ const allModels = [
   {
     label: "llama-3.3-70b",
     deployment: "us.meta.llama3-3-70b-instruct-v1:0",
+    developer: "Meta",
+    maxConcurrency: 5,
+    provider: "braintrust",
+    authorized: true,
+  },
+  {
+    label: "llama-4-scout-17b",
+    deployment: "us.meta.llama4-scout-17b-instruct-v1:0",
+    developer: "Meta",
+    maxConcurrency: 5,
+    provider: "braintrust",
+    authorized: true,
+  },
+  {
+    label: "llama-4-maverick-17b",
+    deployment: "us.meta.llama4-maverick-17b-instruct-v1:0",
     developer: "Meta",
     maxConcurrency: 5,
     provider: "braintrust",
@@ -260,6 +284,14 @@ const allModels = [
     provider: "braintrust",
     authorized: true,
     maxConcurrency: 30,
+  },
+  {
+    label: "nova-premier-v1:0",
+    deployment: "us.amazon.nova-premier-v1:0",
+    developer: "Amazon",
+    provider: "braintrust",
+    maxConcurrency: 10,
+    authorized: true,
   },
   {
     label: "gemini-1.5-flash-002",


### PR DESCRIPTION
Jira: n/a

## Changes

- Add new AWS Bedrock models relevant to our work. 
-

## Notes

- Depends on https://github.com/braintrustdata/braintrust-proxy/issues/232
