### PR TITLE
Handle messages for responses

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -388,15 +388,11 @@ export const config: AppConfig = {
   },
   responsesRouterConfig: {
     createResponse: {
+      conversations,
+      generateResponse,
       supportedModels: ["mongodb-chat-latest"],
       maxOutputTokens: 4000,
-      generateResponse: () =>
-        Promise.resolve({
-          messages: [
-            { role: "user", content: "What is MongoDB?" },
-            { role: "assistant", content: "MongoDB is a database." },
-          ],
-        }),
+      maxUserMessagesInConversation: 6,
     },
   },
   maxRequestTimeoutMs: 60000,

--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
@@ -5,15 +5,7 @@ import { DEFAULT_API_PREFIX } from "../../app";
 import { makeTestApp } from "../../test/testHelpers";
 import { MONGO_CHAT_MODEL } from "../../test/testConfig";
 import { ERROR_TYPE, ERROR_CODE } from "./errors";
-import {
-  INPUT_STRING_ERR_MSG,
-  INPUT_ARRAY_ERR_MSG,
-  METADATA_LENGTH_ERR_MSG,
-  TEMPERATURE_ERR_MSG,
-  STREAM_ERR_MSG,
-  MODEL_NOT_SUPPORTED_ERR_MSG,
-  MAX_OUTPUT_TOKENS_ERR_MSG,
-} from "./createResponse";
+import { ERR_MSG } from "./createResponse";
 
 jest.setTimeout(100000);
 
@@ -351,7 +343,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(`Path: body.input - ${INPUT_STRING_ERR_MSG}`)
+        badRequestError(`Path: body.input - ${ERR_MSG.INPUT_STRING}`)
       );
     });
 
@@ -368,7 +360,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(`Path: body.input - ${INPUT_ARRAY_ERR_MSG}`)
+        badRequestError(`Path: body.input - ${ERR_MSG.INPUT_ARRAY}`)
       );
     });
 
@@ -385,7 +377,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(MODEL_NOT_SUPPORTED_ERR_MSG("gpt-4o-mini"))
+        badRequestError(ERR_MSG.MODEL_NOT_SUPPORTED("gpt-4o-mini"))
       );
     });
 
@@ -402,7 +394,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(`Path: body.stream - ${STREAM_ERR_MSG}`)
+        badRequestError(`Path: body.stream - ${ERR_MSG.STREAM}`)
       );
     });
 
@@ -422,7 +414,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(MAX_OUTPUT_TOKENS_ERR_MSG(max_output_tokens, 4000))
+        badRequestError(ERR_MSG.MAX_OUTPUT_TOKENS(max_output_tokens, 4000))
       );
     });
 
@@ -444,7 +436,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(`Path: body.metadata - ${METADATA_LENGTH_ERR_MSG}`)
+        badRequestError(`Path: body.metadata - ${ERR_MSG.METADATA_LENGTH}`)
       );
     });
 
@@ -482,7 +474,7 @@ describe("POST /responses", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toEqual(
-        badRequestError(`Path: body.temperature - ${TEMPERATURE_ERR_MSG}`)
+        badRequestError(`Path: body.temperature - ${ERR_MSG.TEMPERATURE}`)
       );
     });
 

--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { Express } from "express";
 import { DEFAULT_API_PREFIX, type AppConfig } from "../../app";
 import { makeTestApp } from "../../test/testHelpers";
-import { MONGO_CHAT_MODEL } from "../../test/testConfig";
+import { basicResponsesRequestBody } from "../../test/testConfig";
 import { ERROR_TYPE, ERROR_CODE } from "./errors";
 import { ERR_MSG } from "./createResponse";
 
@@ -32,11 +32,7 @@ describe("POST /responses", () => {
         .post(endpointUrl)
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
-        .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
-        });
+        .send(basicResponsesRequestBody);
 
       expect(response.statusCode).toBe(200);
     });
@@ -47,8 +43,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             { role: "system", content: "You are a helpful assistant." },
             { role: "user", content: "What is MongoDB?" },
@@ -66,9 +61,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           instructions: "You are a helpful chatbot.",
         });
 
@@ -81,9 +74,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           max_output_tokens: 4000,
         });
 
@@ -96,9 +87,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           metadata: { key1: "value1", key2: "value2" },
         });
 
@@ -111,9 +100,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           temperature: 0,
         });
 
