### PR TITLE
(EAI-1173) Content sources endpoint

### DIFF
--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -89,6 +89,27 @@ paths:
               schema:
                 $ref: "#/components/responses/InternalServerError"
 
+  /content/sources:
+    get:
+      operationId: listDataSources
+      tags:
+        - Content
+      summary: List available data sources
+      description: Returns metadata about all available data sources.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListDataSourcesResponse"
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /conversations:
     post:
       operationId: createConversation
@@ -493,6 +514,27 @@ components:
               items:
                 type: string
           additionalProperties: true
+    ListDataSourcesResponse:
+      type: object
+      properties:
+        dataSources:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataSourceMetadata"
+    DataSourceMetadata:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The name of the data source.
+        version:
+          type: array
+          items:
+            type: string
+          description: List of version labels for this data source.
+        type:
+          type: string
+          description: The type of the data source.
   parameters:
     conversationId:
       name: conversationId

--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -529,7 +529,7 @@ components:
         id:
           type: string
           description: The name of the data source.
-        version:
+        versions:
           type: array
           items:
             type: object

--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -523,6 +523,8 @@ components:
             $ref: "#/components/schemas/DataSourceMetadata"
     DataSourceMetadata:
       type: object
+      required:
+        - id
       properties:
         id:
           type: string
@@ -530,8 +532,15 @@ components:
         version:
           type: array
           items:
-            type: string
-          description: List of version labels for this data source.
+            type: object
+            properties:
+              label:
+                type: string
+                description: Version label
+              isCurrent:
+                type: boolean
+                description: Whether this version is current active version
+          description: List of version objects for this data source.
         type:
           type: string
           description: The type of the data source.

--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -539,8 +539,8 @@ components:
                 description: Version label
               isCurrent:
                 type: boolean
-                description: Whether this version is current active version
-          description: List of version objects for this data source.
+                description: Whether this version is current active version.
+          description: List of versions for this data source.
         type:
           type: string
           description: The type of the data source.

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -19,7 +19,7 @@ import {
   makeVerifiedAnswerGenerateResponse,
   addDefaultCustomData,
   ConversationsRouterLocals,
-  SearchContentRouterLocals,
+  ContentRouterLocals,
 } from "mongodb-chatbot-server";
 import cookieParser from "cookie-parser";
 import { blockGetRequests } from "./middleware/blockGetRequests";
@@ -319,7 +319,8 @@ export const config: AppConfig = {
       classifierModel: languageModel,
     }),
     searchResultsStore,
