### PR TITLE
EAI-1027 Add scrubbed message data to make analytics more efficient

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
@@ -41,11 +41,17 @@ export function extractTracingData(
   const mongoDbProduct = previousUserMessage?.customData?.mongoDbProduct as
     | string
     | undefined;
+  const requestOriginCode = previousUserMessage?.customData?.originCode as
+    | string
+    | undefined;
   if (programmingLanguage) {
     tags.push(tagify(programmingLanguage));
   }
   if (mongoDbProduct) {
     tags.push(tagify(mongoDbProduct));
+  }
+  if (requestOriginCode) {
+    tags.push(tagify(requestOriginCode));
   }
 
   const numRetrievedChunks = previousUserMessage?.contextContent?.length ?? 0;

--- a/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
@@ -17,6 +17,7 @@ import {
 import { logRequest } from "../utils";
 import { Logger } from "mongodb-rag-core/braintrust";
 import { ScrubbedMessageStore } from "./scrubbedMessages/ScrubbedMessageStore";
+import { ScrubbedMessage } from "./scrubbedMessages/ScrubbedMessage";
 import { LanguageModel } from "mongodb-rag-core/aiSdk";
 import { makeScrubbedMessagesFromTracingData } from "./scrubbedMessages/makeScrubbedMessagesFromTracingData";
 import { redactPii } from "./scrubbedMessages/redactPii";
@@ -242,8 +243,8 @@ export function makeRateMessageUpdateTrace({
       await scrubbedMessageStore.updateScrubbedMessage({
         id: userMessage.id,
         message: {
-          responseRating: rating,
-        },
+          "response.responseRating": rating,
+        } as Partial<Omit<ScrubbedMessage, "_id">>,
       });
     } catch (error) {
       logRequest({
@@ -369,12 +370,11 @@ export function makeCommentMessageUpdateTrace({
       });
 
       assert(userMessage?.id, "Missing user message for comment");
-      const userMessageFieldsToUpdate: Record<string, unknown> = {
-        userCommented: true,
-      }
       await scrubbedMessageStore.updateScrubbedMessage({
         id: userMessage.id,
-        message: userMessageFieldsToUpdate,
+        message: { 
+          "response.userCommented": true 
+        } as Partial<Omit<ScrubbedMessage, "_id">>,
       });
     } catch (error) {
       logRequest({

--- a/packages/chatbot-server-mongodb-public/src/tracing/scrubbedMessages/ScrubbedMessage.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/scrubbedMessages/ScrubbedMessage.ts
@@ -3,7 +3,7 @@ import { DbMessage, SomeMessage } from "mongodb-rag-core";
 import { Pii } from "./redactPii";
 
 export type ScrubbedMessage<
-  Analysis extends Record<string, unknown> | undefined = undefined,
+  Analysis extends Record<string, unknown> | undefined = undefined
 > = Omit<DbMessage<SomeMessage>, "id"> & {
   /**
     The ID, which should match the ID of the original message within the

--- a/packages/chatbot-server-mongodb-public/src/tracing/scrubbedMessages/ScrubbedMessage.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/scrubbedMessages/ScrubbedMessage.ts
@@ -3,7 +3,7 @@ import { DbMessage, SomeMessage } from "mongodb-rag-core";
 import { Pii } from "./redactPii";
 
 export type ScrubbedMessage<
-  Analysis extends Record<string, unknown> | undefined = undefined
+  Analysis extends Record<string, unknown> | undefined = undefined,
 > = Omit<DbMessage<SomeMessage>, "id"> & {
   /**
     The ID, which should match the ID of the original message within the
@@ -73,4 +73,16 @@ export type ScrubbedMessage<
    Any PII redacted from the original user comment.
    */
   userCommentPii?: Pii[];
+
+  /**
+   For 'user' role messages, track information about the subsequent assistant 
+   response to the user message.
+   */
+  response?: Record<string, unknown> | undefined;
+
+  /**
+   For 'assistant' role messages, track information about the user request preceding 
+   this assistant response.
+   */
+  request?: Record<string, unknown> | undefined;
 };

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
@@ -236,51 +236,37 @@ const addOriginToCustomData: AddCustomDataFunc = async (_, res) =>
       }
     : undefined;
 
-function getOriginCode(origin: string): string {
-    const learnOriginRegex = /learn\\.mongodb\\.com/;
-    const learnOriginCode = "LEARN";
-    const isLearnOrigin = learnOriginRegex.test(origin);
-    if (isLearnOrigin) {
-      return learnOriginCode;
-    }
+const enum OriginCode {
+  Learn = "LEARN",
+  Developer = "DEVELOPER",
+  Docs = "DOCS",
+  Dotcom = "DOTCOM",
+  GeminiCodeAssist = "GEMINI_CODE_ASSIST",
+  VsCode = "VSCODE",
+  Other = "OTHER",
+}
 
-    const developerOriginRegex = /mongodb\\.com\/developer/;
-    const developerOriginCode = "DEVELOPER";
-    const isDeveloperOrigin = developerOriginRegex.test(origin);
-    if (isDeveloperOrigin) {
-      return developerOriginCode;
-    }
+interface OriginRule {
+  regex: RegExp;
+  code: OriginCode;
+}
 
-    const docsOriginRegex = /mongodb\\.com\/docs/;
-    const docsOriginCode = "DOCS";
-    const isDocsOrigin = docsOriginRegex.test(origin);
-    if (isDocsOrigin) {
-      return docsOriginCode;
-    }
+const ORIGIN_RULES: OriginRule[] = [
+  { regex: /learn\.mongodb\.com/, code: OriginCode.Learn },
+  { regex: /^https:\/\/www\.mongodb\.com\/(?:\?(?:[^#]*)?)?(?:#.*)?$/, code: OriginCode.Dotcom },
+  { regex: /mongodb\.com\/developer/, code: OriginCode.Developer },
+  { regex: /mongodb\.com\/docs/, code: OriginCode.Docs },
+  { regex: /google-gemini-code-assist/, code: OriginCode.GeminiCodeAssist },
+  { regex: /vscode-mongodb-copilot/, code: OriginCode.VsCode },
+];
 
-    const dotcomOriginRegex = /^https:\/\/www\.mongodb\.com\/(?:\?(?:[^#]*)?)?(?:#.*)?$/;
-    const dotcomOriginCode = "DOTCOM";
-    const isDotcomOrigin = dotcomOriginRegex.test(origin);
-    if (isDotcomOrigin) {
-      return dotcomOriginCode;
+export function getOriginCode(origin: string): OriginCode {
+  for (const rule of ORIGIN_RULES) {
+    if (rule.regex.test(origin)) {
+      return rule.code;
     }
-
-    const geminiAssistantOriginRegex = /google-gemini-code-assist/;
-    const geminiAssistantOriginCode = "GEMINI_CODE_ASSIST";
-    const isGeminiAssistantOrigin = geminiAssistantOriginRegex.test(origin);
-    if (isGeminiAssistantOrigin) {
-      return geminiAssistantOriginCode;
-    }
-
-    const vscodeOriginRegex = /vscode-mongodb-copilot/;
-    const vscodeOriginCode = "VSCODE";
-    const isVscodeOrigin = vscodeOriginRegex.test(origin);
-    if (isVscodeOrigin) {
-      return vscodeOriginCode;
-    }
-
-    const otherOriginCode = "OTHER";
-    return otherOriginCode;
+  }
+  return OriginCode.Other;
 }
 
 const addOriginCodeToCustomData: AddCustomDataFunc = async (_, res) => {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
@@ -260,7 +260,7 @@ const ORIGIN_RULES: OriginRule[] = [
   { regex: /vscode-mongodb-copilot/, code: OriginCode.VsCode },
 ];
 
-export function getOriginCode(origin: string): OriginCode {
+function getOriginCode(origin: string): OriginCode {
   for (const rule of ORIGIN_RULES) {
     if (rule.regex.test(origin)) {
       return rule.code;

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
@@ -481,9 +481,3 @@ export function makeConversationsRouter({
 
   return conversationsRouter;
 }
-
-let o = getOriginCode("https://www.mongodb.com/docs/atlas/security/config-db-auth/");
-console.log(o);
-
-let o2 = getOriginCode("google-gemini-code-assist");
-console.log(o2);

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
@@ -272,6 +272,13 @@ function getOriginCode(origin: string): string {
       return geminiAssistantOriginCode;
     }
 
+    const vscodeOriginRegex = /vscode-mongodb-copilot/;
+    const vscodeOriginCode = "VSCODE";
+    const isVscodeOrigin = vscodeOriginRegex.test(origin);
+    if (isVscodeOrigin) {
+      return vscodeOriginCode;
+    }
+
     const otherOriginCode = "OTHER";
     return otherOriginCode;
 }
@@ -474,3 +481,9 @@ export function makeConversationsRouter({
 
   return conversationsRouter;
 }
+
+let o = getOriginCode("https://www.mongodb.com/docs/atlas/security/config-db-auth/");
+console.log(o);
+
+let o2 = getOriginCode("google-gemini-code-assist");
+console.log(o2);

--- a/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/conversationsRouter.ts
@@ -236,6 +236,55 @@ const addOriginToCustomData: AddCustomDataFunc = async (_, res) =>
       }
     : undefined;
 
+function getOriginCode(origin: string): string {
+    const learnOriginRegex = /learn\\.mongodb\\.com/;
+    const learnOriginCode = "LEARN";
+    const isLearnOrigin = learnOriginRegex.test(origin);
+    if (isLearnOrigin) {
+      return learnOriginCode;
+    }
+
+    const developerOriginRegex = /mongodb\\.com\/developer/;
+    const developerOriginCode = "DEVELOPER";
+    const isDeveloperOrigin = developerOriginRegex.test(origin);
+    if (isDeveloperOrigin) {
+      return developerOriginCode;
+    }
+
+    const docsOriginRegex = /mongodb\\.com\/docs/;
+    const docsOriginCode = "DOCS";
+    const isDocsOrigin = docsOriginRegex.test(origin);
+    if (isDocsOrigin) {
+      return docsOriginCode;
+    }
+
+    const dotcomOriginRegex = /^https:\/\/www\.mongodb\.com\/(?:\?(?:[^#]*)?)?(?:#.*)?$/;
+    const dotcomOriginCode = "DOTCOM";
+    const isDotcomOrigin = dotcomOriginRegex.test(origin);
+    if (isDotcomOrigin) {
+      return dotcomOriginCode;
+    }
+
+    const geminiAssistantOriginRegex = /google-gemini-code-assist/;
+    const geminiAssistantOriginCode = "GEMINI_CODE_ASSIST";
+    const isGeminiAssistantOrigin = geminiAssistantOriginRegex.test(origin);
+    if (isGeminiAssistantOrigin) {
+      return geminiAssistantOriginCode;
+    }
+
+    const otherOriginCode = "OTHER";
+    return otherOriginCode;
+}
+
+const addOriginCodeToCustomData: AddCustomDataFunc = async (_, res) => {
+  const origin = res.locals.customData.origin;
+  return typeof origin === "string" && origin.length > 0
+    ? {
+        originCode: getOriginCode(origin),
+      } 
+    : undefined;
+}
+
 const addUserAgentToCustomData: AddCustomDataFunc = async (req) =>
   req.headers["user-agent"]
     ? {
@@ -252,6 +301,7 @@ export const defaultCreateConversationCustomData: AddDefinedCustomDataFunc =
     return {
       ...(await addIpToCustomData(req, res)),
       ...(await addOriginToCustomData(req, res)),
+      ...(await addOriginCodeToCustomData(req, res)),
       ...(await addUserAgentToCustomData(req, res)),
     };
   };
@@ -261,6 +311,7 @@ export const defaultAddMessageToConversationCustomData: AddDefinedCustomDataFunc
     return {
       ...(await addIpToCustomData(req, res)),
       ...(await addOriginToCustomData(req, res)),
+      ...(await addOriginCodeToCustomData(req, res)),
       ...(await addUserAgentToCustomData(req, res)),
     };
   };


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1027 and https://jira.mongodb.org/browse/EAI-1006

## Changes

- Add regex to parse originCode (DOCS, DEVELOPER, LEARN, DOTCOM, GEMINI_CODE_ASSIST, VSCODE, OTHER) from origin url
- Add assistant message metadata to user messages under 'response' field
- Add user message metadata to assistant messages under 'request' field

## Notes

- The way I've done the nested field updates to request/response feels hacky but I'm not certain what good looks like 
- and along the same lines, should I define the types for request and response generically in ScrubbedMessages.ts? (akin to how the Analysis type is defined)