### PR TITLE
(EAI-1180) VoyageAI allowed in guardrail

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/mongoDbInputGuardrail.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/mongoDbInputGuardrail.eval.ts
@@ -391,7 +391,19 @@ const evalCases: MongoDbGuardrailEvalCase[] = [
     input: "What is Voyage AI?",
     expected: {
       reason:
-        "This query asks about Voyage AI, which is a valid query and should not be rejected.",
+        "This query asks about Voyage AI. VoyageAI is a subsidary of MongoDB, so this is a valid query and should not be rejected.",
+      rejected: false,
+      metadata: {
+        type: "valid",
+      },
+    },
+    tags: ["valid"],
+  },
+  {
+    input: "Most efficient Voyage embedding model",
+    expected: {
+      reason:
+        "This query asks about Voyage AI embedding models, which is a valid topic and should not be rejected.",
       rejected: false,
       metadata: {
         type: "valid",

--- a/packages/chatbot-server-mongodb-public/src/processors/mongoDbInputGuardrail.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/mongoDbInputGuardrail.ts
@@ -137,6 +137,14 @@ const fewShotExamples: {
       type: "unknown",
     },
   },
+  {
+    input: "how to use the Voyage embeddings API",
+    output: {
+      reasoning:
+        "This query is related to Voyage AI, a subsidary of MongoDB, and is therefore relevant.",
+      type: "valid",
+    },
+  },
 ];
 
 const systemPrompt = `You are the guardrail on an AI chatbot for MongoDB. You must determine whether a user query is valid, irrelevant, or inappropriate, or unknown.
@@ -163,6 +171,7 @@ Relevant topics include (this list is NOT exhaustive):
 - Non-English queries: Accept ALL queries in any language, regardless of content unless it is explicitly inappropriate or irrelevant
 - Vague or unclear queries: If it is unclear whether a query is relevant, ALWAYS accept it
 - Questions about MongoDB company, sales, support, or business inquiries
+- Questions about the company Voyage AI or its embedding models, as Voyage AI is owned by MongoDB
 - Single words, symbols, or short phrases that might be MongoDB-related
 - ANY technical question, even if the connection to MongoDB isn't immediately obvious
 - If there is ANY possible connection to technology, databases, or business, classify as valid.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1180

## Changes

- Add VoyageAI company and its embedding models as allowed query topics to guardrail

## Notes

- [guardrail eval](https://www.braintrust.dev/app/mongodb-education-ai/p/user-message-guardrail/experiments/gpt-4.1-nano-970ed90d?c=gpt-4.1-nano-43f2de8f&tg=false)
- [conversations eval (voyage cases)](https://www.braintrust.dev/app/mongodb-education-ai/p/mongodb-chatbot-conversations/experiments/mongodb-chatbot-voyage-in-guardrail?c=mongodb-chatbot-skills-questions-fcd08da7&tg=false)