-    middleware: [requireValidIpAddress<SearchContentRouterLocals>(), requireRequestOrigin<SearchContentRouterLocals>()],
+    embeddedContentStore,
+    middleware: [requireValidIpAddress<ContentRouterLocals>(), requireRequestOrigin<ContentRouterLocals>()],
   },
   conversationsRouterConfig: {
     middleware: [

--- a/packages/mongodb-chatbot-server/src/routes/content/contentRouter.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/contentRouter.test.ts
@@ -9,6 +9,7 @@ import type {
   SearchContentMiddleware,
 } from "./contentRouter";
 import { makeTestApp } from "../../test/testHelpers";
+import { embeddedContentStore } from "../../test/testConfig";
 
 // Minimal in-memory mock for SearchResultsStore for testing purposes
 const mockSearchResultsStore: MongoDbSearchResultsStore = {
@@ -33,6 +34,7 @@ function makeMockContentRouterConfig(
   return {
     findContent: findContentMock,
     searchResultsStore: mockSearchResultsStore,
+    embeddedContentStore,
     ...overrides,
   } satisfies MakeContentRouterParams;
 }

--- a/packages/mongodb-chatbot-server/src/routes/content/contentRouter.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/contentRouter.ts
@@ -90,7 +90,7 @@ export function makeContentRouter({
     })
   );
 
-  contentRouter.get("/sources", validateRequestSchema(GetDataSourcesRequest), makeListDataSourcesRoute({ embeddedContentStore, addCustomData }));
+  contentRouter.get("/sources", validateRequestSchema(GetDataSourcesRequest), makeListDataSourcesRoute({ embeddedContentStore }));
 
   return contentRouter;
 }

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
@@ -1,4 +1,7 @@
-import type { MongoDbEmbeddedContentStore, DataSourceMetadata } from "mongodb-rag-core";
+import type {
+  MongoDbEmbeddedContentStore,
+  DataSourceMetadata,
+} from "mongodb-rag-core";
 import { createRequest, createResponse } from "node-mocks-http";
 import { makeListDataSourcesRoute } from "./listDataSources";
 
@@ -10,8 +13,19 @@ function makeMockEmbeddedContentStore(dataSources: DataSourceMetadata[]) {
 
 describe("makeListDataSourcesRoute", () => {
   const mockDataSources: DataSourceMetadata[] = [
-    { id: "source1", version: ["current", "v6.0"], type: "docs" },
-    { id: "source2", version: ["v2.11"], type: "university-content" },
+    {
+      id: "source1",
+      version: [
+        { label: "current", isCurrent: true },
+        { label: "v6.0", isCurrent: false },
+      ],
+      type: "docs",
+    },
+    {
+      id: "source2",
+      version: [{ label: "v2.11", isCurrent: false }],
+      type: "university-content",
+    },
   ];
 
   it("should return data sources for a valid request", async () => {

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
@@ -15,7 +15,7 @@ describe("makeListDataSourcesRoute", () => {
   const mockDataSources: DataSourceMetadata[] = [
     {
       id: "source1",
-      version: [
+      versions: [
         { label: "current", isCurrent: true },
         { label: "v6.0", isCurrent: false },
       ],
@@ -23,7 +23,7 @@ describe("makeListDataSourcesRoute", () => {
     },
     {
       id: "source2",
-      version: [{ label: "v2.11", isCurrent: false }],
+      versions: [{ label: "v2.11", isCurrent: false }],
       type: "university-content",
     },
   ];

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.test.ts
@@ -3,7 +3,7 @@ import type {
   DataSourceMetadata,
 } from "mongodb-rag-core";
 import { createRequest, createResponse } from "node-mocks-http";
-import { makeListDataSourcesRoute } from "./listDataSources";
+import { ERROR_MESSAGES, makeListDataSourcesRoute } from "./listDataSources";
 
 function makeMockEmbeddedContentStore(dataSources: DataSourceMetadata[]) {
   return {
@@ -60,7 +60,7 @@ describe("makeListDataSourcesRoute", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(handler(req, res as any)).rejects.toMatchObject({
-      message: "Unable to list data sources",
+      message: ERROR_MESSAGES.UNABLE_TO_LIST_DATA_SOURCES,
       httpStatus: 500,
       name: "RequestError",
     });

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
@@ -40,7 +40,7 @@ export function makeListDataSourcesRoute({
   embeddedContentStore,
 }: MakeListDataSourcesRouteParams) {
   return async (
-    req: ExpressRequest,
+    _req: ExpressRequest,
     res: ExpressResponse<ListDataSourcesResponseBody, ContentRouterLocals>
   ) => {
     try {

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
@@ -3,23 +3,17 @@ import {
   Response as ExpressResponse,
 } from "express";
 import {
-  FindContentResult,
+  DataSourceMetadata,
   MongoDbEmbeddedContentStore,
-  MongoDbSearchResultsStore,
-  QueryFilters,
-  SearchRecordDataSource,
 } from "mongodb-rag-core";
 import { z } from "zod";
 
-import { generateZodErrorMessage, SomeExpressRequest } from "../../middleware";
+import { SomeExpressRequest } from "../../middleware";
 import { makeRequestError } from "../conversations/utils";
 import {
-  SearchContentCustomData,
   ContentRouterLocals,
 } from "./contentRouter";
 import { AddCustomDataFunc } from "../../processors";
-import { wrapTraced } from "mongodb-rag-core/braintrust";
-
 
 export type GetDataSourcesRequest = z.infer<typeof GetDataSourcesRequest>;
 
@@ -31,24 +25,16 @@ export const GetDataSourcesRequest = SomeExpressRequest.merge(
   })
 );
 
-export interface DataSourceMetadata {
-  id: string;
-  version?: string[];
-  type?: string;
-}
-
 export interface ListDataSourcesResponseBody {
   dataSources: DataSourceMetadata[];
 }
 
 export interface MakeListDataSourcesRouteParams {
   embeddedContentStore: MongoDbEmbeddedContentStore;
-  addCustomData?: AddCustomDataFunc;
 }
 
 export function makeListDataSourcesRoute({
   embeddedContentStore,
-  addCustomData
 }: MakeListDataSourcesRouteParams) {
   return async (
     req: ExpressRequest,
@@ -57,17 +43,7 @@ export function makeListDataSourcesRoute({
     try {
       // Fetch data sources from the store
       const dataSources = await embeddedContentStore.listDataSources();
-
-      // Map to the required shape
-      // const result: DataSourceMetadata[] = dataSources.map((ds: any) => ({
-      //   id: ds.id,
-      //   version: ds.version ? (Array.isArray(ds.version) ? ds.version : [ds.version]) : undefined,
-      //   type: ds.type,
-      // }));
-
-      console.log("data sources ", dataSources);
-
-      // res.json({ dataSources: result });
+      res.json({ dataSources });
     } catch (error) {
       throw makeRequestError({
         httpStatus: 500,
@@ -75,81 +51,4 @@ export function makeListDataSourcesRoute({
       });
     }
   };
-}
-
-// function mapFindContentResultToSearchContentResponseChunk(
-//   result: FindContentResult
-// ): GetDataSourcesResponseBody {
-//   return {
-//     results: result.content.map(({ url, metadata, text }) => ({
-//       url,
-//       title: metadata?.pageTitle ?? "",
-//       text,
-//       metadata,
-//     })),
-//   };
-// }
-
-function mapDataSourcesToFilters(
-  dataSources?: SearchRecordDataSource[]
-): QueryFilters {
-  if (!dataSources || dataSources.length === 0) {
-    return {};
-  }
-
-  const sourceNames = dataSources.map((ds) => ds.name);
-  const sourceTypes = dataSources
-    .map((ds) => ds.type)
-    .filter((t): t is string => !!t);
-  const versionLabels = dataSources
-    .map((ds) => ds.versionLabel)
-    .filter((v): v is string => !!v);
-
-  return {
-    ...(sourceNames.length && { sourceName: sourceNames }),
-    ...(sourceTypes.length && { sourceType: sourceTypes }),
-    ...(versionLabels.length && { version: { label: versionLabels } }),
-  };
-}
-
-async function persistSearchResultsToDatabase({
-  query,
-  results,
-  dataSources = [],
-  limit,
-  searchResultsStore,
-  customData,
-}: {
-  query: string;
-  results: FindContentResult;
-  dataSources?: SearchRecordDataSource[];
-  limit: number;
-  searchResultsStore: MongoDbSearchResultsStore;
-  customData?: { [k: string]: unknown };
-}) {
-  searchResultsStore.saveSearchResult({
-    query,
-    results: results.content,
-    dataSources,
-    limit,
-    createdAt: new Date(),
-    ...(customData !== undefined && { customData }),
-  });
-}
-
-async function getCustomData(
-  req: ExpressRequest,
-  res: ExpressResponse<ListDataSourcesResponseBody, ContentRouterLocals>,
-  addCustomData?: AddCustomDataFunc
-): Promise<SearchContentCustomData | undefined> {
-  try {
-    if (addCustomData) {
-      return await addCustomData(req, res);
-    }
-  } catch (error) {
-    throw makeRequestError({
-      httpStatus: 500,
-      message: "Error parsing custom data from the request",
-    });
-  }
 }

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
@@ -1,0 +1,155 @@
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+import {
+  FindContentResult,
+  MongoDbEmbeddedContentStore,
+  MongoDbSearchResultsStore,
+  QueryFilters,
+  SearchRecordDataSource,
+} from "mongodb-rag-core";
+import { z } from "zod";
+
+import { generateZodErrorMessage, SomeExpressRequest } from "../../middleware";
+import { makeRequestError } from "../conversations/utils";
+import {
+  SearchContentCustomData,
+  ContentRouterLocals,
+} from "./contentRouter";
+import { AddCustomDataFunc } from "../../processors";
+import { wrapTraced } from "mongodb-rag-core/braintrust";
+
+
+export type GetDataSourcesRequest = z.infer<typeof GetDataSourcesRequest>;
+
+export const GetDataSourcesRequest = SomeExpressRequest.merge(
+  z.object({
+    headers: z.object({
+      "req-id": z.string(),
+    }),
+  })
+);
+
+export interface DataSourceMetadata {
+  id: string;
+  version?: string[];
+  type?: string;
+}
+
+export interface ListDataSourcesResponseBody {
+  dataSources: DataSourceMetadata[];
+}
+
+export interface MakeListDataSourcesRouteParams {
+  embeddedContentStore: MongoDbEmbeddedContentStore;
+  addCustomData?: AddCustomDataFunc;
+}
+
+export function makeListDataSourcesRoute({
+  embeddedContentStore,
+  addCustomData
+}: MakeListDataSourcesRouteParams) {
+  return async (
+    req: ExpressRequest,
+    res: ExpressResponse<ListDataSourcesResponseBody, ContentRouterLocals>
+  ) => {
+    try {
+      // Fetch data sources from the store
+      const dataSources = await embeddedContentStore.listDataSources();
+
+      // Map to the required shape
+      // const result: DataSourceMetadata[] = dataSources.map((ds: any) => ({
+      //   id: ds.id,
+      //   version: ds.version ? (Array.isArray(ds.version) ? ds.version : [ds.version]) : undefined,
+      //   type: ds.type,
+      // }));
+
+      console.log("data sources ", dataSources);
+
+      // res.json({ dataSources: result });
+    } catch (error) {
+      throw makeRequestError({
+        httpStatus: 500,
+        message: "Unable to list data sources",
+      });
+    }
+  };
+}
+
+// function mapFindContentResultToSearchContentResponseChunk(
+//   result: FindContentResult
+// ): GetDataSourcesResponseBody {
+//   return {
+//     results: result.content.map(({ url, metadata, text }) => ({
+//       url,
+//       title: metadata?.pageTitle ?? "",
+//       text,
+//       metadata,
+//     })),
+//   };
+// }
+
+function mapDataSourcesToFilters(
+  dataSources?: SearchRecordDataSource[]
+): QueryFilters {
+  if (!dataSources || dataSources.length === 0) {
+    return {};
+  }
+
+  const sourceNames = dataSources.map((ds) => ds.name);
+  const sourceTypes = dataSources
+    .map((ds) => ds.type)
+    .filter((t): t is string => !!t);
+  const versionLabels = dataSources
+    .map((ds) => ds.versionLabel)
+    .filter((v): v is string => !!v);
+
+  return {
+    ...(sourceNames.length && { sourceName: sourceNames }),
+    ...(sourceTypes.length && { sourceType: sourceTypes }),
+    ...(versionLabels.length && { version: { label: versionLabels } }),
+  };
+}
+
+async function persistSearchResultsToDatabase({
+  query,
+  results,
+  dataSources = [],
+  limit,
+  searchResultsStore,
+  customData,
+}: {
+  query: string;
+  results: FindContentResult;
+  dataSources?: SearchRecordDataSource[];
+  limit: number;
+  searchResultsStore: MongoDbSearchResultsStore;
+  customData?: { [k: string]: unknown };
+}) {
+  searchResultsStore.saveSearchResult({
+    query,
+    results: results.content,
+    dataSources,
+    limit,
+    createdAt: new Date(),
+    ...(customData !== undefined && { customData }),
+  });
+}
+
+async function getCustomData(
+  req: ExpressRequest,
+  res: ExpressResponse<ListDataSourcesResponseBody, ContentRouterLocals>,
+  addCustomData?: AddCustomDataFunc
+): Promise<SearchContentCustomData | undefined> {
+  try {
+    if (addCustomData) {
+      return await addCustomData(req, res);
+    }
+  } catch (error) {
+    throw makeRequestError({
+      httpStatus: 500,
+      message: "Error parsing custom data from the request",
+    });
+  }
+}

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
@@ -13,7 +13,6 @@ import { makeRequestError } from "../conversations/utils";
 import {
   ContentRouterLocals,
 } from "./contentRouter";
-import { AddCustomDataFunc } from "../../processors";
 
 export type GetDataSourcesRequest = z.infer<typeof GetDataSourcesRequest>;
 

--- a/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/listDataSources.ts
@@ -32,6 +32,10 @@ export interface MakeListDataSourcesRouteParams {
   embeddedContentStore: MongoDbEmbeddedContentStore;
 }
 
+export const ERROR_MESSAGES = {
+  UNABLE_TO_LIST_DATA_SOURCES: "Unable to list data sources",
+};
+
 export function makeListDataSourcesRoute({
   embeddedContentStore,
 }: MakeListDataSourcesRouteParams) {
@@ -46,7 +50,7 @@ export function makeListDataSourcesRoute({
     } catch (error) {
       throw makeRequestError({
         httpStatus: 500,
-        message: "Unable to list data sources",
+        message: ERROR_MESSAGES.UNABLE_TO_LIST_DATA_SOURCES,
       });
     }
   };

--- a/packages/mongodb-chatbot-server/src/routes/content/searchContent.ts
+++ b/packages/mongodb-chatbot-server/src/routes/content/searchContent.ts
@@ -16,7 +16,7 @@ import { generateZodErrorMessage, SomeExpressRequest } from "../../middleware";
 import { makeRequestError } from "../conversations/utils";
 import {
   SearchContentCustomData,
-  SearchContentRouterLocals,
+  ContentRouterLocals,
 } from "./contentRouter";
 import { AddCustomDataFunc } from "../../processors";
 import { wrapTraced } from "mongodb-rag-core/braintrust";
@@ -69,7 +69,7 @@ export function makeSearchContentRoute({
   const tracedFindContent = wrapTraced(findContent, { name: "searchContent" });
   return async (
     req: ExpressRequest<SearchContentRequest["params"]>,
-    res: ExpressResponse<SearchContentResponseBody, SearchContentRouterLocals>
+    res: ExpressResponse<SearchContentResponseBody, ContentRouterLocals>
   ) => {
     try {
       // --- INPUT VALIDATION ---
@@ -169,7 +169,7 @@ async function persistSearchResultsToDatabase({
 
 async function getCustomData(
   req: ExpressRequest,
-  res: ExpressResponse<SearchContentResponseBody, SearchContentRouterLocals>,
+  res: ExpressResponse<SearchContentResponseBody, ContentRouterLocals>,
   addCustomData?: AddCustomDataFunc
 ): Promise<SearchContentCustomData | undefined> {
   try {

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -106,7 +106,7 @@ export type QueryFilters = {
 */
 export type DataSourceMetadata = {
   id: string;
-  version?: string[];
+  version?: { label: string, isCurrent: boolean; }[];
   type?: string;
 }
 

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -106,7 +106,7 @@ export type QueryFilters = {
 */
 export type DataSourceMetadata = {
   id: string;
-  version?: { label: string, isCurrent: boolean; }[];
+  versions?: { label: string, isCurrent: boolean; }[];
   type?: string;
 }
 

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -105,9 +105,9 @@ export type QueryFilters = {
   Metadata of data source
 */
 export type DataSourceMetadata = {
-  sourceName: string;
+  id: string;
   version?: string[];
-  sourceType?: string;
+  type?: string;
 }
 
 /**

--- a/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
+++ b/packages/mongodb-rag-core/src/contentStore/EmbeddedContent.ts
@@ -101,6 +101,15 @@ export type QueryFilters = {
   sourceType?: Page["sourceType"] | string[];
 };
 
+/** 
+  Metadata of data source
+*/
+export type DataSourceMetadata = {
+  sourceName: string;
+  version?: string[];
+  sourceType?: string;
+}
+
 /**
   Data store of the embedded content.
  */
@@ -140,6 +149,11 @@ export type EmbeddedContentStore = VectorStore<EmbeddedContent> & {
     Initialize the store.
    */
   init?: () => Promise<void>;
+
+  /**
+    Lists all unique data sources
+   */
+  listDataSources(): Promise<DataSourceMetadata[]>;
 
   /**
    Get the names of ingested data sources that match the given query. 

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./MongoDbEmbeddedContentStore";
 import { MongoClient } from "mongodb";
 import { EmbeddedContent } from "./EmbeddedContent";
-import { MONGO_MEMORY_REPLICA_SET_URI } from "../test/constants";
+import { MONGO_MEMORY_REPLICA_SET_URI, MONGO_MEMORY_SERVER_URI } from "../test/constants";
 
 const {
   MONGODB_CONNECTION_URI,
@@ -469,7 +469,7 @@ describe("listDataSources", () => {
   let mongoClient: MongoClient | undefined;
   beforeEach(async () => {
     store = makeMongoDbEmbeddedContentStore({
-      connectionUri: MONGO_MEMORY_REPLICA_SET_URI,
+      connectionUri: MONGO_MEMORY_SERVER_URI,
       databaseName: MONGODB_DATABASE_NAME,
       searchIndex: { embeddingName: "test-list-data-sources" },
     });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -471,7 +471,7 @@ describe("listDataSources", () => {
     store = makeMongoDbEmbeddedContentStore({
       connectionUri: MONGO_MEMORY_REPLICA_SET_URI,
       databaseName: MONGODB_DATABASE_NAME,
-      searchIndex: { embeddingName: "test-embedding" },
+      searchIndex: { embeddingName: "test-list-data-sources" },
     });
     mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
   });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -469,8 +469,9 @@ describe("listDataSources", () => {
   let mongoClient: MongoClient | undefined;
   beforeEach(async () => {
     store = makeMongoDbEmbeddedContentStore({
-      connectionUri: MONGO_MEMORY_SERVER_URI,
+      connectionUri: MONGODB_CONNECTION_URI,
       databaseName: MONGODB_DATABASE_NAME,
+      collectionName: "test-list-data-sources-collection",
       searchIndex: { embeddingName: "test-list-data-sources" },
     });
     mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
@@ -479,7 +480,6 @@ describe("listDataSources", () => {
   afterEach(async () => {
     assert(store);
     assert(mongoClient);
-    await store.drop();
     await store.close();
     await mongoClient.close();
   });
@@ -553,7 +553,7 @@ describe("listDataSources", () => {
     const sourceB = result.find((ds) => ds.id === "mongodb-university");
     expect(sourceB).toBeDefined();
     expect(sourceB!.type).toBe("web");
-    expect(sourceB!.versions).toEqual([{ label: "v1.0", isCurrent: true }]);
+    expect(sourceB!.versions).toEqual([{ label: "v1.0", isCurrent: false }]);
     // mongoid should have empty versions array
     const sourceC = result.find((ds) => ds.id === "mongoid");
     expect(sourceC).toBeDefined();

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.test.ts
@@ -8,6 +8,7 @@ import "dotenv/config";
 import { PersistedPage } from ".";
 import {
   MongoDbEmbeddedContentStore,
+  listDataSourcesCache,
   makeMongoDbEmbeddedContentStore,
 } from "./MongoDbEmbeddedContentStore";
 import { MongoClient } from "mongodb";
@@ -467,6 +468,16 @@ describe("initialized DB", () => {
 describe("listDataSources", () => {
   let store: MongoDbEmbeddedContentStore | undefined;
   let mongoClient: MongoClient | undefined;
+  let dateNowSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    dateNowSpy = jest.spyOn(Date, "now");
+  });
+
+  afterAll(() => {
+    dateNowSpy.mockRestore();
+  });
+
   beforeEach(async () => {
     store = makeMongoDbEmbeddedContentStore({
       connectionUri: MONGODB_CONNECTION_URI,
@@ -475,6 +486,11 @@ describe("listDataSources", () => {
       searchIndex: { embeddingName: "test-list-data-sources" },
     });
     mongoClient = new MongoClient(MONGODB_CONNECTION_URI);
+
+    listDataSourcesCache.data = null;
+    listDataSourcesCache.expiresAt = 0;
+    listDataSourcesCache.isRefreshing = false;
+    dateNowSpy.mockReset();
   });
 
   afterEach(async () => {
@@ -559,5 +575,63 @@ describe("listDataSources", () => {
     expect(sourceC).toBeDefined();
     expect(sourceC!.type).toBe("blog");
     expect(sourceC!.versions).toEqual([]);
+  });
+
+  it("returns cached data if cache is fresh (<24hrs)", async () => {
+    const now = 1720000000000;
+    dateNowSpy.mockImplementation(() => now);
+
+    const mockCachedData = [{ id: "name1" }];
+    listDataSourcesCache.data = mockCachedData;
+    listDataSourcesCache.expiresAt = now + 1000 * 60 * 60 * 12; // 12 hrs later
+
+    assert(store);
+    const result = await store.listDataSources();
+    expect(result).toBe(mockCachedData);
+  });
+
+  it("returns stale data and triggers background refresh if cache is >24hrs but <7d", async () => {
+    const now = 1720000000000;
+    dateNowSpy.mockImplementation(() => now);
+
+    const staleData = [{ id: "name2" }];
+    listDataSourcesCache.data = staleData;
+    listDataSourcesCache.expiresAt = now - 1000; // 1 sec ago
+
+    assert(store);
+    const result = await store.listDataSources();
+
+    expect(result).toBe(staleData); // Still returns stale
+    expect(listDataSourcesCache.isRefreshing).toBe(true); // Refresh triggered
+  });
+
+  it("blocks and fetches fresh data if cache is >7d", async () => {
+    const now = 1720000000000;
+    dateNowSpy.mockImplementation(() => now);
+
+    listDataSourcesCache.data = null;
+    listDataSourcesCache.expiresAt = now - 1000 * 60 * 60 * 24 * 8; // 8 days ago
+
+    assert(store);
+
+    // Insert real data into the collection so it can be fetched fresh
+    const coll = mongoClient
+      ?.db(store.metadata.databaseName)
+      .collection<EmbeddedContent>(store.metadata.collectionName);
+    await coll?.deleteMany({});
+    await coll?.insertOne({
+      sourceName: "docs",
+      url: "/test",
+      text: "text",
+      tokenCount: 1,
+      embeddings: { test: [0.1] },
+      updated: new Date(),
+      sourceType: "docs",
+      metadata: { version: { label: "v12.0", isCurrent: true } },
+    });
+
+    const result = await store.listDataSources();
+    expect(result.length).toBeGreaterThan(0); // Real fetch happened
+    expect(result).toStrictEqual([{ id: "docs", versions: [{ label: "v12.0", isCurrent: true }], type: "docs" }])
   });
 });

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
@@ -281,7 +281,7 @@ export function makeMongoDbEmbeddedContentStore({
           {
             $group: {
               _id: "$sourceName",
-              version: {
+              versions: {
                 $addToSet: {
                   label: "$metadata.version.label",
                   isCurrent: "$metadata.version.isCurrent",
@@ -294,11 +294,11 @@ export function makeMongoDbEmbeddedContentStore({
             $project: {
               _id: 0,
               id: "$_id",
-              version: {
+              versions: {
                 $map: {
                   input: {
                     $filter: {
-                      input: "$version",
+                      input: "$versions",
                       as: "v",
                       cond: { $ne: ["$$v.label", null] },
                     },

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
@@ -283,8 +283,14 @@ export function makeMongoDbEmbeddedContentStore({
               _id: "$sourceName",
               versions: {
                 $addToSet: {
-                  label: "$metadata.version.label",
-                  isCurrent: "$metadata.version.isCurrent",
+                  $cond: [
+                    { $ifNull: ["$metadata.version.label", false] },
+                    {
+                      label: "$metadata.version.label",
+                      isCurrent: "$metadata.version.isCurrent",
+                    },
+                    "$$REMOVE",
+                  ],
                 },
               },
               sourceType: { $addToSet: "$sourceType" },

--- a/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
+++ b/packages/mongodb-rag-core/src/contentStore/MongoDbEmbeddedContentStore.ts
@@ -288,7 +288,7 @@ export function makeMongoDbEmbeddedContentStore({
           {
             $project: {
               _id: 0,
-              sourceName: "$_id",
+              id: "$_id",
               version: {
                 $filter: {
                   input: "$version",
@@ -296,7 +296,7 @@ export function makeMongoDbEmbeddedContentStore({
                   cond: { $ne: ["$$v", null] },
                 },
               },
-              sourceType: {
+              type: {
                 $arrayElemAt: [
                   {
                     $filter: {
@@ -314,10 +314,10 @@ export function makeMongoDbEmbeddedContentStore({
         .toArray();
 
       // Explicitly map to DataSourceMetadata
-      return result.map(({ sourceName, version, sourceType }) => ({
-        sourceName,
+      return result.map(({ id, version, type }) => ({
+        id,
         version,
-        sourceType,
+        type,
       }));
     },
 

--- a/packages/mongodb-rag-core/src/contentStore/updateEmbeddedContent.test.ts
+++ b/packages/mongodb-rag-core/src/contentStore/updateEmbeddedContent.test.ts
@@ -13,6 +13,7 @@ import {
 import { makeMockPageStore } from "../test/MockPageStore";
 import * as chunkPageModule from "../chunk/chunkPage";
 import {
+  DataSourceMetadata,
   EmbeddedContentStore,
   EmbeddedContent,
   GetSourcesMatchParams,
@@ -43,6 +44,9 @@ export const makeMockEmbeddedContentStore = (): EmbeddedContentStore => {
     },
     metadata: {
       embeddingName: "test",
+    },
+    async listDataSources(): Promise<DataSourceMetadata[]> {
+      return [];
     },
     async getDataSources(matchQuery: GetSourcesMatchParams): Promise<string[]> {
       return [];

--- a/packages/mongodb-rag-core/src/findContent/BoostOnAtlasSearchFilter.test.ts
+++ b/packages/mongodb-rag-core/src/findContent/BoostOnAtlasSearchFilter.test.ts
@@ -69,6 +69,9 @@ describe("makeBoostOnAtlasSearchFilter()", () => {
       async findNearestNeighbors() {
         return mockBoostedResults;
       },
+      async listDataSources() {
+        return [];
+      },
       async getDataSources(matchQuery) {
         return [];
       },


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1173

## Changes

- Adds new GET `/content/sources` endpoint to list all data sources possible
- Adds route handler and tests for route handler
- Adds documentation for new route in openapi yaml