### PR TITLE
Support 50 user messages in Responses API convo

### DIFF
--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -504,6 +504,8 @@ components:
             Including `previous_response_id` in the request causes the model
             to use the previous response as context.
 
+            Note that conversations support a maximum of 50 `user` messages. If you want to append more messages, create a new conversation. With previous content consolidated.
+
             Usage notes:
             - You can only use `previous_response_id` if `store: true`. 
             - All requests on the same conversation must have the same `user` ID leave it undefined.
@@ -812,7 +814,7 @@ components:
         file_id:
           type: string
           description: |
-            ID of the verified answer. 
+            ID of the verified answer.
         filename:
           type: string
           enum: [verified_answer]
@@ -1009,7 +1011,7 @@ components:
               description: Conversation ID
           additionalProperties:
             type: string
-          description: Additional metadata and conversation ID
+          description: Additional metadata
       required:
         [
           id,
@@ -1027,7 +1029,6 @@ components:
           tool_choice,
           tools,
           top_p,
-          metadata,
         ]
     StreamEventDelta:
       description: Assistant response text.

--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -504,7 +504,7 @@ components:
             Including `previous_response_id` in the request causes the model
             to use the previous response as context.
 
-            Note that conversations support a maximum of 50 `user` messages. If you want to append more messages, create a new conversation. With previous content consolidated.
+            Note that conversations support a maximum of 50 `user` messages. If you want to append more messages, create a new conversation with the previous content consolidated.
 
             Usage notes:
             - You can only use `previous_response_id` if `store: true`. 

--- a/docs/docs/server/openapi.yaml
+++ b/docs/docs/server/openapi.yaml
@@ -1011,7 +1011,7 @@ components:
               description: Conversation ID
           additionalProperties:
             type: string
-          description: Additional metadata
+          description: Additional metadata and conversation ID
       required:
         [
           id,
@@ -1029,6 +1029,7 @@ components:
           tool_choice,
           tools,
           top_p,
+          metadata,
         ]
     StreamEventDelta:
       description: Assistant response text.

--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -465,7 +465,7 @@ export const config: AppConfig = {
       }),
       supportedModels: ["mongodb-chat-latest"],
       maxOutputTokens: 4000,
-      maxUserMessagesInConversation: 6,
+      maxUserMessagesInConversation: 50,
       alwaysAllowedMetadataKeys: [
         "ip",
         "origin",


### PR DESCRIPTION
Jira: n/a
## Changes

- Support 50 user messages in Responses API convo
- update docs accordingly

## Notes

- IDK why it was only 6 before 🤔 