@@ -132,9 +119,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           previous_response_id: previousResponseId,
         });
 
@@ -147,9 +132,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           user: "some-user-id",
         });
 
@@ -162,9 +145,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           store: false,
         });
 
@@ -177,9 +158,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           store: true,
         });
 
@@ -192,9 +171,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tools: [
             {
               name: "test-tool",
@@ -220,9 +197,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tools: [
             {
               name: "test-tool",
@@ -251,8 +226,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             { role: "user", content: "What is MongoDB?" },
             {
@@ -274,8 +248,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             { role: "user", content: "What is MongoDB?" },
             {
@@ -296,9 +269,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tool_choice: "none",
         });
 
@@ -311,9 +282,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tool_choice: "only",
         });
 
@@ -326,9 +295,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tools: [],
         });
 
@@ -343,8 +310,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: "",
         });
 
@@ -360,8 +326,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [],
         });
 
@@ -377,9 +342,8 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
+          ...basicResponsesRequestBody,
           model: "gpt-4o-mini",
-          stream: true,
-          input: "What is MongoDB?",
         });
 
       expect(response.statusCode).toBe(400);
@@ -394,9 +358,8 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
+          ...basicResponsesRequestBody,
           stream: false,
-          input: "What is MongoDB?",
         });
 
       expect(response.statusCode).toBe(400);
@@ -413,9 +376,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           max_output_tokens,
         });
 
@@ -435,9 +396,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           metadata,
         });
 
@@ -453,9 +412,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           metadata: { key1: "a".repeat(513) },
         });
 
@@ -473,9 +430,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           temperature: 0.5,
         });
 
@@ -491,8 +446,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             { role: "user", content: "What is MongoDB?" },
             { role: "invalid-role", content: "This is an invalid role." },
@@ -510,8 +464,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             {
               type: "function_call",
@@ -534,8 +487,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
+          ...basicResponsesRequestBody,
           input: [
             {
               type: "function_call_output",
@@ -557,9 +509,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           tool_choice: "invalid_choice",
         });
 
@@ -575,9 +525,7 @@ describe("POST /responses", () => {
         .set("X-Forwarded-For", ipAddress)
         .set("Origin", origin)
         .send({
-          model: MONGO_CHAT_MODEL,
-          stream: true,
-          input: "What is MongoDB?",
+          ...basicResponsesRequestBody,
           max_output_tokens: -1,
         });
 

--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.test.ts
@@ -398,5 +398,31 @@ describe("POST /responses", () => {
         )
       );
     });
+
+    it("Should return 400 if previous_response_id is not a valid object id", async () => {
+      const messageId = "some-id";
+
+      const response = await makeRequest({
+        previous_response_id: messageId,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error).toEqual(
+        badRequestError(ERR_MSG.INVALID_OBJECT_ID(messageId))
+      );
+    });
+
+    it("Should return 400 if previous_response_id is not found", async () => {
+      const messageId = "123456789012123456789012";
+
+      const response = await makeRequest({
+        previous_response_id: messageId,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error).toEqual(
+        badRequestError(ERR_MSG.MESSAGE_NOT_FOUND(messageId))
+      );
+    });
   });
 });

--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
@@ -15,22 +15,24 @@ import {
   ERROR_TYPE,
 } from "./errors";
 
