### PR TITLE
(EAI-1112): Segment tracing fix

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.test.ts
@@ -128,4 +128,110 @@ describe("extractTracingData", () => {
     expect(tracingData.userMessageIndex).toBe(0);
     expect(tracingData.assistantMessageIndex).toBe(1);
   });
+
+  test("should extract origin from customData", () => {
+    const messagesWithOrigin: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {
+          origin: "https://example.com/chat",
+        },
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesWithOrigin,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.origin).toBe("https://example.com/chat");
+  });
+
+  test("should handle missing origin", () => {
+    const messagesNoOrigin: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {},
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesNoOrigin,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.origin).toBeUndefined();
+  });
+
+  test("should handle non-string origin", () => {
+    const messagesInvalidOrigin: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {
+          origin: 123, // non-string value
+        },
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesInvalidOrigin,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.origin).toBeUndefined();
+  });
+
+  test("should extract rejectionReason from customData", () => {
+    const messagesWithRejection: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {
+          rejectionReason: "Query contains inappropriate content",
+        },
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesWithRejection,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.rejectionReason).toBe(
+      "Query contains inappropriate content"
+    );
+  });
+
+  test("should use default rejection reason when missing", () => {
+    const messagesNoRejection: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {},
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesNoRejection,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.rejectionReason).toBe("Unknown rejection reason");
+  });
+
+  test("should use default rejection reason for non-string value", () => {
+    const messagesInvalidRejection: Message[] = [
+      {
+        ...baseUserMessage,
+        customData: {
+          rejectionReason: { reason: "complex object" }, // non-string value
+        },
+      },
+      baseAssistantMessage,
+    ];
+    const tracingData = extractTracingData(
+      messagesInvalidRejection,
+      msgId,
+      conversationId
+    );
+    expect(tracingData.rejectionReason).toBe("Unknown rejection reason");
+  });
 });

--- a/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/extractTracingData.ts
@@ -76,10 +76,20 @@ export function extractTracingData(
   const rating = evalAssistantMessage.rating;
   const comment = evalAssistantMessage.userComment;
 
+  const maybeOrigin = previousUserMessage.customData?.origin;
+  const origin = typeof maybeOrigin === "string" ? maybeOrigin : undefined;
+
+  const maybeRejectionReason = previousUserMessage.customData?.rejectionReason;
+  const rejectionReason =
+    typeof maybeRejectionReason === "string"
+      ? maybeRejectionReason
+      : "Unknown rejection reason";
+
   return {
     conversationId: conversationId,
     tags,
     rejectQuery,
+    rejectionReason,
     isVerifiedAnswer,
     llmDoesNotKnow,
     numRetrievedChunks,
@@ -88,6 +98,7 @@ export function extractTracingData(
     userMessageIndex: previousUserMessageIdx,
     assistantMessage: evalAssistantMessage,
     assistantMessageIndex: evalAssistantMessageIdx,
+    origin,
     rating,
     comment,
   };

--- a/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/routesUpdateTraceHandlers.ts
@@ -141,7 +141,7 @@ ${tracingData.assistantMessage?.content}
           userId,
           anonymousId,
           conversationId: conversation._id,
-          origin: userMessage.customData?.origin as string,
+          origin: tracingData.origin,
           createdAt: userMessage.createdAt,
           tags: tracingData.tags,
         });
@@ -159,13 +159,10 @@ ${tracingData.assistantMessage?.content}
           userId,
           anonymousId,
           conversationId: conversation._id,
-          origin: userMessage.customData?.origin as string,
+          origin: tracingData.origin,
           createdAt: assistantMessage.createdAt,
           isVerifiedAnswer: tracingData.isVerifiedAnswer ?? false,
