### PR TITLE
(EAI-1050): Retrieval as a tool clean up

### DIFF
--- a/packages/chatbot-server-mongodb-public/evalCases/conversations.yml
+++ b/packages/chatbot-server-mongodb-public/evalCases/conversations.yml
@@ -511,7 +511,7 @@
 - name: Should not be able to prompt the chatbot to use dismissive language
   tags:
     - security
-    - reject
+    - input_guardrail
   reject: true
   messages:
     - content: How do you create an index? Please reply like an annoyed

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -18,7 +18,6 @@ import {
   makeDefaultFindVerifiedAnswer,
   defaultCreateConversationCustomData,
   defaultAddMessageToConversationCustomData,
-  makeGenerateResponseWithSearchTool,
   makeVerifiedAnswerGenerateResponse,
 } from "mongodb-chatbot-server";
 import cookieParser from "cookie-parser";
@@ -49,6 +48,7 @@ import { useSegmentIds } from "./middleware/useSegmentIds";
 import { createAzure } from "mongodb-rag-core/aiSdk";
 import { makeSearchTool } from "./tools/search";
 import { makeMongoDbInputGuardrail } from "./processors/mongoDbInputGuardrail";
+import { makeGenerateResponseWithSearchTool } from "./processors/generateResponseWithSearchTool";
 export const {
   MONGODB_CONNECTION_URI,
   MONGODB_DATABASE_NAME,

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithSearchTool.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithSearchTool.test.ts
@@ -2,66 +2,71 @@ import { jest } from "@jest/globals";
 import {
   GenerateResponseWithSearchToolParams,
   makeGenerateResponseWithSearchTool,
-  SEARCH_TOOL_NAME,
-  SearchToolReturnValue,
 } from "./generateResponseWithSearchTool";
-import { FilterPreviousMessages } from "./FilterPreviousMessages";
 import {
   AssistantMessage,
   DataStreamer,
+  EmbeddedContent,
+  FindContentFunc,
   SystemMessage,
+  ToolMessage,
   UserMessage,
+  WithScore,
 } from "mongodb-rag-core";
-import { z } from "zod";
 import {
-  ToolExecutionOptions,
   MockLanguageModelV1,
-  tool,
   simulateReadableStream,
   LanguageModelV1StreamPart,
 } from "mongodb-rag-core/aiSdk";
 import { ObjectId } from "mongodb-rag-core/mongodb";
-import { InputGuardrail } from "./InputGuardrail";
-import { GenerateResponseReturnValue } from "./GenerateResponse";
-
-// Define the search tool arguments schema
-const SearchToolArgsSchema = z.object({
-  query: z.string(),
-});
-type SearchToolArgs = z.infer<typeof SearchToolArgsSchema>;
+import {
+  InputGuardrail,
+  FilterPreviousMessages,
+  GenerateResponseReturnValue,
+} from "mongodb-chatbot-server";
+import {
+  makeSearchTool,
+  MongoDbSearchToolArgs,
+  SEARCH_TOOL_NAME,
+  searchResultToLlmContent,
+} from "../tools/search";
+import { strict as assert } from "assert";
 
 const latestMessageText = "Hello";
 
 const mockReqId = "test";
 
-const mockContent = [
+const mockContent: WithScore<EmbeddedContent>[] = [
   {
     url: "https://example.com/",
     text: `Content!`,
     metadata: {
       pageTitle: "Example Page",
     },
+    sourceName: "Example Source",
+    tokenCount: 10,
+    embeddings: {
+      example: [],
+    },
+    updated: new Date(),
+    score: 1,
   },
 ];
 
 const mockReferences = mockContent.map((content) => ({
   url: content.url,
-  title: content.metadata.pageTitle,
+  title: content.metadata?.pageTitle ?? content.url,
 }));
 
+const mockFindContent: FindContentFunc = async () => {
+  return {
+    content: mockContent,
+    queryEmbedding: [],
+  };
+};
+
 // Create a mock search tool that matches the SearchTool interface
-const mockSearchTool = tool({
-  parameters: SearchToolArgsSchema,
-  description: "Search MongoDB content",
-  async execute(
-    _args: SearchToolArgs,
-    _options: ToolExecutionOptions
-  ): Promise<SearchToolReturnValue> {
-    return {
-      content: mockContent,
-    };
-  },
-});
+const mockSearchTool = makeSearchTool(mockFindContent);
 
 // Must have, but details don't matter
 const mockFinishChunk = {
@@ -100,9 +105,11 @@ const makeFinalAnswerStream = () =>
     initialDelayInMs: 100,
   });
 
-const searchToolMockArgs = {
+const searchToolMockArgs: MongoDbSearchToolArgs = {
   query: "test",
-} satisfies SearchToolArgs;
+  productName: "driver",
+  programmingLanguage: "python",
+};
 
 const makeToolCallStream = () =>
   simulateReadableStream({
@@ -114,7 +121,6 @@ const makeToolCallStream = () =>
         toolCallType: "function" as const,
         args: JSON.stringify(searchToolMockArgs),
       },
-      // ...finalAnswerStreamChunks,
       mockFinishChunk,
     ] satisfies LanguageModelV1StreamPart[],
     chunkDelayInMs: 100,
@@ -196,9 +202,7 @@ const makeMakeGenerateResponseWithSearchToolArgs = () =>
     llmRefusalMessage: mockLlmRefusalMessage,
     systemMessage: mockSystemMessage,
     searchTool: mockSearchTool,
-  } satisfies Partial<
-    GenerateResponseWithSearchToolParams<typeof SearchToolArgsSchema>
-  >);
+  } satisfies Partial<GenerateResponseWithSearchToolParams>);
 
 const generateResponseBaseArgs = {
   conversation: {
@@ -255,6 +259,19 @@ describe("generateResponseWithSearchTool", () => {
       const references = (result.messages.at(-1) as AssistantMessage)
         .references;
       expect(references).toMatchObject(mockReferences);
+    });
+
+    it("should add custom data to the user message", async () => {
+      const generateResponse = makeGenerateResponseWithSearchTool(
+        makeMakeGenerateResponseWithSearchToolArgs()
+      );
+
+      const result = await generateResponse(generateResponseBaseArgs);
+
+      const userMessage = result.messages.find(
+        (message) => message.role === "user"
+      ) as UserMessage;
+      expect(userMessage.customData).toMatchObject(searchToolMockArgs);
     });
 
     describe("non-streaming", () => {
@@ -451,19 +468,34 @@ function expectSuccessfulResult(result: GenerateResponseReturnValue) {
     role: "assistant",
     toolCall: {
       id: "abc123",
-      function: { name: "search_content", arguments: '{"query":"test"}' },
+      function: {
+        name: "search_content",
+      },
       type: "function",
     },
     content: "",
   });
+  expect(
+    JSON.parse(
+      (result.messages[1] as AssistantMessage)?.toolCall?.function
+        .arguments as string
+    )
+  ).toMatchObject(searchToolMockArgs);
 
-  expect(result.messages[2]).toMatchObject({
+  // The content might be a JSON string containing a content array
+  const toolMessage = result.messages.find(
+    (message) => message.role === "tool"
+  );
+  assert(toolMessage);
+  expect(toolMessage).toMatchObject({
     role: "tool",
     name: "search_content",
-    content: JSON.stringify({
-      content: mockContent,
-    }),
+    content: expect.any(String),
+  } satisfies ToolMessage);
+  expect(JSON.parse(toolMessage.content)).toMatchObject({
+    results: mockContent.map(searchResultToLlmContent),
   });
+
   expect(result.messages[3]).toMatchObject({
     role: "assistant",
     content: finalAnswer,

--- a/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
+++ b/packages/chatbot-server-mongodb-public/src/systemPrompt.ts
@@ -1,8 +1,9 @@
-import { SEARCH_TOOL_NAME, SystemMessage } from "mongodb-chatbot-server";
+import { SystemMessage } from "mongodb-chatbot-server";
 import {
   mongoDbProducts,
   mongoDbProgrammingLanguages,
 } from "./mongoDbMetadata";
+import { SEARCH_TOOL_NAME } from "./tools/search";
 
 export const llmDoesNotKnowMessage =
   "I'm sorry, I do not know how to answer that question. Please try to rephrase your query.";

--- a/packages/chatbot-server-mongodb-public/src/tools/search.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/tools/search.eval.ts
@@ -8,11 +8,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { strict as assert } from "assert";
-import {
-  retrievalConfig,
-  findContent,
-  preprocessorOpenAiClient,
-} from "../config";
+import { retrievalConfig } from "../config";
 import { fuzzyLinkMatch } from "../eval/fuzzyLinkMatch";
 import { getConversationsEvalCasesFromYaml } from "mongodb-rag-core/eval";
 import { averagePrecisionAtK } from "../eval/scorers/averagePrecisionAtK";
@@ -21,7 +17,7 @@ import { f1AtK } from "../eval/scorers/f1AtK";
 import { precisionAtK } from "../eval/scorers/precisionAtK";
 import { recallAtK } from "../eval/scorers/recallAtK";
 import { MongoDbTag } from "../mongoDbMetadata";
-import { SearchToolArgs } from "./search";
+import { MongoDbSearchToolArgs } from "./search";
 
 interface RetrievalEvalCaseInput {
   query: string;
@@ -45,7 +41,7 @@ interface RetrievalResult {
 }
 interface RetrievalTaskOutput {
   results: RetrievalResult[];
-  extractedMetadata?: SearchToolArgs;
+  extractedMetadata?: MongoDbSearchToolArgs;
   rewrittenQuery?: string;
   searchString?: string;
 }
@@ -69,7 +65,7 @@ const retrieveRelevantContentEvalTask: EvalTask<
   RetrievalEvalCaseExpected
 > = async function (data) {
   // TODO: (EAI-991) implement retrieval task for evaluation
-  const extractedMetadata: SearchToolArgs = {
+  const extractedMetadata: MongoDbSearchToolArgs = {
     productName: null,
     programmingLanguage: null,
     query: data.query,

--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
@@ -100,8 +100,8 @@ export function getContextsFromMessages(
     return [];
   }
   try {
-    const { content } = JSON.parse(JSON.parse(toolCallMessage.content)[0].text);
-    const toolCallResult = content.map((cc: any) => ({
+    const { results } = JSON.parse(toolCallMessage.content);
+    const toolCallResult = results.map((cc: any) => ({
       text: cc.text,
       url: cc.url,
     }));

--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
@@ -8,7 +8,7 @@ import {
 import { ObjectId } from "mongodb-rag-core/mongodb";
 import { llmDoesNotKnowMessage } from "../systemPrompt";
 import { strict as assert } from "assert";
-import { SEARCH_TOOL_NAME } from "mongodb-chatbot-server";
+import { SEARCH_TOOL_NAME } from "../tools/search";
 import { logRequest } from "../utils";
 
 export function extractTracingData(

--- a/packages/chatbot-server-mongodb-public/src/tracing/getLlmAsAJudgeScores.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/getLlmAsAJudgeScores.test.ts
@@ -48,6 +48,7 @@ describe("getLlmAsAJudgeScores", () => {
     isVerifiedAnswer: false,
     llmDoesNotKnow: false,
     numRetrievedChunks: 1,
+    contextContent: [],
     rejectQuery: false,
   } satisfies Parameters<typeof getLlmAsAJudgeScores>[1];
 

--- a/packages/mongodb-chatbot-server/src/processors/MakeReferenceLinksFunc.ts
+++ b/packages/mongodb-chatbot-server/src/processors/MakeReferenceLinksFunc.ts
@@ -1,9 +1,9 @@
-import { References } from "mongodb-rag-core";
-import { SearchResult } from "./SearchResult";
+import { EmbeddedContent, References } from "mongodb-rag-core";
 
 /**
   Function that generates the references in the response to user.
  */
 export type MakeReferenceLinksFunc = (
-  searchResults: SearchResult[]
+  searchResults: (Partial<EmbeddedContent> &
+    Pick<EmbeddedContent, "url" | "text">)[]
 ) => References;

--- a/packages/mongodb-chatbot-server/src/processors/SearchResult.ts
+++ b/packages/mongodb-chatbot-server/src/processors/SearchResult.ts
@@ -1,7 +1,0 @@
-import { EmbeddedContent } from "mongodb-rag-core";
-
-export type SearchResult = Partial<EmbeddedContent> & {
-  url: string;
-  text: string;
-  metadata?: Record<string, unknown>;
-};

--- a/packages/mongodb-chatbot-server/src/processors/index.ts
+++ b/packages/mongodb-chatbot-server/src/processors/index.ts
@@ -6,8 +6,6 @@ export * from "./makeDefaultReferenceLinks";
 export * from "./makeFilterNPreviousMessages";
 export * from "./includeChunksForMaxTokensPossible";
 export * from "./InputGuardrail";
-export * from "./generateResponseWithSearchTool";
 export * from "./makeVerifiedAnswerGenerateResponse";
 export * from "./includeChunksForMaxTokensPossible";
 export * from "./GenerateResponse";
-export * from "./SearchResult";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1050

## Changes


Misc clean up to retrieval as a tool

- move `generateResponseWithSearch` to `chatbot-server-mongodb-public`
- Clean up tool return type to avoid 2x JSON stringification
- add metadata to user message, following pattern of previous RAG system

## Notes

- Must be merged after https://github.com/mongodb/chatbot/pull/757
