### PR TITLE
(EAI-1190) fix eval experiments

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -228,10 +228,7 @@ interface MakeGenerateResponseParams {
   verifiedAnswerStream: MakeVerifiedAnswerGenerateResponseParams["stream"];
 }
 
-export const makeGenerateResponse = ({
-  responseWithSearchToolStream,
-  verifiedAnswerStream,
-}: MakeGenerateResponseParams) =>
+export const makeGenerateResponse = (args?: MakeGenerateResponseParams) =>
   wrapTraced(
     makeVerifiedAnswerGenerateResponse({
       findVerifiedAnswer,
@@ -241,7 +238,7 @@ export const makeGenerateResponse = ({
           references: verifiedAnswer.references.map(addReferenceSourceType),
         };
       },
-      stream: verifiedAnswerStream,
+      stream: args?.verifiedAnswerStream,
       onNoVerifiedAnswerFound: wrapTraced(
         makeGenerateResponseWithSearchTool({
           languageModel,
@@ -264,7 +261,7 @@ export const makeGenerateResponse = ({
           searchTool: makeSearchTool(findContent),
           toolChoice: "auto",
           maxSteps: 5,
-          stream: responseWithSearchToolStream,
+          stream: args?.responseWithSearchToolStream,
         }),
         { name: "generateResponseWithSearchTool" }
       ),

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/allScorersTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/allScorersTest.eval.ts
@@ -10,7 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { generateResponse } from "../../config";
+import { makeGenerateResponse } from "../../config";
 
 async function conversationEval() {
   // Get all the conversation eval cases from YAML
@@ -37,7 +37,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generateResponse,
+    generateResponse: makeGenerateResponse(),
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/architectureCenter.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/architectureCenter.eval.ts
@@ -10,7 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { generateResponse } from "../../config";
+import { makeGenerateResponse } from "../../config";
 
 async function conversationEval() {
   // Get ONLY architecture center conversations
@@ -37,7 +37,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generateResponse,
+    generateResponse: makeGenerateResponse(),
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/dotcomQuestionsTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/dotcomQuestionsTest.eval.ts
@@ -10,7 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { generateResponse } from "../../config";
+import { makeGenerateResponse } from "../../config";
 
 async function conversationEval() {
   // Get dotcom question set eval cases from YAML
@@ -40,7 +40,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generateResponse,
+    generateResponse: makeGenerateResponse(),
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/src/eval/experiments/skillsQuestionsTest.eval.ts
+++ b/packages/chatbot-server-mongodb-public/src/eval/experiments/skillsQuestionsTest.eval.ts
@@ -10,7 +10,7 @@ import {
 import fs from "fs";
 import path from "path";
 import { makeConversationEval } from "../ConversationEval";
-import { generateResponse } from "../../config";
+import { makeGenerateResponse } from "../../config";
 
 async function conversationEval() {
   // Get dotcom question set eval cases from YAML
@@ -40,7 +40,7 @@ async function conversationEval() {
         apiVersion: OPENAI_API_VERSION,
       },
     },
-    generateResponse,
+    generateResponse: makeGenerateResponse(),
   });
 }
 conversationEval();

--- a/packages/chatbot-server-mongodb-public/tsconfig.build.json
+++ b/packages/chatbot-server-mongodb-public/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.ts", "**/*.eval.ts", "**/eval/**/*", "**/test/**/*"]
+  "exclude": ["**/*.test.ts", "**/test/**/*"]
 }

--- a/packages/mongodb-rag-core/src/index.ts
+++ b/packages/mongodb-rag-core/src/index.ts
@@ -24,3 +24,4 @@ export * from "./VectorStore";
 export * from "./arrayFilters";
 export * from "./assertEnvVars";
 export * from "./getEnv";
+export * from "./mongoDbMetadata";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1190

## Changes

- using `makeGenerateResponse` instead of `generateResponse` in evals/experiments files
- tsconfig file was excluding `"**/*.eval.ts", "**/eval/**/*"`, I removed this so that these files will be included in the build and the build will fail if there are changes to the config that need to be reflected in evals/experiments files
- found a build error when doing this (Module '"mongodb-rag-core"' has no exported member 'validateTags'.), which I fixed with the change to the `mongodb-rag-core/src/index.ts` file

## Notes

-
