### PR TITLE
(EAI-1157) fix breaking university data source tests

### DIFF
--- a/packages/ingest-mongodb-public/src/sources/mongodb-university/MongoDbUniversityDataApiClient.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodb-university/MongoDbUniversityDataApiClient.ts
@@ -201,7 +201,7 @@ export function makeMongoDbUniversityDataApiClient({
     },
     async getAllVideos() {
       let offset = 0;
-      const LIMIT = 300; // Maximum allowed by the MongoDB University Data API.
+      const LIMIT = 250; // Maximum allowed by the MongoDB University Data API.
       let hasMoreVideos = true;
       const videos: UniversityVideo[] = [];
       let metadata: ResponseMetadata | undefined = undefined;


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1157

## Changes

- reduce limit from 300 to 250 to avoid lambda limits
-

## Notes

- This change was made on the suggestion of the UP team, who explained they have a cap they are unable to raise for the lambda invocation payload https://jira.mongodb.org/browse/UP-7665
