### PR TITLE
(EAI-1201): Add Braintrust tracing to Responses API

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/responsesApi.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/responsesApi.test.ts
@@ -397,7 +397,10 @@ describe("Responses API with OpenAI Client", () => {
     });
   });
 
-  describe("Braintrust tracing", () => {
+  // Skipping these tests because they require manual validation
+  // in the Braintrust UI. There isn't presently a good way to
+  // validate the tracing data in the tests.
+  describe.skip("Braintrust tracing", () => {
     let logger: Logger<true>;
     beforeAll(async () => {
       logger = makeBraintrustLogger({

--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
@@ -14,7 +14,7 @@ import {
   makeDataStreamer,
 } from "mongodb-rag-core";
 import { SomeExpressRequest } from "../../middleware";
-import { getRequestId } from "../../utils";
+import { getRequestId, makeTraceConversation } from "../../utils";
 import type { GenerateResponse } from "../../processors";
 import {
   makeBadRequestError,
@@ -24,6 +24,7 @@ import {
   ERROR_TYPE,
   type SomeOpenAIAPIError,
 } from "./errors";
+import { traced, wrapNoTrace, wrapTraced } from "mongodb-rag-core/braintrust";
 
 export const ERR_MSG = {
   INPUT_STRING: "Input must be a non-empty string",
@@ -321,16 +322,31 @@ export function makeCreateResponseRoute({
       // Convert input to latestMessageText format
       const latestMessageText = convertInputToLatestMessageText(input, headers);
 
-      const { messages } = await generateResponse({
+      const traceMetadata = {
+        name: "generateResponse",
+        event: {
+          id: responseId.toHexString(),
+          metadata: {
+            conversationId: conversation._id.toHexString(),
+            store,
+          },
+        },
+      };
+
+      // Create a wrapper trace. This always creates a top-level trace.
+      // It only traces the contents of the generateResponse function
+      // if `store` is true.
+      const generateResponseMaybeTraced = store
+        ? wrapTraced(generateResponse, traceMetadata)
+        : traced(() => wrapNoTrace(generateResponse), traceMetadata);
+
+      const { messages } = await generateResponseMaybeTraced({
         shouldStream: stream,
         latestMessageText,
         customSystemPrompt: instructions,
         toolDefinitions: tools,
         toolChoice: tool_choice,
-        // TODO: fix these
-        // clientContext ??
-        // customData ??
-        conversation,
+        conversation: makeTraceConversation(conversation),
         dataStreamer,
         reqId,
       });

--- a/packages/mongodb-rag-core/src/aiSdk.ts
+++ b/packages/mongodb-rag-core/src/aiSdk.ts
@@ -1,4 +1,4 @@
 export * from "ai";
 export * from "@ai-sdk/azure";
 export * from "@ai-sdk/openai";
-export { mockId, mockValues, MockEmbeddingModelV2 } from "ai/test";
+export { mockId, mockValues, MockLanguageModelV2 } from "ai/test";

--- a/packages/mongodb-rag-core/src/aiSdk.ts
+++ b/packages/mongodb-rag-core/src/aiSdk.ts
@@ -1,9 +1,4 @@
 export * from "ai";
 export * from "@ai-sdk/azure";
 export * from "@ai-sdk/openai";
-export {
-  MockLanguageModelV2,
-  mockId,
-  mockValues,
-  MockEmbeddingModelV2,
-} from "ai/test";
+export { mockId, mockValues, MockEmbeddingModelV2 } from "ai/test";

--- a/packages/mongodb-rag-core/src/braintrust.ts
+++ b/packages/mongodb-rag-core/src/braintrust.ts
@@ -1,4 +1,11 @@
-import { DatasetRecord, initDataset, initLogger, Logger } from "braintrust";
+import {
+  DatasetRecord,
+  initDataset,
+  initLogger,
+  Logger,
+  NoopSpan,
+  withCurrent,
+} from "braintrust";
 import { z } from "zod";
 
 export * from "braintrust";
@@ -51,4 +58,14 @@ export async function getDatasetFromBraintrust<SchemaReturnType>({
     datasetRowSchema.parse(d)
   );
   return datasetRows;
+}
+
+export function wrapNoTrace<T extends (...args: any[]) => any>(
+  fn: T
+): (...args: Parameters<T>) => Promise<ReturnType<T>> {
+  return async function (...args: Parameters<T>): Promise<ReturnType<T>> {
+    return withCurrent(new NoopSpan(), async () => {
+      return fn(...args);
+    });
+  };
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1201

## Changes

- Add Braintrust tracing to Responses API. 
  - Tracing in Responses API is conditional on `store !== false`. If `store: false`, provide a tombstone trace in Braintrust that contains no data besides the IDs.
- Included tests to see that this works, but skipped b/c there is currently no way to validate functionality besides through the Braintrust UI, to best of my knowledge.

## Notes

- Examples of this working:
  - [Tombstone](https://www.braintrust.dev/app/mongodb-education-ai/p/chatbot-responses-dev/logs?range=%223d%22&r=688a432697349958d96b0486)
  - [Populated information](https://www.braintrust.dev/app/mongodb-education-ai/p/chatbot-responses-dev/logs?range=%223d%22&r=688a432297349958d96b047f)
