### PR TITLE
(EAI-1189): Stream Responses API verified answer metadata

### DIFF
--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -744,22 +744,9 @@ components:
           type: integer
           description: Index of the annotation
         annotation:
-          type: object
-          properties:
-            type:
-              type: string
-              enum: [text_annotation]
-            text:
-              type: string
-              description: The annotation text content
-            start:
-              type: integer
-              description: Start position of the annotation
-            end:
-              type: integer
-              description: End position of the annotation
-          required: [type, text, start, end]
-          description: The annotation object
+          oneOf:
+            - $ref: "#/components/schemas/ResponseOutputTextAnnotationUrlCitation"
+            - $ref: "#/components/schemas/ResponseOutputTextAnnotationVerifiedAnswer"
         sequence_number:
           type: integer
           description: Sequence number of the event
@@ -767,6 +754,61 @@ components:
       description: |
         Event sent when a text annotation is added to response output.
         This is used to include references used by the internal search tool.
+    ResponseOutputTextAnnotationUrlCitation:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [url_citation]
+        url:
+          type: string
+          format: uri
+          description: |
+            URL to the reference. For example, "https://mongodb.com/docs/atlas/getting-started".
+        title:
+          type: string
+          description: |
+            Title of the reference. This is what shows up in
+            rendered links. For example, "How to connect to
+            MongoDB Atlas".
+        start_index:
+          type: integer
+          description: Start position of the annotation
+        end_index:
+          type: integer
+          description: End position of the annotation
+      required: [type, url, title, start_index, end_index]
+    ResponseOutputTextAnnotationVerifiedAnswer:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [file_citation]
+          # Note: placing description on the first property
+          # b/c our OpenAI spec renderer doesn't show
+          # descriptions for the top level object here :/
+          description: |
+            This annotation contains metadata about a verified answer. 
+
+            Note that this is a bit of a hack of the Responses API,
+            repurposing the `file_citation` type to include metadata
+            about a verified answer.
+            While a bit hacky, there aren't clear alternative better paths
+            that stay fully compliant with the Responses API.
+        file_id:
+          type: string
+          description: |
+            ID of the verified answer. 
+        filename:
+          type: string
+          enum: [verified_answer]
+        index:
+          type: integer
+          format: timestamp
+          description: |
+            Timestamp for when the verified answer was updated/created.
+            `0` if unknown.
+      required: [type, file_id, filename, index]
     ResponseOutputTextDeltaEvent:
       type: object
       properties:
@@ -1174,6 +1216,9 @@ tags:
   - name: Conversations
     x-displayName: Conversations
     description: Interact with MongoDB Chatbot
+  - name: Responses
+    x-displayName: Responses
+    description: Responses API
 
 x-tagGroups:
   - name: Content
@@ -1182,3 +1227,6 @@ x-tagGroups:
   - name: Conversations
     tags:
       - Conversations
+  - name: Responses
+    tags:
+      - Responses

--- a/packages/mongodb-chatbot-server/src/processors/makeVerifiedAnswerGenerateResponse.ts
+++ b/packages/mongodb-chatbot-server/src/processors/makeVerifiedAnswerGenerateResponse.ts
@@ -87,6 +87,22 @@ export const responsesVerifiedAnswerStream: MakeVerifiedAnswerGenerateResponsePa
           item_id: itemId,
         } satisfies ResponseStreamOutputTextAnnotationAdded);
       });
+      dataStreamer.streamResponses({
+        type: "response.output_text.annotation.added",
+        annotation: {
+          type: "file_citation",
+          file_id: verifiedAnswer._id,
+          filename: "verified_answer",
+          index:
+            verifiedAnswer.updated?.getTime() ??
+            verifiedAnswer.created?.getTime() ??
+            0,
+        },
+        annotation_index: verifiedAnswer.references.length, // One more than the last reference
+        content_index: 0,
+        output_index: 0,
+        item_id: itemId,
+      } satisfies ResponseStreamOutputTextAnnotationAdded);
 
       dataStreamer.streamResponses({
         type: "response.output_text.done",

--- a/packages/mongodb-rag-core/src/DataStreamer.ts
+++ b/packages/mongodb-rag-core/src/DataStreamer.ts
@@ -70,12 +70,16 @@ export type ResponseStreamOutputTextDelta = Omit<
   OpenAI.Responses.ResponseTextDeltaEvent,
   "sequence_number"
 >;
+
 export type ResponseStreamOutputTextAnnotationAdded = Omit<
   OpenAI.Responses.ResponseOutputTextAnnotationAddedEvent,
   "sequence_number" | "annotation"
 > & {
-  annotation: OpenAI.Responses.ResponseOutputText.URLCitation;
+  annotation:
+    | OpenAI.Responses.ResponseOutputText.FileCitation
+    | OpenAI.Responses.ResponseOutputText.URLCitation;
 };
+
 export type ResponseStreamOutputTextDone = Omit<
   OpenAI.Responses.ResponseTextDoneEvent,
   "sequence_number"


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1189

## Changes

- Stream Responses API Verified Answer metadata
- Document changes
  - Also small fix to existing url_citation annotation spec

## Notes

- We have to do a bit of a hacky implementation here b/c there's no clean, spec compliant way to stream the verified answer metdata. This PR contains my best attempt to include the verified answer metadata in way that balances spec compliance with being relatively reasonable. 
