### PR TITLE
MongoDB Responses API spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9092,9 +9092,9 @@
       }
     },
     "node_modules/@langchain/openai/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -25193,9 +25193,9 @@
       }
     },
     "node_modules/braintrust/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -35673,9 +35673,9 @@
       }
     },
     "node_modules/llamaindex/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -54894,9 +54894,9 @@
       "license": "MIT"
     },
     "packages/benchmarks/node_modules/openai": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.47.1.tgz",
-      "integrity": "sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -54905,11 +54905,22 @@
         "agentkeepalive": "^4.2.1",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
+        "node-fetch": "^2.6.7"
       },
       "bin": {
         "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "packages/benchmarks/node_modules/openai/node_modules/@types/node": {
@@ -56091,21 +56102,12 @@
       }
     },
     "packages/mongodb-chatbot-server/node_modules/@langchain/core/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.2.0.tgz",
+      "integrity": "sha512-b+Sf2Yk2eApDkhqHr7C4d5hux9gkHUvyqQ7RrdSfLsjrXkCZpJPqkME0u5Py7RPB28Ozz+RkJZpW7YPTOoChew==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
@@ -56133,17 +56135,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "packages/mongodb-chatbot-server/node_modules/@types/node": {
-      "version": "18.19.86",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
-      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "packages/mongodb-chatbot-server/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
@@ -56167,14 +56158,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "packages/mongodb-chatbot-server/node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "packages/mongodb-chatbot-server/node_modules/ip-address": {
       "version": "8.1.0",
@@ -56464,21 +56447,12 @@
       }
     },
     "packages/mongodb-chatbot-server/node_modules/langchain/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.2.0.tgz",
+      "integrity": "sha512-b+Sf2Yk2eApDkhqHr7C4d5hux9gkHUvyqQ7RrdSfLsjrXkCZpJPqkME0u5Py7RPB28Ozz+RkJZpW7YPTOoChew==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
@@ -58339,7 +58313,7 @@
         "ignore": "^5.3.2",
         "langchain": "^0.3.5",
         "mongodb": "^6.3.0",
-        "openai": "^4.95.0",
+        "openai": "^5.2.0",
         "rimraf": "^6.0.1",
         "simple-git": "^3.27.0",
         "toml": "^3.0.0",
@@ -58955,6 +58929,45 @@
         "@langchain/core": ">=0.2.26 <0.4.0"
       }
     },
+    "packages/mongodb-rag-core/node_modules/@langchain/openai/node_modules/@types/node": {
+      "version": "18.19.111",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
+      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/mongodb-rag-core/node_modules/@langchain/openai/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "packages/mongodb-rag-core/node_modules/@types/jest": {
       "version": "26.0.24",
       "dev": true,
@@ -59192,19 +59205,10 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/openai": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.95.0.tgz",
-      "integrity": "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.2.0.tgz",
+      "integrity": "sha512-b+Sf2Yk2eApDkhqHr7C4d5hux9gkHUvyqQ7RrdSfLsjrXkCZpJPqkME0u5Py7RPB28Ozz+RkJZpW7YPTOoChew==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
@@ -59219,13 +59223,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "packages/mongodb-rag-core/node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.61",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/mongodb-rag-core/node_modules/path-scurry": {
@@ -62008,9 +62005,9 @@
       }
     },
     "packages/release-notes-generator/node_modules/openai": {
-      "version": "4.96.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.0.tgz",
-      "integrity": "sha512-dKoW56i02Prv2XQolJ9Rl9Svqubqkzg3QpwEOBuSVZLk05Shelu7s+ErRTwFc1Bs3JZ2qBqBfVpXQiJhwOGG8A==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -99,7 +99,7 @@
     "ignore": "^5.3.2",
     "langchain": "^0.3.5",
     "mongodb": "^6.3.0",
-    "openai": "^4.95.0",
+    "openai": "^5.2.0",
     "rimraf": "^6.0.1",
     "simple-git": "^3.27.0",
     "toml": "^3.0.0",

--- a/packages/mongodb-rag-core/src/responsesApiSpec.ts
+++ b/packages/mongodb-rag-core/src/responsesApiSpec.ts
@@ -106,7 +106,6 @@ async function main() {
     // Non-streaming
     // Note: consider not supporting this for first pass. Only streaming at first.
     // Also, I don't think will have users any time soon.
-    // There's not a good way to support calling tools and generating the response on the server in non-streaming.
   }
 }
 

