### PR TITLE
(EAI-972) Add extra braintrust tracing to searchContent route

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/findContentWithMongoDbMetadata.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/findContentWithMongoDbMetadata.ts
@@ -31,7 +31,7 @@ export const makeFindContentWithMongoDbMetadata = ({
       return res;
     },
     {
-      name: "makeFindContentWithMongoDbMetadata",
+      name: "findContentWithMongoDbMetadata",
     }
   );
   return wrappedFindContent;


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-972

## Changes

- Adds extra braintrust tracing to searchContent route

## Notes

- Proof of tracing added seen [in braintrust here](https://www.braintrust.dev/app/mongodb-education-ai/p/chatbot-responses-dev/logs?tg=false&range=%223d%22&r=b9daf5b0-c1f4-44b1-9ca6-5f4fca4bddf2&s=5f6dc6f7-c510-40a2-9c5b-6cabdc9b96ce)