-export const INPUT_STRING_ERR_MSG = "Input must be a non-empty string";
-export const INPUT_ARRAY_ERR_MSG =
-  "Input must be a string or array of messages. See https://platform.openai.com/docs/api-reference/responses/create#responses-create-input for more information.";
-export const METADATA_LENGTH_ERR_MSG = "Too many metadata fields. Max 16.";
-export const TEMPERATURE_ERR_MSG = "Temperature must be 0 or unset";
-export const STREAM_ERR_MSG = "'stream' must be true";
-export const MODEL_NOT_SUPPORTED_ERR_MSG = (model: string) =>
-  `Path: body.model - ${model} is not supported.`;
-export const MAX_OUTPUT_TOKENS_ERR_MSG = (input: number, max: number) =>
-  `Path: body.max_output_tokens - ${input} is greater than the maximum allowed ${max}.`;
+export const ERR_MSG = {
+  INPUT_STRING: "Input must be a non-empty string",
+  INPUT_ARRAY:
+    "Input must be a string or array of messages. See https://platform.openai.com/docs/api-reference/responses/create#responses-create-input for more information.",
+  METADATA_LENGTH: "Too many metadata fields. Max 16.",
+  TEMPERATURE: "Temperature must be 0 or unset",
+  STREAM: "'stream' must be true",
+  MODEL_NOT_SUPPORTED: (model: string) =>
+    `Path: body.model - ${model} is not supported.`,
+  MAX_OUTPUT_TOKENS: (input: number, max: number) =>
+    `Path: body.max_output_tokens - ${input} is greater than the maximum allowed ${max}.`,
+};
 
 const CreateResponseRequestBodySchema = z.object({
   model: z.string(),
   instructions: z.string().optional(),
   input: z.union([
-    z.string().refine((input) => input.length > 0, INPUT_STRING_ERR_MSG),
+    z.string().refine((input) => input.length > 0, ERR_MSG.INPUT_STRING),
     z
       .array(
         z.union([
@@ -73,7 +75,7 @@ const CreateResponseRequestBodySchema = z.object({
           }),
         ])
       )
-      .refine((input) => input.length > 0, INPUT_ARRAY_ERR_MSG),
+      .refine((input) => input.length > 0, ERR_MSG.INPUT_ARRAY),
   ]),
   max_output_tokens: z.number().min(0).default(1000),
   metadata: z
@@ -81,7 +83,7 @@ const CreateResponseRequestBodySchema = z.object({
     .optional()
     .refine(
       (metadata) => Object.keys(metadata ?? {}).length <= 16,
-      METADATA_LENGTH_ERR_MSG
+      ERR_MSG.METADATA_LENGTH
     ),
   previous_response_id: z
     .string()
@@ -92,10 +94,10 @@ const CreateResponseRequestBodySchema = z.object({
     .optional()
     .describe("Whether to store the response in the conversation.")
     .default(true),
-  stream: z.boolean().refine((stream) => stream, STREAM_ERR_MSG),
+  stream: z.boolean().refine((stream) => stream, ERR_MSG.STREAM),
   temperature: z
     .number()
-    .refine((temperature) => temperature === 0, TEMPERATURE_ERR_MSG)
+    .refine((temperature) => temperature === 0, ERR_MSG.TEMPERATURE)
     .optional()
     .describe("Temperature for the model. Defaults to 0.")
     .default(0),
@@ -176,7 +178,7 @@ export function makeCreateResponseRoute({
       // --- MODEL CHECK ---
       if (!supportedModels.includes(model)) {
         throw makeBadRequestError({
-          error: new Error(MODEL_NOT_SUPPORTED_ERR_MSG(model)),
+          error: new Error(ERR_MSG.MODEL_NOT_SUPPORTED(model)),
           headers,
         });
       }
@@ -185,7 +187,7 @@ export function makeCreateResponseRoute({
       if (max_output_tokens > maxOutputTokens) {
         throw makeBadRequestError({
           error: new Error(
-            MAX_OUTPUT_TOKENS_ERR_MSG(max_output_tokens, maxOutputTokens)
+            ERR_MSG.MAX_OUTPUT_TOKENS(max_output_tokens, maxOutputTokens)
           ),
           headers,
         });

--- a/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.test.ts
@@ -3,7 +3,7 @@ import { AppConfig } from "../../app";
 import { DEFAULT_API_PREFIX } from "../../app";
 import { makeTestApp } from "../../test/testHelpers";
 import { makeTestAppConfig } from "../../test/testHelpers";
-import { MONGO_CHAT_MODEL } from "../../test/testConfig";
+import { basicResponsesRequestBody } from "../../test/testConfig";
 import { ERROR_TYPE, ERROR_CODE, makeBadRequestError } from "./errors";
 
 jest.setTimeout(60000);
@@ -11,11 +11,6 @@ jest.setTimeout(60000);
 describe("Responses Router", () => {
   const ipAddress = "127.0.0.1";
   const responsesEndpoint = DEFAULT_API_PREFIX + "/responses";
-  const validRequestBody = {
-    model: MONGO_CHAT_MODEL,
-    stream: true,
-    input: "What is MongoDB?",
-  };
   let appConfig: AppConfig;
 
   beforeAll(async () => {
@@ -29,7 +24,7 @@ describe("Responses Router", () => {
       .post(responsesEndpoint)
       .set("X-FORWARDED-FOR", ipAddress)
       .set("Origin", origin)
-      .send(validRequestBody);
+      .send(basicResponsesRequestBody);
 
     expect(res.status).toBe(200);
   });
@@ -51,7 +46,7 @@ describe("Responses Router", () => {
       .post(responsesEndpoint)
       .set("X-FORWARDED-FOR", ipAddress)
       .set("Origin", origin)
-      .send(validRequestBody);
+      .send(basicResponsesRequestBody);
 
     expect(res.status).toBe(500);
     expect(res.body.type).toBe(ERROR_TYPE);
@@ -86,7 +81,7 @@ describe("Responses Router", () => {
       .post(responsesEndpoint)
       .set("X-FORWARDED-FOR", ipAddress)
       .set("Origin", origin)
-      .send(validRequestBody);
+      .send(basicResponsesRequestBody);
 
     expect(res.status).toBe(400);
     expect(res.body.type).toBe(ERROR_TYPE);
@@ -117,13 +112,13 @@ describe("Responses Router", () => {
       .post(responsesEndpoint)
       .set("X-FORWARDED-FOR", ipAddress)
       .set("Origin", origin)
-      .send(validRequestBody);
+      .send(basicResponsesRequestBody);
 
     const rateLimitedRes = await request(app)
       .post(responsesEndpoint)
       .set("X-FORWARDED-FOR", ipAddress)
       .set("Origin", origin)
-      .send(validRequestBody);
+      .send(basicResponsesRequestBody);
 
     expect(successRes.status).toBe(200);
     expect(successRes.error).toBeFalsy();

--- a/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.test.ts
@@ -23,22 +23,7 @@ describe("Responses Router", () => {
   });
 
   it("should return 200 given a valid request", async () => {
-    const { app, origin } = await makeTestApp({
-      ...appConfig,
-      responsesRouterConfig: {
-        createResponse: {
-          supportedModels: [MONGO_CHAT_MODEL],
-          maxOutputTokens: 4000,
-          generateResponse: () =>
-            Promise.resolve({
-              messages: [
-                { role: "user", content: "What is MongoDB?" },
-                { role: "assistant", content: "MongoDB is a database." },
-              ],
-            }),
-        },
-      },
-    });
+    const { app, origin } = await makeTestApp(appConfig);
 
     const res = await request(app)
       .post(responsesEndpoint)
@@ -54,9 +39,9 @@ describe("Responses Router", () => {
     const { app, origin } = await makeTestApp({
       ...appConfig,
       responsesRouterConfig: {
+        ...appConfig.responsesRouterConfig,
         createResponse: {
-          supportedModels: [MONGO_CHAT_MODEL],
-          maxOutputTokens: 4000,
+          ...appConfig.responsesRouterConfig.createResponse,
           generateResponse: () => Promise.reject(new Error(errorMessage)),
         },
       },
@@ -83,9 +68,9 @@ describe("Responses Router", () => {
     const { app, origin } = await makeTestApp({
       ...appConfig,
       responsesRouterConfig: {
+        ...appConfig.responsesRouterConfig,
         createResponse: {
-          supportedModels: [MONGO_CHAT_MODEL],
-          maxOutputTokens: 4000,
+          ...appConfig.responsesRouterConfig.createResponse,
           generateResponse: () =>
             Promise.reject(
               makeBadRequestError({

--- a/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/responsesRouter.ts
@@ -1,4 +1,5 @@
 import Router from "express-promise-router";
+import type { ConversationsService } from "mongodb-rag-core";
 import { makeCreateResponseRoute } from "./createResponse";
 import type { GenerateResponse } from "../../processors";
 import { getRequestId } from "../../utils";
@@ -16,9 +17,11 @@ export interface ResponsesRouterParams {
     routerSlowDownConfig?: SlowDownOptions;
   };
   createResponse: {
+    conversations: ConversationsService;
     generateResponse: GenerateResponse;
     supportedModels: string[];
     maxOutputTokens: number;
+    maxUserMessagesInConversation: number;
   };
 }
 

--- a/packages/mongodb-chatbot-server/src/test/testConfig.ts
+++ b/packages/mongodb-chatbot-server/src/test/testConfig.ts
@@ -182,15 +182,11 @@ export async function makeDefaultConfig(): Promise<AppConfig> {
     },
     responsesRouterConfig: {
       createResponse: {
+        conversations,
+        generateResponse: mockGenerateResponse,
         supportedModels: [MONGO_CHAT_MODEL],
         maxOutputTokens: 4000,
-        generateResponse: () =>
-          Promise.resolve({
-            messages: [
-              { role: "user", content: "What is MongoDB?" },
-              { role: "assistant", content: "MongoDB is a database." },
-            ],
-          }),
+        maxUserMessagesInConversation: 6,
       },
     },
     maxRequestTimeoutMs: 30000,

--- a/packages/mongodb-chatbot-server/src/test/testConfig.ts
+++ b/packages/mongodb-chatbot-server/src/test/testConfig.ts
@@ -173,6 +173,12 @@ export const mockGenerateResponse: GenerateResponse = async ({
 
 export const MONGO_CHAT_MODEL = "mongodb-chat-latest";
 
+export const basicResponsesRequestBody = {
+  model: MONGO_CHAT_MODEL,
+  stream: true,
+  input: "What is MongoDB?",
+};
+
 export async function makeDefaultConfig(): Promise<AppConfig> {
   const conversations = makeMongoDbConversationsService(memoryDb);
   return {

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -32,7 +32,6 @@
     "./mongodb": "./build/mongodb.js",
     "./mongoDbMetadata": "./build/mongoDbMetadata/index.js",
     "./openai": "./build/openai.js",
-    "./aiSdk": "./build/aiSdk.js",
     "./braintrust": "./build/braintrust.js",
     "./dataSources": "./build/dataSources/index.js",
     "./models": "./build/models/index.js",

--- a/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
+++ b/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
@@ -213,6 +213,9 @@ export type AddManyConversationMessagesParams = {
 export interface FindByIdParams {
   _id: ObjectId;
 }
+export interface FindByMessageIdParams {
+  messageId: ObjectId;
+}
 export interface RateMessageParams {
   conversationId: ObjectId;
   messageId: ObjectId;
@@ -263,6 +266,13 @@ export interface ConversationsService {
     params: AddManyConversationMessagesParams
   ) => Promise<Message[]>;
   findById: ({ _id }: FindByIdParams) => Promise<Conversation | null>;
+
+  /**
+    Find a {@link Conversation} by the id of a {@link Message} in the conversation.
+   */
+  findByMessageId: ({
+    messageId,
+  }: FindByMessageIdParams) => Promise<Conversation | null>;
 
   /**
     Rate a {@link Message} in a {@link Conversation}.

--- a/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
+++ b/packages/mongodb-rag-core/src/conversations/ConversationsService.ts
@@ -249,6 +249,11 @@ export interface ConversationsService {
   conversationConstants: ConversationConstants;
 
   /**
+    Initialize the conversations service.
+   */
+  init: () => Promise<void>;
+
+  /**
     Create a new {@link Conversation}.
    */
   create: (params?: CreateConversationParams) => Promise<Conversation>;

--- a/packages/mongodb-rag-core/src/conversations/MongoDbConversations.test.ts
+++ b/packages/mongodb-rag-core/src/conversations/MongoDbConversations.test.ts
@@ -202,15 +202,20 @@ describe("Conversations Service", () => {
     expect(conversationInDb).toBeNull();
   });
   test("should find a conversation by message id", async () => {
-    // TODO: implement
-    expect(true).toBe(false);
+    const conversation = await conversationsService.create({
+      initialMessages: [systemPrompt],
+    });
+    const messageId = conversation.messages[0].id;
+    const conversationInDb = await conversationsService.findByMessageId({
+      messageId,
+    });
+    expect(conversationInDb).toEqual(conversation);
   });
   test("should return null if cannot find a conversation by message id", async () => {
-    // const conversationInDb = await conversationsService.findByMessageId({
-    //   messageId: new BSON.ObjectId(),
-    // });
-    // expect(conversationInDb).toBeNull();
-    expect(true).toBe(false);
+    const conversationInDb = await conversationsService.findByMessageId({
+      messageId: new BSON.ObjectId(),
+    });
+    expect(conversationInDb).toBeNull();
   });
   test("Should rate a message", async () => {
     const { _id: conversationId } = await conversationsService.create({

--- a/packages/mongodb-rag-core/src/conversations/MongoDbConversations.test.ts
+++ b/packages/mongodb-rag-core/src/conversations/MongoDbConversations.test.ts
@@ -204,6 +204,17 @@ describe("Conversations Service", () => {
     });
     expect(conversationInDb).toBeNull();
   });
+  test("should find a conversation by message id", async () => {
+    // TODO: implement
+    expect(true).toBe(false);
+  });
+  test("should return null if cannot find a conversation by message id", async () => {
+    // const conversationInDb = await conversationsService.findByMessageId({
+    //   messageId: new BSON.ObjectId(),
+    // });
+    // expect(conversationInDb).toBeNull();
+    expect(true).toBe(false);
+  });
   test("Should rate a message", async () => {
     const { _id: conversationId } = await conversationsService.create({
       initialMessages: [systemPrompt],

--- a/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
+++ b/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
@@ -23,6 +23,13 @@ export function makeMongoDbConversationsService(
     database.collection<Conversation>("conversations");
   return {
     conversationConstants,
+
+    async init() {
+      await conversationsCollection.createIndex("messages.id");
+      // NOTE: createdAt index is only used via the production collection
+      await conversationsCollection.createIndex("createdAt");
+    },
+
     async create(params) {
       const customData = params?.customData;
       const initialMessages = params?.initialMessages;

--- a/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
+++ b/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
@@ -4,18 +4,12 @@ import {
   defaultConversationConstants,
   ConversationsService,
   Conversation,
-  CreateConversationParams,
-  AddConversationMessageParams,
-  FindByIdParams,
-  RateMessageParams,
   Message,
   UserMessage,
-  AddManyConversationMessagesParams,
-  AddSomeMessageParams,
   AssistantMessage,
   SystemMessage,
-  CommentMessageParams,
   ToolMessage,
+  AddSomeMessageParams,
 } from "./ConversationsService";
 
 /**
@@ -29,7 +23,7 @@ export function makeMongoDbConversationsService(
     database.collection<Conversation>("conversations");
   return {
     conversationConstants,
-    async create(params?: CreateConversationParams) {
+    async create(params) {
       const customData = params?.customData;
       const initialMessages = params?.initialMessages;
       const newConversation = {
@@ -56,7 +50,7 @@ export function makeMongoDbConversationsService(
       return newConversation;
     },
 
-    async addConversationMessage(params: AddConversationMessageParams) {
+    async addConversationMessage(params) {
       const { conversationId, message } = params;
       const newMessage = createMessage(message);
       const updateResult = await conversationsCollection.updateOne(
@@ -75,9 +69,7 @@ export function makeMongoDbConversationsService(
       return newMessage;
     },
 
-    async addManyConversationMessages(
-      params: AddManyConversationMessagesParams
-    ) {
+    async addManyConversationMessages(params) {
       const { messages, conversationId } = params;
       const newMessages = messages.map(createMessage);
       const updateResult = await conversationsCollection.updateOne(
@@ -98,7 +90,7 @@ export function makeMongoDbConversationsService(
       return newMessages;
     },
 
-    async findById({ _id }: FindByIdParams) {
+    async findById({ _id }) {
       const conversation = await conversationsCollection.findOne({ _id });
       return conversation;
     },
@@ -132,11 +124,7 @@ export function makeMongoDbConversationsService(
       return true;
     },
 
-    async commentMessage({
-      conversationId,
-      messageId,
-      comment,
-    }: CommentMessageParams) {
+    async commentMessage({ conversationId, messageId, comment }) {
       const updateResult = await conversationsCollection.updateOne(
         {
           _id: conversationId,

--- a/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
+++ b/packages/mongodb-rag-core/src/conversations/MongoDbConversations.ts
@@ -103,11 +103,14 @@ export function makeMongoDbConversationsService(
       return conversation;
     },
 
-    async rateMessage({
-      conversationId,
-      messageId,
-      rating,
-    }: RateMessageParams) {
+    async findByMessageId({ messageId }) {
+      const conversation = await conversationsCollection.findOne({
+        "messages.id": messageId,
+      });
+      return conversation;
+    },
+
+    async rateMessage({ conversationId, messageId, rating }) {
       const updateResult = await conversationsCollection.updateOne(
         {
           _id: conversationId,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1123

## Changes

- add findByMessageId to conversation service in rag-core
- add logic for fetching previous conversation by messageId to chat-server

## Notes

- only thing this needs is some slight cleanup around one spot with duplicated logic (called out with TODO)
