### PR TITLE
(EAI-977) Add Braintrust evals to core metadata classifiers

### DIFF
--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -1,0 +1,110 @@
+import "dotenv/config";
+import { wrapOpenAI, Eval } from "mongodb-rag-core/braintrust";
+import { Scorer } from "autoevals";
+import { 
+  classifyMongoDbMetadata,
+  MongoDbTag,
+  classifyMongoDbProduct,
+  classifyMongoDbProgrammingLanguage,
+  classifyMongoDbTopic
+} from "./";
+import { assertEnvVars } from "../assertEnvVars"
+
+
+// need an  AI client to run the classifier
+// from evalHelpers
+import { AzureOpenAI } from "openai";
+export const {
+  OPENAI_API_KEY,
+  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
+  OPENAI_ENDPOINT,
+  OPENAI_API_VERSION,
+} = assertEnvVars({
+  OPENAI_API_KEY: "",
+  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT: "",
+  OPENAI_ENDPOINT: "",
+  OPENAI_API_VERSION: "",
+});
+
+export const openAiClient = wrapOpenAI(
+  new AzureOpenAI({
+    apiKey: OPENAI_API_KEY,
+    endpoint: OPENAI_ENDPOINT,
+    apiVersion: OPENAI_API_VERSION,
+  })
+);
+
+interface ClassifyMongoDbMetadataEvalCase {
+  name: string;
+  input: string;
+  expected: {
+    product: Awaited<ReturnType<typeof classifyMongoDbProduct>>;
+    programmingLanguage: Awaited<ReturnType<typeof classifyMongoDbProgrammingLanguage>>;
+    topic: Awaited<ReturnType<typeof classifyMongoDbTopic>>;
+  };
+  tags?: MongoDbTag[];
+}
+
+const evalCases: ClassifyMongoDbMetadataEvalCase[] = [
+  {
+    name: "should identify MongoDB Atlas Search",
+    input: "Does atlas search support copy to fields",
+    expected: {
+      product: "atlas_search",
+      programmingLanguage: null,
+      topic: null,
+    },
+    tags: ["atlas", "atlas_search"],
+  },
+];
+
+const ProductNameCorrect: Scorer<
+  Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
+  unknown
+> = (args) => {
+  return {
+    name: "ProductNameCorrect",
+    score: args.expected?.product === args.output.product ? 1 : 0,
+  };
+};
+
+const ProgrammingLanguageCorrect: Scorer<
+  Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
+  unknown
+> = (args) => {
+  return {
+    name: "ProgrammingLanguageCorrect",
+    score:
+      args.expected?.programmingLanguage === args.output.programmingLanguage
+        ? 1
+        : 0,
+  };
+};
+
+const TopicCorrect: Scorer<Awaited<ReturnType<typeof classifyMongoDbMetadata>>, unknown> = (args) => {
+  return {
+    name: "TopicCorrect",
+    score: args.expected?.topic === args.output.topic ? 1 : 0,
+  };
+};
+
+
+const model = "";
+
+Eval("BT project name", {
+  data: evalCases,
+  experimentName: model,
+  async task(input) {
+    try {
+      return await classifyMongoDbMetadata({
+        model: openAiClient,
+        data: input,
+      });
+    } catch (error) {
+      console.log(`Error evaluating input: ${input}`);
+      console.log(error);
+      throw error;
+    }
+  },
+  scores: [ProductNameCorrect, ProgrammingLanguageCorrect, TopicCorrect],
+});

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -29,7 +29,7 @@ async function main() {
       expected: {
         product: "atlas_search",
         programmingLanguage: null,
-        topic: null,
+        topic: "search",
       },
       tags: ["atlas", "atlas_search"],
     },
@@ -49,7 +49,7 @@ async function main() {
       expected: {
         programmingLanguage: "python",
         product: "driver",
-        topic: "troubleshoot_debug",
+        topic: "queries",
       },
       tags: ["driver", "python"],
     },
