### PR TITLE
EAI-1168 Remove query string, hash fragment in normalizeUrl

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/fuzzyLinkMatch.ts
@@ -9,8 +9,8 @@ export function fuzzyLinkMatch(expected: string, actual: string) {
     return cleanActualPath.endsWith(cleanExpectedPath);
   } else {
     // compare normalized full URLs
-    const normalizedActual = normalizeUrl(actual);
-    const normalizedExpected = normalizeUrl(expected);
+    const normalizedActual = normalizeUrl({ url: actual });
+    const normalizedExpected = normalizeUrl({ url: expected });
     return normalizedActual === normalizedExpected;
   }
 }

--- a/packages/chatbot-server-mongodb-public/src/tools/fetchPage.ts
+++ b/packages/chatbot-server-mongodb-public/src/tools/fetchPage.ts
@@ -59,7 +59,7 @@ export function makeFetchPageTool({
         args: MongoDbFetchPageToolArgs,
         _options: ToolExecutionOptions
       ): Promise<FetchPageToolResult> {
-        const normalizedUrl = normalizeUrl(args.pageUrl);
+        const normalizedUrl = normalizeUrl({ url: args.pageUrl });
         const page = await loadPage({
           urls: [normalizedUrl],
           query: {

--- a/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/DevCenterDataSource.ts
@@ -133,12 +133,12 @@ export function makeDevCenterPageBody({
 }
 
 function makeDevCenterPageUrl(calculated_slug: string, baseUrl: string) {
-  return normalizeUrl(
-    /^https?:\/\//.test(calculated_slug)
+  return normalizeUrl({
+    url: /^https?:\/\//.test(calculated_slug)
       ? calculated_slug
       : new URL(
           calculated_slug.replace(/^\/?/, ""), // Strip leading slash (if present) to not clobber baseUrl path
           baseUrl.replace(/\/?$/, "/") // Add trailing slash to not lose last segment of baseUrl
-        ).toString()
-  );
+        ).toString(),
+  });
 }

--- a/packages/ingest-mongodb-public/src/sources/index.ts
+++ b/packages/ingest-mongodb-public/src/sources/index.ts
@@ -90,7 +90,7 @@ export const mongoDbCorpDataSourceConfig: MakeMdOnGithubDataSourceParams<SourceT
       if (!frontMatter?.url) {
         throw new Error("frontMatter.url must be specified");
       }
-      return normalizeUrl(frontMatter?.url as string);
+      return normalizeUrl({ url: frontMatter?.url as string });
     },
     extractMetadata(_, frontMatter) {
       if (!frontMatter) {
@@ -120,7 +120,7 @@ export const mongoDbUniMetadataDataSourceConfig: MakeMdOnGithubDataSourceParams<
       if (!frontMatter?.url) {
         throw new Error("frontMatter.url must be specified");
       }
-      return normalizeUrl(frontMatter?.url as string);
+      return normalizeUrl({ url: frontMatter?.url as string });
     },
     extractMetadata(_, frontMatter) {
       if (!frontMatter) {
@@ -152,9 +152,9 @@ export const terraformProviderSourceConfig: MakeMdOnGithubDataSourceParams<Sourc
     pathToPageUrl(pathInRepo, _) {
       const siteBaseUrl =
         "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs";
-      return normalizeUrl(
-        siteBaseUrl + pathInRepo.replace("docs/", "").replace(".md", "")
-      );
+      return normalizeUrl({
+        url: siteBaseUrl + pathInRepo.replace("docs/", "").replace(".md", ""),
+      });
     },
     filter: (path: string) => path.includes("docs") && path.endsWith(".md"),
     sourceType: "tech-docs-external",
@@ -204,7 +204,7 @@ const voyageAiDocsDataSourceConstructor = async (): Promise<DataSource> => {
       tags: ["docs", "voyageai"],
     },
     markdownUrlToPageUrl: (url: string) => {
-      return normalizeUrl(removeMarkdownFileExtension(url));
+      return normalizeUrl({ url: removeMarkdownFileExtension(url) });
     },
   });
 };

--- a/packages/ingest-mongodb-public/src/sources/mongodb-university/makeUniversityPages.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodb-university/makeUniversityPages.ts
@@ -195,9 +195,9 @@ function makeUniversityPageUrl({
   sectionSlug: string;
   lessonSlug: string;
 }) {
-  return normalizeUrl(
-    `${UNI_BASE_URL}/learn/course/${catalogItemSlug}/${sectionSlug}/${lessonSlug}`
-  );
+  return normalizeUrl({
+    url: `${UNI_BASE_URL}/learn/course/${catalogItemSlug}/${sectionSlug}/${lessonSlug}`,
+  });
 }
 
 /**
@@ -205,7 +205,9 @@ function makeUniversityPageUrl({
   This is used for Learning Paths and Courses that have nested content.
  */
 function makeUniversityHighLevelCourseUrl(catalogItemSlug: string) {
-  return normalizeUrl(`${UNI_BASE_URL}/learning-paths/${catalogItemSlug}`);
+  return normalizeUrl({
+    url: `${UNI_BASE_URL}/learning-paths/${catalogItemSlug}`,
+  });
 }
 
 /**

--- a/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.test.ts
@@ -175,6 +175,18 @@ describe("WebDataSource", () => {
     const pages = await source.fetchPages();
     expect(pages.length).toBe(0);
   });
+  it("handles url normalization options", async () => {
+    const urlWithQueryString = "https://www.mongodb.com/company?q=val";
+    const source = await makeWebDataSource({
+      name: "mongodb-dot-com",
+      urls: [urlWithQueryString],
+      removeQueryString: false,
+      makeBrowser: async () => mockBrowser,
+    });
+    const pages = await source.fetchPages();
+    expect(pages.length).toBe(1);
+    expect(pages[0].url).toEqual("mongodb.com/company?q=val");
+  });
   it("handles valid urls", async () => {
     const source = await makeWebDataSource({
       name: "valid-source",

--- a/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.ts
@@ -18,6 +18,8 @@ export function makeWebDataSource({
   urls,
   sourceType,
   staticMetadata,
+  removeHash,
+  removeQueryString,
   makeBrowser,
 }: WebSourceParams): DataSource {
   return {
@@ -35,7 +37,7 @@ export function makeWebDataSource({
           });
           if (content) {
             pages.push({
-              url: normalizeUrl({ url }),
+              url: normalizeUrl({ url, removeHash, removeQueryString }),
               format: "md",
               sourceName: name,
               sourceType,

--- a/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodbDotCom/WebDataSource.ts
@@ -35,7 +35,7 @@ export function makeWebDataSource({
           });
           if (content) {
             pages.push({
-              url: normalizeUrl(url),
+              url: normalizeUrl({ url }),
               format: "md",
               sourceName: name,
               sourceType,

--- a/packages/ingest-mongodb-public/src/sources/mongodbDotCom/webSources.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodbDotCom/webSources.ts
@@ -26,6 +26,12 @@ export type InitialWebSource = {
    Optional additional metadata determined by the web source.
    */
   staticMetadata?: Record<string, string | string[]>;
+
+  /**
+    URL normalization options for this source.
+    */
+  removeHash?: boolean;
+  removeQueryString?: boolean;
 };
 
 export const initialWebSources: InitialWebSource[] = [
@@ -459,6 +465,7 @@ export const initialWebSources: InitialWebSource[] = [
     staticMetadata: {
       tags: ["Skills", "MongoDB University"],
     },
+    removeQueryString: false,
   },
 ];
 
@@ -474,7 +481,12 @@ export async function getUrlsFromSitemap(
 
 export type WebSource = Pick<
   InitialWebSource,
-  "name" | "sourceType" | "staticMetadata" | "urls"
+  | "name"
+  | "sourceType"
+  | "staticMetadata"
+  | "urls"
+  | "removeHash"
+  | "removeQueryString"
 >;
 
 type PrepareWebSourcesParams = {

--- a/packages/ingest-mongodb-public/src/sources/mongodbDotCom/webSources.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongodbDotCom/webSources.ts
@@ -505,7 +505,8 @@ export const prepareWebSources = async ({
 }: PrepareWebSourcesParams): Promise<WebSource[]> => {
   const webSources: WebSource[] = [];
   for (const initialWebSource of initialWebSources) {
-    const { name, staticMetadata, sourceType } = initialWebSource;
+    const { name, staticMetadata, sourceType, removeHash, removeQueryString } =
+      initialWebSource;
     let urls = initialWebSource.urls || [];
     if (initialWebSource.directoryUrls?.length) {
       for (const directoryUrl of initialWebSource.directoryUrls) {
@@ -520,6 +521,8 @@ export const prepareWebSources = async ({
       staticMetadata,
       urls,
       sourceType,
+      removeHash,
+      removeQueryString,
     });
   }
   return webSources;

--- a/packages/ingest-mongodb-public/src/sources/mongoose.ts
+++ b/packages/ingest-mongodb-public/src/sources/mongoose.ts
@@ -21,11 +21,11 @@ export const mongooseSourceConstructor = async () => {
     repoLoaderOptions,
     name: "mongoose",
     pathToPageUrl(path) {
-      return normalizeUrl(
-        path
+      return normalizeUrl({
+        url: path
           .replace(/^\/docs\//, "https://mongoosejs.com/docs/")
-          .replace(/\.md$/, ".html")
-      );
+          .replace(/\.md$/, ".html"),
+      });
     },
     testFileLoaderOptions,
     acquitCodeBlockLanguageReplacement: "javascript",

--- a/packages/ingest-mongodb-public/src/sources/practicalAggregations.ts
+++ b/packages/ingest-mongodb-public/src/sources/practicalAggregations.ts
@@ -14,10 +14,11 @@ export const practicalAggregationsConfig: MakeMdOnGithubDataSourceParams<SourceT
       ignoreFiles: [/^(?!^\/src\/).*/, /^(\/src\/SUMMARY\.md)$/],
     },
     pathToPageUrl(pathInRepo) {
-      return normalizeUrl(
-        "https://www.practical-mongodb-aggregations.com" +
-          pathInRepo.replace(/^\/src\//, "/").replace(/\.md$/, "")
-      );
+      return normalizeUrl({
+        url:
+          "https://www.practical-mongodb-aggregations.com" +
+          pathInRepo.replace(/^\/src\//, "/").replace(/\.md$/, ""),
+      });
     },
     sourceType: "book-external",
     metadata: {

--- a/packages/ingest-mongodb-public/src/sources/prisma.ts
+++ b/packages/ingest-mongodb-public/src/sources/prisma.ts
@@ -54,7 +54,7 @@ export const prismaSourceConstructor = async () => {
       if (frontMatter?.dbSwitcher) {
         url += "-mongodb";
       }
-      return normalizeUrl(url);
+      return normalizeUrl({ url });
     },
     extractTitle(_pageContent, frontMatter) {
       // metaTitle is more descriptive

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.test.ts
@@ -85,7 +85,7 @@ describe("SnootyDataSource", () => {
         body: firstPageText,
       });
       for (const page of pages) {
-        expect(page.url).toBe(normalizeUrl(page.url));
+        expect(page.url).toBe(normalizeUrl({ url: page.url }));
       }
     });
     it("should skip inactive branches", async () => {

--- a/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
+++ b/packages/ingest-mongodb-public/src/sources/snooty/SnootyDataSource.ts
@@ -461,7 +461,7 @@ function makeUrl(pagePath: string, baseUrl: string): string {
 
   // Handle empty pagePath or root path
   if (!pagePath || pagePath === "/") {
-    return normalizeUrl(baseUrlTrailingSlash);
+    return normalizeUrl({ url: baseUrlTrailingSlash });
   }
 
   // For non-empty paths, remove leading slash and ensure trailing slash
@@ -470,5 +470,5 @@ function makeUrl(pagePath: string, baseUrl: string): string {
     .replace(/\/?$/, "/"); // Ensure trailing slash
 
   // Concatenate the base URL with the clean page path
-  return normalizeUrl(baseUrlTrailingSlash + cleanPagePath);
+  return normalizeUrl({ url: baseUrlTrailingSlash + cleanPagePath });
 }

--- a/packages/ingest-mongodb-public/src/sources/wiredTiger.ts
+++ b/packages/ingest-mongodb-public/src/sources/wiredTiger.ts
@@ -27,7 +27,7 @@ const extractMetadata = (domDoc: Document) => {
 };
 const htmlParserOptions: Omit<HandleHtmlPageFuncOptions, "sourceName"> = {
   pathToPageUrl: (pathInRepo: string) =>
-    normalizeUrl(`https://source.wiredtiger.com${pathInRepo}`),
+    normalizeUrl({ url: `https://source.wiredtiger.com${pathInRepo}` }),
   removeElements,
   extractTitle,
   extractMetadata,

--- a/packages/mongodb-rag-core/src/dataSources/normalizeUrl.test.ts
+++ b/packages/mongodb-rag-core/src/dataSources/normalizeUrl.test.ts
@@ -1,52 +1,132 @@
 import { normalizeUrl, ensureProtocol } from "./normalizeUrl";
 
 describe("normalizeUrl", () => {
+  const baseParams = {
+    url: "example.com",
+    removeHash: false,
+    removeQueryString: false,
+  };
+
   it("should handle URLs with https:// domain", () => {
-    expect(normalizeUrl("https://example.com")).toBe("example.com");
+    const params = {
+      ...baseParams,
+      url: "https://example.com",
+    };
+    expect(normalizeUrl(params)).toBe("example.com");
   });
 
   it("should handle URLs with https:// domain", () => {
-    expect(normalizeUrl("https://example.com")).toBe("example.com");
+    const params = {
+      ...baseParams,
+      url: "http://example.com",
+    };
+    expect(normalizeUrl(params)).toBe("example.com");
   });
-
   it("should remove www prefix", () => {
-    expect(normalizeUrl("www.example.com/path")).toBe("example.com/path");
+    const params = {
+      ...baseParams,
+      url: "www.example.com/path",
+    };
+    expect(normalizeUrl(params)).toBe("example.com/path");
   });
 
   it("should remove trailing slashes", () => {
-    const url = "example.com/path/";
-    expect(normalizeUrl(url)).toBe("example.com/path");
+    const params = {
+      ...baseParams,
+      url: "example.com/path/",
+    };
+    expect(normalizeUrl(params)).toBe("example.com/path");
   });
 
   it("should handle URLs with a domain and a trailing slash", () => {
-    expect(normalizeUrl("https://example.com/")).toBe("example.com");
+    const params = {
+      ...baseParams,
+      url: "https://example.com/",
+    };
+    expect(normalizeUrl(params)).toBe("example.com");
   });
 
   it("should handle URLs with https://www. prefix", () => {
-    expect(normalizeUrl("https://www.example.com/path")).toBe(
-      "example.com/path"
-    );
+    const params = {
+      ...baseParams,
+      url: "https://www.example.com/path",
+    };
+    expect(normalizeUrl(params)).toBe("example.com/path");
   });
 
   it("should handle URLs with http://www. prefix", () => {
-    expect(normalizeUrl("http://www.example.com/path")).toBe(
-      "example.com/path"
-    );
+    const params = {
+      ...baseParams,
+      url: "http://www.example.com/path",
+    };
+    expect(normalizeUrl(params)).toBe("example.com/path");
   });
 
   it("should handle complex URLs with many normalizations needed", () => {
-    const url = "http://www.example.com/path/to/resource/";
-    expect(normalizeUrl(url)).toBe("example.com/path/to/resource");
+    const params = {
+      ...baseParams,
+      url: "http://www.example.com/path/to/resource/",
+    };
+    expect(normalizeUrl(params)).toBe("example.com/path/to/resource");
   });
 
-  it("should not remove query string", () => {
-    const url = "https://learn.mongodb.com/skills?openTab=query";
-    expect(normalizeUrl(url)).toBe("learn.mongodb.com/skills?openTab=query");
+  it("should not remove hash fragment if removeHash=false", () => {
+    const params = {
+      ...baseParams,
+      url: "https://www.mongodb.com/docs/atlas/atlas-vector-search/rag/#why-use-rag-",
+      removeHash: false,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/atlas/atlas-vector-search/rag/#why-use-rag-"
+    );
+  });
+
+  it("should remove hash fragment if removeHash=true", () => {
+    const params = {
+      ...baseParams,
+      url: "https://www.mongodb.com/docs/atlas/atlas-vector-search/rag/#why-use-rag-",
+      removeHash: true,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/atlas/atlas-vector-search/rag"
+    );
+  });
+
+  it("should not remove query string if removeQueryString=false", () => {
+    const params = {
+      ...baseParams,
+      url: "https://learn.mongodb.com/skills?openTab=query",
+      removeQueryString: false,
+    };
+    expect(normalizeUrl(params)).toBe("learn.mongodb.com/skills?openTab=query");
+  });
+
+  it("should remove query string if removeQueryString=true", () => {
+    const params = {
+      ...baseParams,
+      url: "https://learn.mongodb.com/skills?openTab=query",
+      removeQueryString: true,
+    };
+    expect(normalizeUrl(params)).toBe("learn.mongodb.com/skills");
+  });
+
+  it("should remove both query string & hash if both true", () => {
+    const params = {
+      url: "https://www.mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot#configure-read-preference",
+      removeHash: true,
+      removeQueryString: true,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/manual/core/read-preference"
+    );
   });
 
   it("should return the URL unchanged if it is already normalized", () => {
-    const url = "example.com/path/to/resource";
-    expect(normalizeUrl(url)).toBe(url);
+    const params = {
+      ...baseParams,
+      url: "example.com/path/to/resource",
+    };
+    expect(normalizeUrl(params)).toBe(params.url);
   });
 });
 

--- a/packages/mongodb-rag-core/src/dataSources/normalizeUrl.test.ts
+++ b/packages/mongodb-rag-core/src/dataSources/normalizeUrl.test.ts
@@ -1,15 +1,8 @@
 import { normalizeUrl, ensureProtocol } from "./normalizeUrl";
 
 describe("normalizeUrl", () => {
-  const baseParams = {
-    url: "example.com",
-    removeHash: false,
-    removeQueryString: false,
-  };
-
   it("should handle URLs with https:// domain", () => {
     const params = {
-      ...baseParams,
       url: "https://example.com",
     };
     expect(normalizeUrl(params)).toBe("example.com");
@@ -17,14 +10,12 @@ describe("normalizeUrl", () => {
 
   it("should handle URLs with https:// domain", () => {
     const params = {
-      ...baseParams,
       url: "http://example.com",
     };
     expect(normalizeUrl(params)).toBe("example.com");
   });
   it("should remove www prefix", () => {
     const params = {
-      ...baseParams,
       url: "www.example.com/path",
     };
     expect(normalizeUrl(params)).toBe("example.com/path");
@@ -32,7 +23,6 @@ describe("normalizeUrl", () => {
 
   it("should remove trailing slashes", () => {
     const params = {
-      ...baseParams,
       url: "example.com/path/",
     };
     expect(normalizeUrl(params)).toBe("example.com/path");
@@ -40,7 +30,6 @@ describe("normalizeUrl", () => {
 
   it("should handle URLs with a domain and a trailing slash", () => {
     const params = {
-      ...baseParams,
       url: "https://example.com/",
     };
     expect(normalizeUrl(params)).toBe("example.com");
@@ -48,7 +37,6 @@ describe("normalizeUrl", () => {
 
   it("should handle URLs with https://www. prefix", () => {
     const params = {
-      ...baseParams,
       url: "https://www.example.com/path",
     };
     expect(normalizeUrl(params)).toBe("example.com/path");
@@ -56,7 +44,6 @@ describe("normalizeUrl", () => {
 
   it("should handle URLs with http://www. prefix", () => {
     const params = {
-      ...baseParams,
       url: "http://www.example.com/path",
     };
     expect(normalizeUrl(params)).toBe("example.com/path");
@@ -64,7 +51,6 @@ describe("normalizeUrl", () => {
 
   it("should handle complex URLs with many normalizations needed", () => {
     const params = {
-      ...baseParams,
       url: "http://www.example.com/path/to/resource/",
     };
     expect(normalizeUrl(params)).toBe("example.com/path/to/resource");
@@ -72,7 +58,6 @@ describe("normalizeUrl", () => {
 
   it("should not remove hash fragment if removeHash=false", () => {
     const params = {
-      ...baseParams,
       url: "https://www.mongodb.com/docs/atlas/atlas-vector-search/rag/#why-use-rag-",
       removeHash: false,
     };
@@ -83,7 +68,6 @@ describe("normalizeUrl", () => {
 
   it("should remove hash fragment if removeHash=true", () => {
     const params = {
-      ...baseParams,
       url: "https://www.mongodb.com/docs/atlas/atlas-vector-search/rag/#why-use-rag-",
       removeHash: true,
     };
@@ -94,7 +78,6 @@ describe("normalizeUrl", () => {
 
   it("should not remove query string if removeQueryString=false", () => {
     const params = {
-      ...baseParams,
       url: "https://learn.mongodb.com/skills?openTab=query",
       removeQueryString: false,
     };
@@ -103,7 +86,6 @@ describe("normalizeUrl", () => {
 
   it("should remove query string if removeQueryString=true", () => {
     const params = {
-      ...baseParams,
       url: "https://learn.mongodb.com/skills?openTab=query",
       removeQueryString: true,
     };
@@ -121,9 +103,52 @@ describe("normalizeUrl", () => {
     );
   });
 
+  it("should not remove both query string & hash if both false", () => {
+    const params = {
+      url: "https://www.mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot#configure-read-preference",
+      removeHash: false,
+      removeQueryString: false,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot#configure-read-preference"
+    );
+  });
+
+  it("should only remove query string", () => {
+    const params = {
+      url: "https://www.mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot#configure-read-preference",
+      removeHash: false,
+      removeQueryString: true,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/manual/core/read-preference/#configure-read-preference"
+    );
+  });
+
+  it("should only remove query string (no hash fragment in URL)", () => {
+    const params = {
+      url: "https://www.mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot",
+      removeHash: false,
+      removeQueryString: true,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/manual/core/read-preference"
+    );
+  });
+
+  it("should only remove hash fragment", () => {
+    const params = {
+      url: "https://www.mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot#configure-read-preference",
+      removeHash: true,
+      removeQueryString: false,
+    };
+    expect(normalizeUrl(params)).toBe(
+      "mongodb.com/docs/manual/core/read-preference/?tck=mongodb_ai_chatbot"
+    );
+  });
+
   it("should return the URL unchanged if it is already normalized", () => {
     const params = {
-      ...baseParams,
       url: "example.com/path/to/resource",
     };
     expect(normalizeUrl(params)).toBe(params.url);

--- a/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
+++ b/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
@@ -26,7 +26,10 @@ export function normalizeUrl({
   } else if (removeHash) {
     url = (url.match(optionalRegex.REMOVE_HASH) ?? [url])[0];
   } else if (removeQueryString) {
-    url = (url.match(optionalRegex.REMOVE_QUERY) ?? [url])[0];
+    // Splitting on hash so we retain the hash fragment
+    const [frontUrl, hashFragment] = url.split("#");
+    url = (frontUrl.match(optionalRegex.REMOVE_QUERY) ?? [url])[0];
+    url += hashFragment ? `#${hashFragment}` : "";
   }
   return url
     .replace(/^https?:\/\//i, "")

--- a/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
+++ b/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
@@ -14,7 +14,7 @@ const optionalRegex = {
 /**
   Utility function that normalizes a URL.
   Removes http/s protocol, www, trailing backslashes.
-  Also removes query string and hash fragment (optional behavior).
+  Optionally removes query string and hash fragment.
 */
 export function normalizeUrl({
   url,

--- a/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
+++ b/packages/mongodb-rag-core/src/dataSources/normalizeUrl.ts
@@ -1,9 +1,33 @@
+type NormalizeUrlParams = {
+  url: string;
+  removeHash?: boolean;
+  removeQueryString?: boolean;
+};
+
+// Regex used to get just the "front part" of a URL
+const optionalRegex = {
+  REMOVE_HASH: /^[^#]+/,
+  REMOVE_QUERY: /^[^?]+/,
+  REMOVE_BOTH: /^[^?#]+/,
+};
+
 /**
   Utility function that normalizes a URL.
   Removes http/s protocol, www, trailing backslashes.
-  DOES NOT remove query string and anchor tag.
+  Also removes query string and hash fragment (optional behavior).
 */
-export function normalizeUrl(url: string): string {
+export function normalizeUrl({
+  url,
+  removeHash = true,
+  removeQueryString = true,
+}: NormalizeUrlParams): string {
+  if (removeHash && removeQueryString) {
+    url = (url.match(optionalRegex.REMOVE_BOTH) ?? [url])[0];
+  } else if (removeHash) {
+    url = (url.match(optionalRegex.REMOVE_HASH) ?? [url])[0];
+  } else if (removeQueryString) {
+    url = (url.match(optionalRegex.REMOVE_QUERY) ?? [url])[0];
+  }
   return url
     .replace(/^https?:\/\//i, "")
     .replace(/^www\./, "")

--- a/packages/scripts/src/checkUrlsAgainstDB.ts
+++ b/packages/scripts/src/checkUrlsAgainstDB.ts
@@ -80,14 +80,14 @@ async function main({ urlListFilePath }: { urlListFilePath: string }) {
   });
   const urlsNotIngested = await pageStore.getMissingPagesByUrl({
     expectedUrls: urlList,
-    urlTransformer: normalizeUrl,
+    urlTransformer: (url) => normalizeUrl({ url }),
   });
   // look for urls that redirect
   const { noRedirect, redirectTo } = await getUrlRedirects(urlsNotIngested);
   // check if the pages we are redirecting to are in the pages collection again
   const urlsNotIngestedOfRedirectTo = await pageStore.getMissingPagesByUrl({
     expectedUrls: Array.from(redirectTo),
-    urlTransformer: normalizeUrl,
+    urlTransformer: (url) => normalizeUrl({ url }),
   });
   // the urls we need to ingest are the ones that don't redirect (no-redirect) and the urls we redirect-to
   const urlsToIngest = new Set([...noRedirect, ...urlsNotIngestedOfRedirectTo]);


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1168

## Changes

- Option to remove query string & hash fragment in normalizeUrl

## Notes

- I made these configurable because there could be future cases where we don't want to remove them (e.g. before, in ingest, we had 4 unique pages for the same URL, only difference was the URL hash fragments) 