### PR TITLE
(EAI-1053) Fix to page validation script runner command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "scripts:materializeScrubbedMessagesStats:latest": "lerna run --scope='scripts' materializeScrubbedMessagesStats:latest",
     "scripts:listSlackMessages": "lerna run --scope='scripts' listSlackMessages -- ",
     "scripts:removeSlackMessage": "lerna run --scope='scripts' removeSlackMessage -- ",
+    "scripts:verifyPagesInSource": "lerna run --scope='scripts' verifyPagesInSource -- ",
     "server:start": "lerna run start --scope='chatbot-server-mongodb-public'",
     "eval:conversationQualityCheckPipeline": "lerna run pipeline:conversationQualityCheck --scope='chatbot-eval-mongodb-public'",
     "eval:faqConversationQualityCheckPipeline": "lerna run pipeline:faqConversationQualityCheck --scope='chatbot-eval-mongodb-public'"

--- a/packages/scripts/environments/production.yml
+++ b/packages/scripts/environments/production.yml
@@ -42,7 +42,7 @@ cronJobs:
 
   - name: verify-sources-have-pages-prod
     schedule: "0 0 * * *" # every day at midnight UTC
-    command: ["npm", "run", "scripts:verifyPagesInSources"]
+    command: ["npm", "run", "scripts:verifyPagesInSource"]
     env:
       MONGODB_DATABASE_NAME: docs-chatbot-prod
     envSecrets:

--- a/packages/scripts/environments/staging.yml
+++ b/packages/scripts/environments/staging.yml
@@ -51,7 +51,7 @@ cronJobs:
 
   - name: verify-sources-have-pages-staging
     schedule: "0 0 * * *" # every day at midnight UTC
-    command: ["npm", "run", "scripts:verifyPagesInSources"]
+    command: ["npm", "run", "scripts:verifyPagesInSource"]
     env:
       MONGODB_DATABASE_NAME: docs-chatbot-staging
     envSecrets:

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -28,7 +28,7 @@
     "listSlackMessages": "npm run build && node ./build/main/listSlackMessagesMain.js",
     "removeSlackMessage": "npm run build && node ./build/main/removeSlackMessageMain.js",
     "checkUrlsAgainstDB": "npm run build && node ./build/checkUrlsAgainstDB.js",
-    "verifyPagesInSources": "npm run build && node ./build/verifyPagesInSources.js",
+    "verifyPagesInSource": "npm run build && node ./build/verifyPagesInSource.js",
     "test": "jest --forceExit",
     "build": "npm run clean && tsc -b tsconfig.build.json",
     "clean": "rm -rf ./build",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1053

## Changes

- Fixes the following error by making all npm commands reference the correct filename (singular, verifyPagesInSource, not plural)
` npm error Missing script: "scripts:verifyPagesInSources" `