@@ -138,7 +138,7 @@ async function main() {
     },
     {
       name: "should detect transaction management topic",
-      input: "How do I manage multi-document transactions?",  // TODO potentially should add transaction topic or smth about how databases work
+      input: "How do I manage multi-document transactions?",
       expected: {
         product: "server",
         programmingLanguage: null,
@@ -162,7 +162,7 @@ async function main() {
       expected: {
         programmingLanguage: "java",
         product: "driver",
-        topic: "monitoring",
+        topic: "queries",
       },
       tags: ["driver", "java"],
     },
@@ -192,7 +192,7 @@ async function main() {
       expected: {
         programmingLanguage: "javascript",
         product: "driver",
-        topic: "troubleshoot_debug",
+        topic: "queries",
       },
       tags: ["driver", "javascript"],
     },
@@ -244,7 +244,7 @@ async function main() {
       expected: {
         product: "enterprise_kubernetes_operator",
         programmingLanguage: null,
-        topic: "troubleshoot_debug",
+        topic: null,
       },
       tags: [],
     },
@@ -262,7 +262,7 @@ async function main() {
       name: "should identify k8s controllers",
       input: "deploy mongodb as multi-cluster k8s",
       expected: {
-        product: "mck",
+        product: "mongodb_kubernetes_controllers",
         programmingLanguage: null,
         topic: "performance",
       },
@@ -273,8 +273,8 @@ async function main() {
       input: "How to connect to database mongosh",
       expected: {
         product: "shell",
-        programmingLanguage: null,
-        topic: "troubleshoot_debug",
+        programmingLanguage: "shell",
+        topic: "queries",
       },
       tags: [],
     },
@@ -283,7 +283,7 @@ async function main() {
       input: "download shell",
       expected: {
         product: "shell",
-        programmingLanguage: null,
+        programmingLanguage: "shell",
         topic: null,
       },
       tags: [],

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -219,17 +219,6 @@ async function main() {
       tags: ["atlas", "atlas_vector_search"],
     },
     {
-      name: "should identify community k8s with exact reference",
-      input:
-        "help in deploying sharded replica set using mongodb community kubernetes operator",
-      expected: {
-        product: "community_kubernetes_operator",
-        programmingLanguage: null,
-        topic: "sharding",
-      },
-      tags: [k8sAsTag],
-    },
-    {
       name: "should identify community k8s without exact reference",
       input: "run mongodb on kubernetes on local machine",
       expected: {
@@ -281,16 +270,6 @@ async function main() {
       tags: ["shell"],
     },
     {
-      name: "should classify mongodb shell",
-      input: "download shell",
-      expected: {
-        product: "shell",
-        programmingLanguage: "shell",
-        topic: null,
-      },
-      tags: ["shell"],
-    },
-    {
       name: "should identify maintenance topic",
       input: "upgrade mongodb 5 to 7",
       expected: {
@@ -309,16 +288,6 @@ async function main() {
         topic: "migration",
       },
       tags: [],
-    },
-    {
-      name: "should identify mongodb university",
-      input: "dba courses on mongodb university",
-      expected: {
-        product: "mongodb_university",
-        programmingLanguage: null,
-        topic: "mongodb_university",
-      },
-      tags: ["mongodb_university"],
     },
     {
       name: "should identify skills",
@@ -341,16 +310,6 @@ async function main() {
       tags: ["mongodb_university"],
     },
     {
-      name: "should identify backup",
-      input: "How do I backup mongodb atlas cluster data to s3",
-      expected: {
-        product: "atlas",
-        programmingLanguage: null,
-        topic: "backup",
-      },
-      tags: ["atlas"],
-    },
-    {
       name: "should identify data modeling",
       input: "when should i use nested documents vs creating a new collection",
       expected: {
@@ -359,26 +318,6 @@ async function main() {
         topic: "data_modeling",
       },
       tags: [],
-    },
-    {
-      name: "should identify monitoring",
-      input: "Mongodb monitoring best practices for atlas cluster",
-      expected: {
-        product: "atlas",
-        programmingLanguage: null,
-        topic: "monitoring",
-      },
-      tags: ["atlas"],
-    },
-    {
-      name: "should identify troubleshooting",
-      input: 'Detected unknown BSON type 23 for fieldname "Unit"',
-      expected: {
-        product: "server",
-        programmingLanguage: null,
-        topic: "troubleshoot_debug",
-      },
-      tags: ["troubleshoot_debug"],
     },
     {
       name: "should identify troubleshooting",
@@ -395,41 +334,11 @@ async function main() {
       name: "should identify security",
       input: "how to whitelist ips on atlas cluster",
       expected: {
-        product: "server",
+        product: "atlas",
         programmingLanguage: null,
         topic: "security",
       },
       tags: [],
-    },
-    {
-      name: "should identify kotlin from framework name",
-      input: "i want to add mongodb to my ktor app",
-      expected: {
-        product: "driver",
-        programmingLanguage: "kotlin",
-        topic: null,
-      },
-      tags: ["kotlin", "driver"],
-    },
-    {
-      name: "should identify java from framework name",
-      input: "spring boot sample application code with mongodb",
-      expected: {
-        product: "driver",
-        programmingLanguage: "java",
-        topic: null,
-      },
-      tags: ["java", "driver"],
-    },
-    {
-      name: "should identify javascript from framework name",
-      input: "Hono sample application code with mongodb",
-      expected: {
-        product: "driver",
-        programmingLanguage: "javascript",
-        topic: null,
-      },
-      tags: ["javascript", "driver"],
     },
   ];
 

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -2,34 +2,11 @@ import "dotenv/config";
 import { strict as assert } from "assert";
 import { Eval } from "../braintrust";
 import { Scorer } from "autoevals";
-import {
-  classifyMongoDbMetadata,
-  MongoDbTag,
-  classifyMongoDbProduct,
-  classifyMongoDbProgrammingLanguage,
-  classifyMongoDbTopic,
-} from "./";
-// import { assertEnvVars } from "../assertEnvVars";
+import { classifyMongoDbMetadata, MongoDbTag } from "./";
 import { createOpenAI } from "@ai-sdk/openai";
 import { getOpenAiEndpointAndApiKey, models } from "../models";
 
-// export const {
-//   OPENAI_API_KEY,
-//   OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
-//   OPENAI_ENDPOINT,
-//   OPENAI_API_VERSION,
-// } = assertEnvVars({
-//   OPENAI_API_KEY: "",
-//   OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT: "",
-//   OPENAI_ENDPOINT: "",
-//   OPENAI_API_VERSION: "",
-// });
-
 async function main() {
-  // need an  AI client to run the classifier.
-  // ok so this gets the models from the list we define
-  // and we want to get the gpt4.1 one
-  // this is where we'd test with different models if interested
   const modelLabel = "gpt-4.1";
   const modelConfig = models.find((m) => m.label === modelLabel);
   assert(modelConfig, `Model ${modelLabel} not found`);
@@ -41,11 +18,7 @@ async function main() {
   interface ClassifyMongoDbMetadataEvalCase {
     name: string;
     input: string;
-    expected: {
-      product: Awaited<ReturnType<typeof classifyMongoDbProduct>>;
-      programmingLanguage: Awaited<ReturnType<typeof classifyMongoDbProgrammingLanguage>>;
-      topic: Awaited<ReturnType<typeof classifyMongoDbTopic>>;
-    };
+    expected: Awaited<ReturnType<typeof classifyMongoDbMetadata>>;
     tags?: MongoDbTag[];
   }
 
@@ -59,6 +32,189 @@ async function main() {
         topic: null,
       },
       tags: ["atlas", "atlas_search"],
+    },
+    {
+      name: "should identify aggregation stage",
+      input: "$merge",
+      expected: {
+        product: "aggregation",
+        programmingLanguage: null,
+        topic: "queries",
+      },
+      tags: ["aggregation"],
+    },
+    {
+      name: "should know pymongo is python driver",
+      input: "pymongo insert data",
+      expected: {
+        programmingLanguage: "python",
+        product: "driver",
+        topic: "troubleshoot_debug",
+      },
+      tags: ["driver", "python"],
+    },
+    {
+      name: "should identify MongoDB Atlas",
+      input: "how to create a new cluster atlas",
+      expected: {
+        product: "atlas",
+        programmingLanguage: null,
+        topic: null,
+      },
+      tags: ["atlas"],
+    },
+    {
+      name: "should know atlas billing",
+      input: "how do I see my bill in atlas",
+      expected: {
+        product: "atlas",
+        programmingLanguage: null,
+        topic: "billing",
+      },
+      tags: ["atlas"],
+    },
+    {
+      name: "should be aware of vector search product",
+      input: "how to use vector search",
+      expected: {
+        product: "atlas_vector_search",
+        programmingLanguage: null,
+        topic: "search",
+      },
+      tags: ["atlas", "atlas_vector_search"],
+    },
+    {
+      name: "should know change streams",
+      input:
+        "how to open a change stream watch on a database and filter the stream",
+      expected: {
+        product: "change_streams",
+        programmingLanguage: "javascript",
+        topic: "change_streams",
+      },
+      tags: ["change_streams"],
+    },
+    {
+      name: "should know change streams",
+      input:
+        "how to open a change stream watch on a database and filter the stream pymongo",
+      expected: {
+        product: "driver",
+        programmingLanguage: "python",
+        topic: "change_streams",
+      },
+      tags: ["change_streams"],
+    },
+    {
+      name: "should know to include programming language when coding task implied.",
+      input:
+        "How do I choose the order of fields when creating a compound index?",
+      expected: {
+        product: "server",
+        programmingLanguage: "javascript",
+        topic: "indexes",
+      },
+      tags: ["indexes"],
+    },
+    {
+      name: "should detect gridfs usage",
+      input: "What is the best way to store large files with MongoDB?",
+      expected: {
+        product: "gridfs",
+        programmingLanguage: null,
+        topic: "performance",
+      },
+      tags: ["gridfs"],
+    },
+    {
+      name: "should recognize MongoDB for analytics",
+      input: "How do I run real-time analytics on my data?",
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "analytics",
+      },
+      tags: ["analytics"],
+    },
+    {
+      name: "should detect transaction management topic",
+      input: "How do I manage multi-document transactions?",  // TODO potentially should add transaction topic or smth about how databases work
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "performance",
+      },
+      tags: ["server"],
+    },
+    {
+      name: "should know multi-cloud clustering",
+      input: "Can I create a multi-cloud cluster with Atlas?",
+      expected: {
+        product: "atlas",
+        programmingLanguage: null,
+        topic: "multi_cloud",
+      },
+      tags: ["atlas", "multi_cloud"],
+    },
+    {
+      name: "should identify usage in Java with the MongoDB driver",
+      input: "How do I connect to MongoDB using the Java driver?",
+      expected: {
+        programmingLanguage: "java",
+        product: "driver",
+        topic: "monitoring",
+      },
+      tags: ["driver", "java"],
+    },
+    {
+      name: "should know usage of MongoDB in C#",
+      input: "How do I query a collection using LINQ in C#?",
+      expected: {
+        programmingLanguage: "csharp",
+        product: "driver",
+        topic: "queries",
+      },
+      tags: ["driver", "csharp"],
+    },
+    {
+      name: "should recognize Python use in aggregation queries",
+      input: "How do I perform an aggregation pipeline in pymongo?",
+      expected: {
+        programmingLanguage: "python",
+        product: "aggregation",
+        topic: "queries",
+      },
+      tags: ["driver", "python", "aggregation"],
+    },
+    {
+      name: "should detect use of Node.js for MongoDB",
+      input: "How do I handle MongoDB connections in Node.js?",
+      expected: {
+        programmingLanguage: "javascript",
+        product: "driver",
+        topic: "troubleshoot_debug",
+      },
+      tags: ["driver", "javascript"],
+    },
+    {
+      name: "should identify usage of Go with MongoDB",
+      input: "How do I insert multiple documents with the MongoDB Go driver?",
+      expected: {
+        programmingLanguage: "go",
+        product: "driver",
+        topic: "queries",
+      },
+      tags: ["driver", "go"],
+    },
+    {
+      name: "should know of $vectorSearch stage",
+      input: "$vectorSearch",
+      expected: {
+        product: "atlas_vector_search",
+        programmingLanguage: null,
+        topic: "search",
+      },
+      tags: ["atlas", "atlas_vector_search"],
     },
   ];
 
@@ -85,7 +241,9 @@ async function main() {
     };
   };
 
-  const TopicCorrect: Scorer<Awaited<ReturnType<typeof classifyMongoDbMetadata>>, unknown> = (args) => {
+  const TopicCorrect: Scorer<
+    Awaited<ReturnType<typeof classifyMongoDbMetadata>>, unknown
+  > = (args) => {
     return {
       name: "TopicCorrect",
       score: args.expected?.topic === args.output.topic ? 1 : 0,

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -22,6 +22,8 @@ async function main() {
     tags?: MongoDbTag[];
   }
 
+  const k8sAsTag = "kubernetes" as MongoDbTag;
+
   const evalCases: ClassifyMongoDbMetadataEvalCase[] = [
     {
       name: "should identify MongoDB Atlas Search",
@@ -162,7 +164,7 @@ async function main() {
       expected: {
         programmingLanguage: "java",
         product: "driver",
-        topic: "queries",
+        topic: null,
       },
       tags: ["driver", "java"],
     },
@@ -192,7 +194,7 @@ async function main() {
       expected: {
         programmingLanguage: "javascript",
         product: "driver",
-        topic: "queries",
+        topic: null,
       },
       tags: ["driver", "javascript"],
     },
@@ -225,17 +227,17 @@ async function main() {
         programmingLanguage: null,
         topic: "sharding",
       },
-      tags: [],
+      tags: [k8sAsTag],
     },
     {
       name: "should identify community k8s without exact reference",
-      input: "deploy mongodb with kubernetes on local machine",
+      input: "run mongodb on kubernetes on local machine",
       expected: {
         product: "community_kubernetes_operator",
         programmingLanguage: null,
         topic: null,
       },
-      tags: [],
+      tags: [k8sAsTag],
     },
     {
       name: "should identify k8s enterprise",
@@ -246,7 +248,7 @@ async function main() {
         programmingLanguage: null,
         topic: null,
       },
-      tags: [],
+      tags: [k8sAsTag],
     },
     {
       name: "should identify atlas k8s",
@@ -256,7 +258,7 @@ async function main() {
         programmingLanguage: null,
         topic: "iam",
       },
-      tags: [],
+      tags: [k8sAsTag, "atlas"],
     },
     {
       name: "should identify k8s controllers",
@@ -266,7 +268,7 @@ async function main() {
         programmingLanguage: null,
         topic: "performance",
       },
-      tags: [],
+      tags: [k8sAsTag],
     },
     {
       name: "should classify mongosh as mongodb shell",
@@ -274,9 +276,9 @@ async function main() {
       expected: {
         product: "shell",
         programmingLanguage: "shell",
-        topic: "queries",
+        topic: null,
       },
-      tags: [],
+      tags: ["shell"],
     },
     {
       name: "should classify mongodb shell",
@@ -286,7 +288,7 @@ async function main() {
         programmingLanguage: "shell",
         topic: null,
       },
-      tags: [],
+      tags: ["shell"],
     },
     {
       name: "should identify maintenance topic",
@@ -316,7 +318,7 @@ async function main() {
         programmingLanguage: null,
         topic: "mongodb_university",
       },
-      tags: [],
+      tags: ["mongodb_university"],
     },
     {
       name: "should identify skills",
@@ -326,7 +328,7 @@ async function main() {
         programmingLanguage: null,
         topic: "mongodb_university",
       },
-      tags: [],
+      tags: ["mongodb_university"],
     },
     {
       name: "should identify certificate exam",
@@ -336,7 +338,7 @@ async function main() {
         programmingLanguage: null,
         topic: "certificate_exam",
       },
-      tags: [],
+      tags: ["mongodb_university"],
     },
     {
       name: "should identify backup",
@@ -346,7 +348,7 @@ async function main() {
         programmingLanguage: null,
         topic: "backup",
       },
-      tags: [],
+      tags: ["atlas"],
     },
     {
       name: "should identify data modeling",
@@ -366,7 +368,7 @@ async function main() {
         programmingLanguage: null,
         topic: "monitoring",
       },
-      tags: [],
+      tags: ["atlas"],
     },
     {
       name: "should identify troubleshooting",
@@ -376,7 +378,7 @@ async function main() {
         programmingLanguage: null,
         topic: "troubleshoot_debug",
       },
-      tags: [],
+      tags: ["troubleshoot_debug"],
     },
     {
       name: "should identify troubleshooting",
@@ -387,7 +389,7 @@ async function main() {
         programmingLanguage: "javascript",
         topic: "troubleshoot_debug",
       },
-      tags: [],
+      tags: ["troubleshoot_debug"],
     },
     {
       name: "should identify security",
@@ -397,7 +399,37 @@ async function main() {
         programmingLanguage: null,
         topic: "security",
       },
-      tags: ["security"],
+      tags: [],
+    },
+    {
+      name: "should identify kotlin from framework name",
+      input: "i want to add mongodb to my ktor app",
+      expected: {
+        product: "driver",
+        programmingLanguage: "kotlin",
+        topic: null,
+      },
+      tags: ["kotlin", "driver"],
+    },
+    {
+      name: "should identify java from framework name",
+      input: "spring boot sample application code with mongodb",
+      expected: {
+        product: "driver",
+        programmingLanguage: "java",
+        topic: null,
+      },
+      tags: ["java", "driver"],
+    },
+    {
+      name: "should identify javascript from framework name",
+      input: "Hono sample application code with mongodb",
+      expected: {
+        product: "driver",
+        programmingLanguage: "javascript",
+        topic: null,
+      },
+      tags: ["javascript", "driver"],
     },
   ];
 

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -34,7 +34,6 @@ async function main() {
       input: "Does atlas search support copy to fields",
       expected: {
         product: "atlas_search",
-        programmingLanguage: null,
         topic: "search",
       },
       tags: ["atlas", "atlas_search"],
@@ -44,7 +43,6 @@ async function main() {
       input: "$merge",
       expected: {
         product: "aggregation",
-        programmingLanguage: null,
         topic: "queries",
       },
       tags: ["aggregation"],
@@ -65,7 +63,6 @@ async function main() {
       expected: {
         product: "atlas",
         programmingLanguage: null,
-        topic: null,
       },
       tags: ["atlas"],
     },
@@ -84,7 +81,6 @@ async function main() {
       input: "how to use vector search",
       expected: {
         product: "atlas_vector_search",
-        programmingLanguage: null,
         topic: "search",
       },
       tags: ["atlas", "atlas_vector_search"],
@@ -137,7 +133,6 @@ async function main() {
       input: "How do I run real-time analytics on my data?",
       expected: {
         product: "server",
-        programmingLanguage: null,
         topic: "analytics",
       },
       tags: ["analytics"],
@@ -147,7 +142,6 @@ async function main() {
       input: "How do I manage multi-document transactions?",
       expected: {
         product: "server",
-        programmingLanguage: null,
         topic: "performance",
       },
       tags: ["server"],
@@ -157,7 +151,6 @@ async function main() {
       input: "Can I create a multi-cloud cluster with Atlas?",
       expected: {
         product: "atlas",
-        programmingLanguage: null,
         topic: "multi_cloud",
       },
       tags: ["atlas", "multi_cloud"],
@@ -168,7 +161,6 @@ async function main() {
       expected: {
         programmingLanguage: "java",
         product: "driver",
-        topic: null,
       },
       tags: ["driver", "java"],
     },
@@ -198,7 +190,6 @@ async function main() {
       expected: {
         programmingLanguage: "javascript",
         product: "driver",
-        topic: null,
       },
       tags: ["driver", "javascript"],
     },
@@ -217,7 +208,6 @@ async function main() {
       input: "$vectorSearch",
       expected: {
         product: "atlas_vector_search",
-        programmingLanguage: null,
         topic: "search",
       },
       tags: ["atlas", "atlas_vector_search"],
@@ -233,7 +223,7 @@ async function main() {
     {
       name: "should identify k8s enterprise",
       input:
-        "I would like to run a MongoDB Enterprise docker image inside a Kubernetes cluster, but there is no official MongoDB Enterprise docker image. Is there any other way?",
+        "What versions of MongoDB does the Enterprise Kubernetes Operator support?",
       expected: {
         product: "enterprise_kubernetes_operator",
       },
@@ -263,7 +253,6 @@ async function main() {
       expected: {
         product: "shell",
         programmingLanguage: "shell",
-        topic: null,
       },
       tags: ["shell"],
     },
@@ -272,7 +261,6 @@ async function main() {
       input: "upgrade mongodb 5 to 7",
       expected: {
         product: "server",
-        programmingLanguage: null,
         topic: "maintenance",
       },
       tags: [],

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -216,6 +216,88 @@ async function main() {
       },
       tags: ["atlas", "atlas_vector_search"],
     },
+    {
+      name: "should identify community k8s with exact reference",
+      input:
+        "help in deploying sharded replica set using mongodb community kubernetes operator",
+      expected: {
+        product: "community_kubernetes_operator",
+        programmingLanguage: null,
+        topic: "sharding",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify community k8s without exact reference",
+      input: "deploy mongodb with kubernetes on local machine",
+      expected: {
+        product: "community_kubernetes_operator",
+        programmingLanguage: null,
+        topic: null,
+      },
+      tags: [],
+    },
+    {
+      name: "should identify k8s enterprise",
+      input:
+        "I would like to run a MongoDB Enterprise docker image inside a Kubernetes cluster, but there is no official MongoDB Enterprise docker image. Is there any other way?",
+      expected: {
+        product: "enterprise_kubernetes_operator",
+        programmingLanguage: null,
+        topic: "troubleshoot_debug",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify atlas k8s",
+      input: "manage atlas mongodb cluster users from kubernetes",
+      expected: {
+        product: "atlas_operator",
+        programmingLanguage: null,
+        topic: "iam",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify k8s controllers",
+      input: "deploy mongodb as multi-cluster k8s",
+      expected: {
+        product: "mck",
+        programmingLanguage: null,
+        topic: "performance",
+      },
+      tags: [],
+    },
+    {
+      name: "should classify mongosh as mongodb shell",
+      input: "How to connect to database mongosh",
+      expected: {
+        product: "shell",
+        programmingLanguage: null,
+        topic: "troubleshoot_debug",
+      },
+      tags: [],
+    },
+    {
+      name: "should classify mongodb shell",
+      input: "download shell",
+      expected: {
+        product: "shell",
+        programmingLanguage: null,
+        topic: null,
+      },
+      tags: [],
+    },
+    {
+      name: "should identify maintenance topic",
+      input: "upgrade mongodb 5 to 7",
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "maintenance",
+      },
+      tags: [],
+    },
   ];
 
   const ProductNameCorrect: Scorer<

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -298,6 +298,107 @@ async function main() {
       },
       tags: [],
     },
+    {
+      name: "should identify relational migrator",
+      input: "migrate from postgres to mongodb",
+      expected: {
+        product: "relational_migrator",
+        programmingLanguage: null,
+        topic: "migration",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify mongodb university",
+      input: "dba courses on mongodb university",
+      expected: {
+        product: "mongodb_university",
+        programmingLanguage: null,
+        topic: "mongodb_university",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify skills",
+      input: "what skills badge is right for me as a beginner",
+      expected: {
+        product: "skills",
+        programmingLanguage: null,
+        topic: "mongodb_university",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify certificate exam",
+      input: "mock exams for associate developer certificate",
+      expected: {
+        product: "mongodb_university",
+        programmingLanguage: null,
+        topic: "certificate_exam",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify backup",
+      input: "How do I backup mongodb atlas cluster data to s3",
+      expected: {
+        product: "atlas",
+        programmingLanguage: null,
+        topic: "backup",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify data modeling",
+      input: "when should i use nested documents vs creating a new collection",
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "data_modeling",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify monitoring",
+      input: "Mongodb monitoring best practices for atlas cluster",
+      expected: {
+        product: "atlas",
+        programmingLanguage: null,
+        topic: "monitoring",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify troubleshooting",
+      input: 'Detected unknown BSON type 23 for fieldname "Unit"',
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "troubleshoot_debug",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify troubleshooting",
+      input:
+        "how do i fix: \n{ MongoNetworkError: connection 3 to cluster0-shard-00-02-z0urk.mongodb.net:27017 closed at TLSSocket. (/home/fahad/Personal Work/Nodejs/Node js start/node_modules/mongoose/node_modules/mongodb-core/lib/connection/connection.js:352:9) at Object.onceWrapper (events.js:276:13) at TLSSocket.emit (events.js:188:13) at _handle.close (net.js:610:12) at TCP.done (_tls_wrap.js:386:7) name: 'MongoNetworkError', errorLabels: [ 'TransientTransactionError' ],\n[Symbol(mongoErrorContextSymbol)]: {} }",
+      expected: {
+        product: "driver",
+        programmingLanguage: "javascript",
+        topic: "troubleshoot_debug",
+      },
+      tags: [],
+    },
+    {
+      name: "should identify security",
+      input: "how to whitelist ips on atlas cluster",
+      expected: {
+        product: "server",
+        programmingLanguage: null,
+        topic: "security",
+      },
+      tags: ["security"],
+    },
   ];
 
   const ProductNameCorrect: Scorer<
@@ -331,7 +432,6 @@ async function main() {
       score: args.expected?.topic === args.output.topic ? 1 : 0,
     };
   };
-
 
   Eval("classify-mongodb-metadata", {
     data: evalCases,

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts
@@ -1,110 +1,122 @@
 import "dotenv/config";
-import { wrapOpenAI, Eval } from "mongodb-rag-core/braintrust";
+import { strict as assert } from "assert";
+import { Eval } from "../braintrust";
 import { Scorer } from "autoevals";
-import { 
+import {
   classifyMongoDbMetadata,
   MongoDbTag,
   classifyMongoDbProduct,
   classifyMongoDbProgrammingLanguage,
-  classifyMongoDbTopic
+  classifyMongoDbTopic,
 } from "./";
-import { assertEnvVars } from "../assertEnvVars"
+// import { assertEnvVars } from "../assertEnvVars";
+import { createOpenAI } from "@ai-sdk/openai";
+import { getOpenAiEndpointAndApiKey, models } from "../models";
 
+// export const {
+//   OPENAI_API_KEY,
+//   OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
+//   OPENAI_ENDPOINT,
+//   OPENAI_API_VERSION,
+// } = assertEnvVars({
+//   OPENAI_API_KEY: "",
+//   OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT: "",
+//   OPENAI_ENDPOINT: "",
+//   OPENAI_API_VERSION: "",
+// });
 
-// need an  AI client to run the classifier
-// from evalHelpers
-import { AzureOpenAI } from "openai";
-export const {
-  OPENAI_API_KEY,
-  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT,
-  OPENAI_ENDPOINT,
-  OPENAI_API_VERSION,
-} = assertEnvVars({
-  OPENAI_API_KEY: "",
-  OPENAI_PREPROCESSOR_CHAT_COMPLETION_DEPLOYMENT: "",
-  OPENAI_ENDPOINT: "",
-  OPENAI_API_VERSION: "",
-});
+async function main() {
+  // need an  AI client to run the classifier.
+  // ok so this gets the models from the list we define
+  // and we want to get the gpt4.1 one
+  // this is where we'd test with different models if interested
+  const modelLabel = "gpt-4.1";
+  const modelConfig = models.find((m) => m.label === modelLabel);
+  assert(modelConfig, `Model ${modelLabel} not found`);
 
-export const openAiClient = wrapOpenAI(
-  new AzureOpenAI({
-    apiKey: OPENAI_API_KEY,
-    endpoint: OPENAI_ENDPOINT,
-    apiVersion: OPENAI_API_VERSION,
-  })
-);
+  const openai = createOpenAI({
+    ...(await getOpenAiEndpointAndApiKey(modelConfig)),
+  });
 
-interface ClassifyMongoDbMetadataEvalCase {
-  name: string;
-  input: string;
-  expected: {
-    product: Awaited<ReturnType<typeof classifyMongoDbProduct>>;
-    programmingLanguage: Awaited<ReturnType<typeof classifyMongoDbProgrammingLanguage>>;
-    topic: Awaited<ReturnType<typeof classifyMongoDbTopic>>;
+  interface ClassifyMongoDbMetadataEvalCase {
+    name: string;
+    input: string;
+    expected: {
+      product: Awaited<ReturnType<typeof classifyMongoDbProduct>>;
+      programmingLanguage: Awaited<ReturnType<typeof classifyMongoDbProgrammingLanguage>>;
+      topic: Awaited<ReturnType<typeof classifyMongoDbTopic>>;
+    };
+    tags?: MongoDbTag[];
+  }
+
+  const evalCases: ClassifyMongoDbMetadataEvalCase[] = [
+    {
+      name: "should identify MongoDB Atlas Search",
+      input: "Does atlas search support copy to fields",
+      expected: {
+        product: "atlas_search",
+        programmingLanguage: null,
+        topic: null,
+      },
+      tags: ["atlas", "atlas_search"],
+    },
+  ];
+
+  const ProductNameCorrect: Scorer<
+    Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
+    unknown
+  > = (args) => {
+    return {
+      name: "ProductNameCorrect",
+      score: args.expected?.product === args.output.product ? 1 : 0,
+    };
   };
-  tags?: MongoDbTag[];
+
+  const ProgrammingLanguageCorrect: Scorer<
+    Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
+    unknown
+  > = (args) => {
+    return {
+      name: "ProgrammingLanguageCorrect",
+      score:
+        args.expected?.programmingLanguage === args.output.programmingLanguage
+          ? 1
+          : 0,
+    };
+  };
+
+  const TopicCorrect: Scorer<Awaited<ReturnType<typeof classifyMongoDbMetadata>>, unknown> = (args) => {
+    return {
+      name: "TopicCorrect",
+      score: args.expected?.topic === args.output.topic ? 1 : 0,
+    };
+  };
+
+
+  Eval("classify-mongodb-metadata", {
+    data: evalCases,
+    experimentName: modelLabel,
+    metadata: {
+      description:
+        "Evaluates whether the MongoDB metadata classifier is working correctly",
+      model: modelLabel,
+    },
+    maxConcurrency: 15,
+    timeout: 20000,
+    async task(input) {
+      try {
+        return await classifyMongoDbMetadata(
+          openai.languageModel(modelLabel),
+          input
+        );
+      } catch (error) {
+        console.log(`Error evaluating input: ${input}`);
+        console.log(error);
+        throw error;
+      }
+    },
+    scores: [ProductNameCorrect, ProgrammingLanguageCorrect, TopicCorrect],
+  });
 }
 
-const evalCases: ClassifyMongoDbMetadataEvalCase[] = [
-  {
-    name: "should identify MongoDB Atlas Search",
-    input: "Does atlas search support copy to fields",
-    expected: {
-      product: "atlas_search",
-      programmingLanguage: null,
-      topic: null,
-    },
-    tags: ["atlas", "atlas_search"],
-  },
-];
-
-const ProductNameCorrect: Scorer<
-  Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
-  unknown
-> = (args) => {
-  return {
-    name: "ProductNameCorrect",
-    score: args.expected?.product === args.output.product ? 1 : 0,
-  };
-};
-
-const ProgrammingLanguageCorrect: Scorer<
-  Awaited<ReturnType<typeof classifyMongoDbMetadata>>,
-  unknown
-> = (args) => {
-  return {
-    name: "ProgrammingLanguageCorrect",
-    score:
-      args.expected?.programmingLanguage === args.output.programmingLanguage
-        ? 1
-        : 0,
-  };
-};
-
-const TopicCorrect: Scorer<Awaited<ReturnType<typeof classifyMongoDbMetadata>>, unknown> = (args) => {
-  return {
-    name: "TopicCorrect",
-    score: args.expected?.topic === args.output.topic ? 1 : 0,
-  };
-};
-
-
-const model = "";
-
-Eval("BT project name", {
-  data: evalCases,
-  experimentName: model,
-  async task(input) {
-    try {
-      return await classifyMongoDbMetadata({
-        model: openAiClient,
-        data: input,
-      });
-    } catch (error) {
-      console.log(`Error evaluating input: ${input}`);
-      console.log(error);
-      throw error;
-    }
-  },
-  scores: [ProductNameCorrect, ProgrammingLanguageCorrect, TopicCorrect],
-});
+main();

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import { generateObject, LanguageModel } from "ai";
-import { MongoDbProduct, MongoDbProductId, mongoDbProducts } from "./products";
+import { MongoDbProductId, mongoDbProducts } from "./products";
 import {
   MongoDbProgrammingLanguageId,
   mongoDbProgrammingLanguageIds,
   mongoDbProgrammingLanguages,
 } from "./programmingLanguages";
-import { MongoDbTopic, MongoDbTopicId, mongoDbTopics } from "./topics";
+import { MongoDbTopicId, mongoDbTopics } from "./topics";
 import { MongoDbTag } from "./tags";
 
 const baseSystemPrompt = `You are an expert data labeler employed by MongoDB.
@@ -108,7 +108,9 @@ export const classifyMongoDbTopic = async (
           role: "system",
           content: `${baseSystemPrompt}
 
-${mongoDbTopics.map((t) => ` - ${t.id}`).join("\n")}`,
+${mongoDbTopics
+  .map((t) => ` - ${t.id}: **${t.name}**. ${t.description}`)
+  .join("\n")}`,
         },
         {
           role: "user",

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
@@ -339,13 +339,13 @@ export const mongoDbProducts = [
     id: "community_kubernetes_operator",
     name: "Community Kubernetes Operator",
     description:
-      "[End-of-Life] Deploy applications on replica sets of MongoDB Community.",
+      "[Deprecated] Deploy basic MongoDB ReplicaSets on Kubernetes, open-source and free.",
   },
   {
     id: "enterprise_kubernetes_operator",
     name: "Kubernetes Operator",
     description:
-      "[End-of-Life] Deploy and manage an Enterprise Advanced MongoDB cluster on Kubernetes",
+      "[Deprecated] Deploy production MongoDB clusters with greater features, requires commercial license.",
   },
   {
     id: "mongodb_kubernetes_controllers",

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
@@ -368,7 +368,7 @@ export const mongoDbProducts = [
     id: "skills",
     name: "MongoDB University Skills",
     description:
-      "An educational program that allows users to earn a skill badge after taking a short course and completing an assessment",
+      "Earn a skill badge after taking a short course and completing an assessment",
   },
 ] as const satisfies MongoDbProduct[];
 

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/products.ts
@@ -246,7 +246,7 @@ export const mongoDbProducts = [
     name: "MongoDB Atlas Kubernetes Operator",
     parentProductId: "atlas",
     description:
-      "Manage resources in MongoDB Atlas from an external Kubernetes cluster",
+      "Manage Atlas resources (clusters, projects, database users) directly within a Kubernetes cluster.",
   },
   {
     id: "atlas_gov",
@@ -291,7 +291,7 @@ export const mongoDbProducts = [
     id: "shell",
     name: "MongoDB Shell",
     description:
-      "JavaScript and Node.js REPL for interacting with MongoDB deployments. Also called mongosh",
+      "The MongoDB Shell, mongosh, is a JavaScript and Node.js REPL for interacting with MongoDB databases.",
   },
   {
     id: "mongodb_vscode",
@@ -339,18 +339,19 @@ export const mongoDbProducts = [
     id: "community_kubernetes_operator",
     name: "Community Kubernetes Operator",
     description:
-      "Manage the typical lifecycle events for a Community tier MongoDB cluster deployed to Kubernetes",
+      "[End-of-Life] Deploy applications on replica sets of MongoDB Community.",
   },
   {
     id: "enterprise_kubernetes_operator",
     name: "Kubernetes Operator",
     description:
-      "Manage the typical lifecycle events for a Enterprise Advanced MongoDB cluster deployed to Kubernetes",
+      "[End-of-Life] Deploy and manage an Enterprise Advanced MongoDB cluster on Kubernetes",
   },
   {
-    id: "mck",
+    id: "mongodb_kubernetes_controllers",
     name: "MongoDB Controllers for Kubernetes",
-    description: "Deploy and manage a MongoDB cluster on Kubernetes",
+    description:
+      "MongoDB Kubernetes Operator provisions storage, networking, and users and integrates with Cloud/Ops Manager.",
   },
   {
     id: "relational_migrator",

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/topics.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/topics.ts
@@ -78,8 +78,7 @@ export const mongoDbTopics = [
   {
     id: "search",
     name: "Search",
-    description:
-      "Search capabilities and tools: Full-text, semantic (vector), and hybrid",
+    description: "MongoDB search capabilities and tools",
   },
   {
     id: "troubleshoot_debug",

--- a/packages/mongodb-rag-core/src/mongoDbMetadata/topics.ts
+++ b/packages/mongodb-rag-core/src/mongoDbMetadata/topics.ts
@@ -73,7 +73,7 @@ export const mongoDbTopics = [
   {
     id: "queries",
     name: "Queries",
-    description: "Write and edit MongoDB queries",
+    description: "Write and edit MongoDB CRUD queries and aggregations",
   },
   {
     id: "search",
@@ -94,7 +94,8 @@ export const mongoDbTopics = [
   {
     id: "certificate_exam",
     name: "Certificate Exams",
-    description: "Earn MongoDB certifications by taking skill-assessment exams",
+    description:
+      "Earn formal certificates by taking exams that prove mastery over core MongoDB topics.",
   },
   {
     id: "backup",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-977

Braintrust project: https://www.braintrust.dev/app/mongodb-education-ai/p/classify-mongodb-metadata 

## Changes

- Copies eval cases from `packages/chatbot-server-mongodb-public/src/processors/extractMongoDbMetadataFromUserMessage.eval.ts` to `packages/mongodb-rag-core/src/mongoDbMetadata/classifyMetadata.eval.ts`
- also add topic correct evaluator fxn
- Add topic name/description to topic classification system prompt 
- add more eval cases