--- a/packages/mongodb-rag-core/src/responsesApiSpec.ts
+++ b/packages/mongodb-rag-core/src/responsesApiSpec.ts
@@ -1,0 +1,121 @@
+import { ObjectId } from "mongodb";
+import OpenAI from "openai";
+import { References } from "./References";
+import { Conversation } from "./conversations";
+
+async function main() {
+  //----------------
+  // Data model
+  //----------------
+
+  // Store in database using the same data model as our normal conversations.
+  // Update the model to have a few additional fields:
+  type ResponseConversation = Conversation & {
+    store?: boolean; // true by default
+    userId?: string;
+  };
+
+  //----------------
+  // Calling the API
+  //----------------
+
+  // "mongodb-latest-search" performs RAG under the hood, similar to https://platform.openai.com/docs/guides/tools-web-search
+  // "mongodb-latest" is the standard model. No server-defined RAG
+  type Model = "mongodb-latest-search";
+
+  const options = {
+    model: "mongodb-latest-search",
+    input: "hello",
+    metadata: {
+      // if the client wants to store any conversation metadata, they can do so here.
+      // This metadata is persisted on the server.
+      // For example:
+      conversationId: "CLIENT_DEFINED",
+    },
+    tools: [
+      // Client-defined tool calls here
+      {
+        name: "something_compass_related",
+        parameters: {
+          // client can specify what they want
+        },
+        strict: true,
+        type: "function",
+      },
+    ],
+    user: "CLIENT_DEFINED", // client can define a user ID. saved in database.
+
+    // If the client has a previous response ID, they can pass it in here.
+    // By including this, the server will use the previous response as a context for the new response.
+    // We'll need to add serverside logic to handle finding previous response ID, and adding it to the
+    // messages array.
+    // For MongoDB, can do this by indexing messages.id and then doing an update like
+    // db.collection.updateOne({ "messages.id": "SOME_VALUE"}, {$push: {messages: {role: "assistant", content: "new!"}}})
+    previous_response_id: "SOME_VALUE",
+    store: true, // client defines whether or not to store the messages. If false, only store the metadata.
+  } satisfies OpenAI.Responses.ResponseCreateParams;
+  const oai = new OpenAI();
+
+  // Streaming
+  const streamedRes = await oai.responses.create({
+    ...options,
+    stream: true,
+  });
+
+  const out: Record<string, unknown> & {
+    content: string;
+  } = {
+    content: "",
+  };
+
+  // how request comes back
+  // Based on https://platform.openai.com/docs/api-reference/responses-streaming/response
+  for await (const event of streamedRes) {
+    switch (event.type) {
+      case "response.created":
+        out.id = event.response.id;
+        out.createdAt = event.response.created_at;
+        out.conversationId = event.response.metadata?.conversationId;
+        break;
+      case "response.output_text.delta":
+        out.content += event.delta;
+
+        break;
+      // Note: "response.output_text_annotation.added" supports arbitrary annotations.
+      case "response.output_text_annotation.added":
+        if (
+          event.annotation &&
+          typeof event.annotation === "object" &&
+          "type" in event.annotation &&
+          typeof event.annotation.type === "string"
+        ) {
+          if (event.annotation.type === "references") {
+            out.references = (
+              event.annotation as ReferencesAnnotation
+            ).references;
+          }
+          if (event.annotation.type === "verified_answer") {
+            out.isVerified = (
+              event.annotation as VerifiedAnswerAnnotation
+            ).isVerified;
+          }
+        }
+        break;
+    }
+
+    // Non-streaming
+    // Note: consider not supporting this for first pass. Only streaming at first.
+    // Also, I don't think will have users any time soon.
+    // There's not a good way to support calling tools and generating the response on the server in non-streaming.
+  }
+}
+
+type VerifiedAnswerAnnotation = {
+  type: "verified_answer";
+  isVerified: true;
+};
+
+type ReferencesAnnotation = {
+  type: "references";
+  references: References;
+};


### PR DESCRIPTION
Jira: n/a

## Changes

- Lite specification of new MongoDB Responses API
- This spec supports both the stateful use case, a la docs chatbot and newer stateless ones like what we're proposing for compass

## Notes

- Conformant to the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
- Note that this is instead of doing a chat completions API, which wouldn't work well for our desire for custom server-side tools or persisting conversations.
