### PR TITLE
EAI-973: Persist search queries and results in mongodb

### DIFF
--- a/packages/mongodb-chatbot-server/src/routes/content/contentRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/contentRouter.ts
@@ -1,15 +1,14 @@
 import { Router } from "express";
-import { FindContentFunc } from "mongodb-rag-core";
+import { FindContentFunc, MongoDbSearchResultsStore } from "mongodb-rag-core";
 import validateRequestSchema from "../../middleware/validateRequestSchema";
 import {
   SearchContentRequest,
-  SearchResultsStore,
   makeSearchContentRoute,
 } from "./searchContent";
 
 export interface MakeContentRouterParams {
   findContent: FindContentFunc;
-  searchResultsStore: SearchResultsStore;
+  searchResultsStore: MongoDbSearchResultsStore;
 }
 
 export function makeContentRouter({

--- a/packages/mongodb-chatbot-server/src/routes/content/searchContent.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/searchContent.ts
@@ -1,7 +1,10 @@
 import {
   FindContentFunc,
   FindContentResult,
+  MongoDbSearchResultsStore,
   QueryFilters,
+  SearchRecordDataSource,
+  SearchRecordDataSourceSchema,
 } from "mongodb-rag-core";
 import { SomeExpressRequest } from "../../middleware";
 import { z } from "zod";
@@ -11,20 +14,9 @@ import {
   Response as ExpressResponse,
 } from "express";
 
-// TODO: need to make this store, as discussed, it should probably be in mongodb-rag-core
-export type SearchResultsStore = unknown;
-
-export const DataSourceSchema = z.object({
-  name: z.string(),
-  type: z.string().optional(),
-  versionLabel: z.string().optional(),
-});
-
-export type DataSource = z.infer<typeof DataSourceSchema>;
-
 export const SearchContentRequestBody = z.object({
   query: z.string(),
-  dataSources: z.array(DataSourceSchema).optional(),
+  dataSources: z.array(SearchRecordDataSourceSchema).optional(),
   limit: z.number().int().min(1).max(500).optional().default(5),
 });
 
@@ -42,7 +34,7 @@ export type SearchContentRequestBody = z.infer<typeof SearchContentRequestBody>;
 
 export interface MakeSearchContentRouteParams {
   findContent: FindContentFunc;
-  searchResultsStore: SearchResultsStore;
+  searchResultsStore: MongoDbSearchResultsStore;
 }
 
 interface SearchContentResponseChunk {
@@ -100,7 +92,9 @@ function mapFindContentResultToSearchContentResponseChunk(
   };
 }
 
-function mapDataSourcesToFilters(dataSources: DataSource[]): QueryFilters {
+function mapDataSourcesToFilters(
+  dataSources: SearchRecordDataSource[]
+): QueryFilters {
   // TODO: implement
   return {};
 }
@@ -108,9 +102,9 @@ function mapDataSourcesToFilters(dataSources: DataSource[]): QueryFilters {
 async function persistSearchResultsToDatabase(params: {
   query: string;
   results: FindContentResult;
-  dataSources: DataSource[];
+  dataSources: SearchRecordDataSource[];
   limit: number;
-  searchResultsStore: SearchResultsStore;
+  searchResultsStore: MongoDbSearchResultsStore;
 }) {
   // TODO: implement
 }

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
@@ -10,10 +10,8 @@ import {
   SearchResultRecord,
 } from "./MongoDbSearchResultsStore";
 
-const {
-  MONGODB_CONNECTION_URI,
-  MONGODB_DATABASE_NAME,
-} = assertEnvVars(CORE_ENV_VARS);
+const { MONGODB_CONNECTION_URI, MONGODB_DATABASE_NAME } =
+  assertEnvVars(CORE_ENV_VARS);
 
 describe("MongoDbSearchResultsStore", () => {
   let store: MongoDbSearchResultsStore | undefined;
@@ -82,9 +80,10 @@ describe("MongoDbSearchResultsStore", () => {
         createdAt: new Date(),
       };
       await expect(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         store.saveSearchResult(badSearchResultRecord)
-      ).rejects.toThrow();;
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
@@ -1,1 +1,121 @@
-// TODO: Add tests for MongoDbSearchResultsStore
+import { strict as assert } from "assert";
+import { assertEnvVars } from "../assertEnvVars";
+import { CORE_ENV_VARS } from "../CoreEnvVars";
+import "dotenv/config";
+import { MongoClient } from "mongodb";
+import { MONGO_MEMORY_SERVER_URI } from "../test/constants";
+import {
+  makeMongoDbSearchResultsStore,
+  MongoDbSearchResultsStore,
+  SearchResultRecord,
+} from "./MongoDbSearchResultsStore";
+
+const {
+  MONGODB_CONNECTION_URI,
+  MONGODB_DATABASE_NAME,
+} = assertEnvVars(CORE_ENV_VARS);
+
+describe("MongoDbSearchResultsStore", () => {
+  let store: MongoDbSearchResultsStore | undefined;
+  const searchResultRecord: SearchResultRecord = {
+    query: "What is MongoDB Atlas?",
+    results: [],
+    dataSources: [{ name: "source1", type: "docs" }],
+    createdAt: new Date(),
+  };
+  const uri = MONGO_MEMORY_SERVER_URI;
+
+  beforeAll(async () => {
+    store = makeMongoDbSearchResultsStore({
+      connectionUri: uri,
+      databaseName: "test-search-content-database",
+    });
+  });
+
+  afterEach(async () => {
+    await store?.drop();
+  });
+  afterAll(async () => {
+    await store?.close();
+  });
+
+  it("has an overridable default collection name", async () => {
+    assert(store);
+
+    expect(store.metadata.collectionName).toBe("search_results");
+
+    const storeWithCustomCollectionName = makeMongoDbSearchResultsStore({
+      connectionUri: MONGODB_CONNECTION_URI,
+      databaseName: store.metadata.databaseName,
+      collectionName: "custom-search_results",
+    });
+
+    expect(storeWithCustomCollectionName.metadata.collectionName).toBe(
+      "custom-search_results"
+    );
+  });
+
+  describe("saveSearchResult", () => {
+    it("saves search result records to db", async () => {
+      assert(store);
+      await store.saveSearchResult(searchResultRecord);
+
+      // Check for record in db
+      const client = new MongoClient(uri);
+      await client.connect();
+      const db = client.db(store.metadata.databaseName);
+      const collection = db.collection<SearchResultRecord>("search_results");
+      const found = await collection.findOne(searchResultRecord);
+
+      expect(found).toBeTruthy();
+      // Optionally, check specific fields
+      expect(found?.query).toBe(searchResultRecord.query);
+
+      await client.close();
+    });
+    it("does NOT save badly formed record", async () => {
+      assert(store);
+      const badSearchResultRecord = {
+        query: "What is aggregation?",
+        results: [],
+        dataSources: [{ type: "docs" }],
+        createdAt: new Date(),
+      };
+      await expect(
+        // @ts-ignore
+        store.saveSearchResult(badSearchResultRecord)
+      ).rejects.toThrow();;
+    });
+  });
+});
+
+describe("initializes DB", () => {
+  let store: MongoDbSearchResultsStore | undefined;
+  let mongoClient: MongoClient | undefined;
+
+  beforeEach(async () => {
+    store = makeMongoDbSearchResultsStore({
+      connectionUri: MONGODB_CONNECTION_URI,
+      databaseName: MONGODB_DATABASE_NAME,
+    });
+    mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
+  });
+
+  afterEach(async () => {
+    assert(store);
+    assert(mongoClient);
+    await store.close();
+    await mongoClient.close();
+  });
+
+  it("creates indexes", async () => {
+    assert(store);
+    await store.init();
+
+    const coll = mongoClient
+      ?.db(store.metadata.databaseName)
+      .collection<SearchResultRecord>(store.metadata.collectionName);
+    const indexes = await coll?.listIndexes().toArray();
+    expect(indexes?.some((el) => el.name === "createdAt_-1")).toBe(true);
+  });
+});

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
@@ -17,7 +17,16 @@ describe("MongoDbSearchResultsStore", () => {
   let store: MongoDbSearchResultsStore | undefined;
   const searchResultRecord: SearchResultRecord = {
     query: "What is MongoDB Atlas?",
-    results: [],
+    results: [
+      {
+        url: "foo",
+        title: "bar",
+        text: "baz",
+        metadata: {
+          sourceName: "source",
+        },
+      },
+    ],
     dataSources: [{ name: "source1", type: "docs" }],
     createdAt: new Date(),
   };

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
@@ -1,0 +1,1 @@
+// TODO: Add tests for MongoDbSearchResultsStore

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.test.ts
@@ -66,8 +66,7 @@ describe("MongoDbSearchResultsStore", () => {
       const found = await collection.findOne(searchResultRecord);
 
       expect(found).toBeTruthy();
-      // Optionally, check specific fields
-      expect(found?.query).toBe(searchResultRecord.query);
+      expect(found).toMatchObject(searchResultRecord);
 
       await client.close();
     });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
@@ -12,7 +12,9 @@ export const SearchRecordDataSourceSchema = z.object({
   versionLabel: z.string().optional(),
 });
 
-export type SearchRecordDataSource = z.infer<typeof SearchRecordDataSourceSchema>;
+export type SearchRecordDataSource = z.infer<
+  typeof SearchRecordDataSourceSchema
+>;
 
 export const SearchResultRecordSchema = z.object({
   query: z.string(),
@@ -69,9 +71,7 @@ export function makeMongoDbSearchResultsStore({
       const insertResult = await searchResultsCollection.insertOne(record);
 
       if (!insertResult.acknowledged) {
-        throw new Error(
-          "Insert was not acknowledged by MongoDB"
-        );
+        throw new Error("Insert was not acknowledged by MongoDB");
       }
       if (!insertResult.insertedId) {
         throw new Error(

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
@@ -6,29 +6,36 @@ import {
 } from "../MongoDbDatabaseConnection";
 import { Document } from "mongodb";
 
-export const DataSourceSchema = z.object({
+export const SearchRecordDataSourceSchema = z.object({
   name: z.string(),
   type: z.string().optional(),
   versionLabel: z.string().optional(),
 });
 
-export type DataSource = z.infer<typeof DataSourceSchema>;
+export type SearchRecordDataSource = z.infer<typeof SearchRecordDataSourceSchema>;
+
+export const SearchResultRecordSchema = z.object({
+  query: z.string(),
+  results: z.array(z.any()), // or a more specific schema
+  dataSources: z.array(SearchRecordDataSourceSchema).optional(),
+  limit: z.number().optional(),
+  createdAt: z.date(),
+});
 
 export interface SearchResultRecord {
   query: string;
   results: Document[];
-  dataSources?: DataSource[];
+  dataSources?: SearchRecordDataSource[];
   limit?: number;
   createdAt: Date;
 }
 
-export type SearchResultsStore = DatabaseConnection & {
-  saveSearchResult(record: SearchResultRecord): Promise<void>;
-  // Add more methods as needed
+export type MongoDbSearchResultsStore = DatabaseConnection & {
   metadata: {
     databaseName: string;
     collectionName: string;
   };
+  saveSearchResult(record: SearchResultRecord): Promise<void>;
   init(): Promise<void>;
 };
 
@@ -42,8 +49,8 @@ export type ContentCustomData = Record<string, unknown> | undefined;
 export function makeMongoDbSearchResultsStore({
   connectionUri,
   databaseName,
-  collectionName = "searchResults",
-}: MakeMongoDbSearchResultsStoreParams): SearchResultsStore {
+  collectionName = "search_results",
+}: MakeMongoDbSearchResultsStoreParams): MongoDbSearchResultsStore {
   const { db, drop, close } = makeMongoDbDatabaseConnection({
     connectionUri,
     databaseName,
@@ -57,11 +64,22 @@ export function makeMongoDbSearchResultsStore({
       databaseName,
       collectionName,
     },
-    async saveSearchResult(record) {
-      // TODO: implement in EAI-973
+    async saveSearchResult(record: SearchResultRecord) {
+      SearchResultRecordSchema.parse(record);
+      const insertResult = await searchResultsCollection.insertOne(record);
+
+      if (!insertResult.acknowledged) {
+        throw new Error(
+          "Insert was not acknowledged by MongoDB"
+        );
+      }
+      if (!insertResult.insertedId) {
+        throw new Error(
+          "No insertedId returned from MongoDbSearchResultsStore.saveSearchResult insertOne"
+        );
+      }
     },
     async init() {
-      await searchResultsCollection.createIndex({ query: 1 });
       await searchResultsCollection.createIndex({ createdAt: -1 });
     },
   };

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { DatabaseConnection } from "../DatabaseConnection";
+import {
+  MakeMongoDbDatabaseConnectionParams,
+  makeMongoDbDatabaseConnection,
+} from "../MongoDbDatabaseConnection";
+import { Document } from "mongodb";
+
+export const DataSourceSchema = z.object({
+  name: z.string(),
+  type: z.string().optional(),
+  versionLabel: z.string().optional(),
+});
+
+export type DataSource = z.infer<typeof DataSourceSchema>;
+
+export interface SearchResultRecord {
+  query: string;
+  results: Document[];
+  dataSources?: DataSource[];
+  limit?: number;
+  createdAt: Date;
+}
+
+export type SearchResultsStore = DatabaseConnection & {
+  saveSearchResult(record: SearchResultRecord): Promise<void>;
+  // Add more methods as needed
+  metadata: {
+    databaseName: string;
+    collectionName: string;
+  };
+  init(): Promise<void>;
+};
+
+export type MakeMongoDbSearchResultsStoreParams =
+  MakeMongoDbDatabaseConnectionParams & {
+    collectionName?: string;
+  };
+
+export type ContentCustomData = Record<string, unknown> | undefined;
+
+export function makeMongoDbSearchResultsStore({
+  connectionUri,
+  databaseName,
+  collectionName = "searchResults",
+}: MakeMongoDbSearchResultsStoreParams): SearchResultsStore {
+  const { db, drop, close } = makeMongoDbDatabaseConnection({
+    connectionUri,
+    databaseName,
+  });
+  const searchResultsCollection =
+    db.collection<SearchResultRecord>(collectionName);
+  return {
+    drop,
+    close,
+    metadata: {
+      databaseName,
+      collectionName,
+    },
+    async saveSearchResult(record) {
+      // TODO: implement in EAI-973
+    },
+    async init() {
+      await searchResultsCollection.createIndex({ query: 1 });
+      await searchResultsCollection.createIndex({ createdAt: -1 });
+    },
+  };
+}

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbSearchResultsStore.ts
@@ -16,9 +16,32 @@ export type SearchRecordDataSource = z.infer<
   typeof SearchRecordDataSourceSchema
 >;
 
+export interface ResultChunk {
+  url: string;
+  title: string;
+  text: string;
+  metadata: {
+    sourceName: string;
+    sourceType?: string;
+    tags?: string[];
+    [key: string]: any; // Accept additional unknown properties
+  };
+}
+
+export const ResultChunkSchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  text: z.string(),
+  metadata: z.object({
+    sourceName: z.string(),
+    sourceType: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+  }).passthrough(),
+});
+
 export const SearchResultRecordSchema = z.object({
   query: z.string(),
-  results: z.array(z.any()), // or a more specific schema
+  results: z.array(ResultChunkSchema),
   dataSources: z.array(SearchRecordDataSourceSchema).optional(),
   limit: z.number().optional(),
   createdAt: z.date(),

--- a/packages/mongodb-rag-core/src/contentStore/index.ts
+++ b/packages/mongodb-rag-core/src/contentStore/index.ts
@@ -2,6 +2,7 @@ export * from "./EmbeddedContent";
 export * from "./getChangedPages";
 export * from "./MongoDbEmbeddedContentStore";
 export * from "./MongoDbPageStore";
+export * from "./MongoDbSearchResultsStore";
 export * from "./MongoDbTransformedContentStore";
 export * from "./Page";
 export * from "./PageFormat";

--- a/packages/mongodb-rag-core/src/findContent/DefaultFindContent.test.ts
+++ b/packages/mongodb-rag-core/src/findContent/DefaultFindContent.test.ts
@@ -96,6 +96,19 @@ describe("makeDefaultFindContent()", () => {
     expect(embeddingModelName).toBe(OPENAI_RETRIEVAL_EMBEDDING_DEPLOYMENT);
   });
   test("should limit results", async () => {
-    // TODO: test behavior
+    const findContent = makeDefaultFindContent({
+      embedder,
+      store: embeddedContentStore,
+      findNearestNeighborsOptions: {
+        minScore: 0.1, // low min, should return at least one result
+      },
+    });
+    const query = "MongoDB";
+    const { content } = await findContent({
+      query,
+      limit: 1, // limit to 1, should return 1 result
+    });
+    expect(content).toBeDefined();
+    expect(content.length).toBe(1);
   });
 });

--- a/packages/mongodb-rag-core/src/findContent/DefaultFindContent.ts
+++ b/packages/mongodb-rag-core/src/findContent/DefaultFindContent.ts
@@ -28,7 +28,7 @@ export const makeDefaultFindContent = ({
     let content = await store.findNearestNeighbors(embedding, {
       ...findNearestNeighborsOptions,
       filter: filters,
-      // TODO: need to add logic to pass limit to findNearestNeighbors
+      k: limit,
     });
 
     for (const booster of searchBoosters ?? []) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-

## Changes

- Implements `MongoDbSearchResultStore`
- Creates tests for `MongoDbSearchResultStore`
- Updates `FindContent` to support limiting
- Adds test for limit