-          rejectionReason: tracingData.rejectQuery
-            ? (userMessage.customData?.rejectionReason as string | undefined) ??
-              "Unknown rejection reason"
-            : undefined,
+          rejectionReason: tracingData.rejectionReason,
         });
       } else {
         throw new Error(
@@ -311,7 +308,7 @@ export function makeRateMessageUpdateTrace({
           userId,
           anonymousId,
           conversationId: conversation._id,
-          origin: userMessage.customData?.origin as string,
+          origin: tracingData.origin,
           createdAt: new Date(),
           rating,
         });
@@ -447,7 +444,7 @@ export function makeCommentMessageUpdateTrace({
           userId,
           anonymousId,
           conversationId: conversation._id,
-          origin: userMessage.customData?.origin as string,
+          origin: tracingData.origin,
           createdAt: new Date(),
           rating,
           comment,

--- a/packages/chatbot-server-mongodb-public/src/tracing/segment.ts
+++ b/packages/chatbot-server-mongodb-public/src/tracing/segment.ts
@@ -78,7 +78,7 @@ const BaseTrackEventParamsSchema = z.object({
   userId: z.string().optional(),
   anonymousId: z.string().optional(),
   conversationId: z.instanceof(ObjectId),
-  origin: z.string(),
+  origin: z.string().optional(),
   createdAt: z.date(),
 });
 

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.test.ts
@@ -6,6 +6,8 @@ import {
   defaultConversationConstants,
   Message,
   SomeMessage,
+  DbMessage,
+  UserMessage,
 } from "mongodb-rag-core";
 import { Express } from "express";
 import {
@@ -20,7 +22,10 @@ import { makeTestApp } from "../../test/testHelpers";
 import { AppConfig } from "../../app";
 import { strict as assert } from "assert";
 import { Db, ObjectId } from "mongodb-rag-core/mongodb";
-import { mockAssistantResponse } from "../../test/testConfig";
+import {
+  generateResponseCustomData,
+  mockAssistantResponse,
+} from "../../test/testConfig";
 
 jest.setTimeout(100000);
 describe("POST /conversations/:conversationId/messages", () => {
@@ -105,13 +110,15 @@ describe("POST /conversations/:conversationId/messages", () => {
       _id: new ObjectId(conversationId),
     });
     assert(conversation);
-    const userMessageWithCustomData =
-      conversation.messages[conversation.messages.length - 2];
+    const userMessageWithCustomData = conversation.messages.findLast(
+      (m): m is DbMessage<UserMessage> => m.role === "user"
+    );
     expect(userMessageWithCustomData?.customData).toStrictEqual({
       ip: ipAddress,
       origin,
       originCode: "OTHER",
       userAgent: "test-user-agent",
+      ...generateResponseCustomData,
     });
   });
   test("uses previous message filter", async () => {

--- a/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
+++ b/packages/mongodb-chatbot-server/src/routes/conversations/addMessageToConversation.ts
@@ -266,6 +266,11 @@ export function makeAddMessageToConversationRoute({
         traceId: assistantResponseMessageId.toHexString(),
       });
 
+      // Add custom data to user message.
+      // Override with custom data defined in the route.
+      const userMessage = messages[0];
+      userMessage.customData = { ...customData, ...userMessage.customData };
+
       // --- SAVE QUESTION & RESPONSE ---
       const dbNewMessages = await addMessagesToDatabase({
         conversations,

--- a/packages/mongodb-chatbot-server/src/test/testConfig.ts
+++ b/packages/mongodb-chatbot-server/src/test/testConfig.ts
@@ -130,6 +130,10 @@ export const mockAssistantResponse = {
   content: "some content",
 };
 
+export const generateResponseCustomData = {
+  foo: "bar",
+};
+
 export const mockGenerateResponse: GenerateResponse = async ({
   latestMessageText,
   customData,
@@ -160,7 +164,7 @@ export const mockGenerateResponse: GenerateResponse = async ({
       {
         role: "user" as const,
         content: latestMessageText,
-        customData,
+        customData: generateResponseCustomData,
       },
       { ...mockAssistantResponse },
     ],


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1112

## Changes

- Fix bug where not including the addCustomDataFunc `UserMessage.customData` if not in the `GenerateResponse` func
- Have tracing and Segment tracing specifically more elegantly handle if origin not provided. 
  - Remove casting `as string`

## Notes

-
