### PR TITLE
(EAI-1153) fix eval experiments

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/eval/ConversationEval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/ConversationEval.ts
@@ -264,7 +264,7 @@ export async function makeConversationEval({
         });
 
         const { rejectQuery, userMessage, contextContent, assistantMessage } =
-          extractTracingData(mockDbMessages, id);
+          extractTracingData(mockDbMessages, id, new ObjectId());
         assert(assistantMessage, "No assistant message found");
         assert(contextContent, "No context content found");
         assert(userMessage, "No user message found");

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/allScorersTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/allScorersTest.eval.ts
@@ -10,8 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { systemPrompt } from "../../systemPrompt";
-import { config, conversations } from "../../config";
+import { generateResponse } from "../../config";
 
 async function conversationEval() {
   // Get all the conversation eval cases from YAML
@@ -19,17 +18,6 @@ async function conversationEval() {
   const conversationEvalCases = getConversationsEvalCasesFromYaml(
     fs.readFileSync(path.resolve(basePath, "all_scorers.yml"), "utf8")
   );
-
-  const generateConfig = {
-    systemPrompt,
-    llm: config.conversationsRouterConfig.llm,
-    llmNotWorkingMessage: conversations.conversationConstants.LLM_NOT_WORKING,
-    noRelevantContentMessage:
-      conversations.conversationConstants.NO_RELEVANT_CONTENT,
-    filterPreviousMessages:
-      config.conversationsRouterConfig.filterPreviousMessages,
-    generateUserPrompt: config.conversationsRouterConfig.generateUserPrompt,
-  };
 
   // Run the conversation eval
   makeConversationEval({
@@ -49,7 +37,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generate: generateConfig,
+    generateResponse,
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/architectureCenter.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/architectureCenter.eval.ts
@@ -10,8 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { systemPrompt } from "../../systemPrompt";
-import { config, conversations } from "../../config";
+import { generateResponse } from "../../config";
 
 async function conversationEval() {
   // Get ONLY architecture center conversations
@@ -19,17 +18,6 @@ async function conversationEval() {
   const conversationEvalCases = getConversationsEvalCasesFromYaml(
     fs.readFileSync(path.resolve(basePath, "conversations.yml"), "utf8")
   ).filter((c) => c.tags?.includes("atlas-architecture"));
-
-  const generateConfig = {
-    systemPrompt,
-    llm: config.conversationsRouterConfig.llm,
-    llmNotWorkingMessage: conversations.conversationConstants.LLM_NOT_WORKING,
-    noRelevantContentMessage:
-      conversations.conversationConstants.NO_RELEVANT_CONTENT,
-    filterPreviousMessages:
-      config.conversationsRouterConfig.filterPreviousMessages,
-    generateUserPrompt: config.conversationsRouterConfig.generateUserPrompt,
-  };
 
   // Run the conversation eval
   makeConversationEval({
@@ -49,7 +37,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generate: generateConfig,
+    generateResponse,
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/dotcomQuestionsTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/dotcomQuestionsTest.eval.ts
@@ -10,8 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { systemPrompt } from "../../systemPrompt";
-import { config, conversations } from "../../config";
+import { generateResponse } from "../../config";
 
 async function conversationEval() {
   // Get dotcom question set eval cases from YAML
@@ -22,17 +21,6 @@ async function conversationEval() {
       "utf8"
     )
   );
-
-  const generateConfig = {
-    systemPrompt,
-    llm: config.conversationsRouterConfig.llm,
-    llmNotWorkingMessage: conversations.conversationConstants.LLM_NOT_WORKING,
-    noRelevantContentMessage:
-      conversations.conversationConstants.NO_RELEVANT_CONTENT,
-    filterPreviousMessages:
-      config.conversationsRouterConfig.filterPreviousMessages,
-    generateUserPrompt: config.conversationsRouterConfig.generateUserPrompt,
-  };
 
   // Run the conversation eval
   makeConversationEval({
@@ -52,7 +40,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generate: generateConfig,
+    generateResponse,
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/skillsQuestionsTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/skillsQuestionsTest.eval.ts
@@ -10,8 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { systemPrompt } from "../../systemPrompt";
-import { config, conversations } from "../../config";
+import { generateResponse } from "../../config";
 
 async function conversationEval() {
   // Get dotcom question set eval cases from YAML
@@ -22,17 +21,6 @@ async function conversationEval() {
       "utf8"
     )
   );
-
-  const generateConfig = {
-    systemPrompt,
-    llm: config.conversationsRouterConfig.llm,
-    llmNotWorkingMessage: conversations.conversationConstants.LLM_NOT_WORKING,
-    noRelevantContentMessage:
-      conversations.conversationConstants.NO_RELEVANT_CONTENT,
-    filterPreviousMessages:
-      config.conversationsRouterConfig.filterPreviousMessages,
-    generateUserPrompt: config.conversationsRouterConfig.generateUserPrompt,
-  };
 
   // Run the conversation eval
   makeConversationEval({
@@ -52,7 +40,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generate: generateConfig,
+    generateResponse,
   });
 }
 conversationEval();


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1153

## Changes

- replace deprecated `generate` with `generateResponse`
-

## Notes

-
