### PR TITLE
(EAI-1245) querying Profound API with local (EDT) dates

### DIFF
--- a/packages/scripts/environments/production.yml
+++ b/packages/scripts/environments/production.yml
@@ -57,7 +57,7 @@ cronJobs:
     backoffLimit: 2
 
   - name: process-citations-for-metrics
-    schedule: "1 0 * * *" # every day at 00:01 (12:01 AM) UTC
+    schedule: "1 4 * * *" # every day at 04:01 UTC, after Profound is done processing prompts for the day
     command: ["npm", "run", "scripts:getLLMAnswers"]
     env:
       MONGODB_DATABASE_NAME: docs-chatbot-prod

--- a/packages/scripts/environments/staging.yml
+++ b/packages/scripts/environments/staging.yml
@@ -66,7 +66,7 @@ cronJobs:
     backoffLimit: 2
 
   - name: process-citations-for-metrics
-    schedule: "0 1 * * *" # every day at 1 AM UTC
+    schedule: "15 4 * * *" # every day at 04:15 UTC, after Profound is done processing prompts for the day
     command: ["npm", "run", "scripts:getLLMAnswers"]
     env:
       MONGODB_DATABASE_NAME: docs-chatbot-staging
@@ -87,7 +87,7 @@ cronJobs:
     backoffLimit: 2
 
   - name: process-citations-for-metrics-dev
-    schedule: "30 0 * * *" # every day at 00:30 (12:30 AM) UTC
+    schedule: "30 4 * * *" # every day at 04:30 UTC, after Profound is done processing prompts for the day
     command: ["npm", "run", "scripts:getLLMAnswers"]
     env:
       MONGODB_DATABASE_NAME: docs-chatbot-dev

--- a/packages/scripts/src/profound/getAndProcessAnswers.ts
+++ b/packages/scripts/src/profound/getAndProcessAnswers.ts
@@ -138,6 +138,13 @@ const model: ModelConfig = {
 export const main = async (startDateArg?: string, endDateArg?: string) => {
   // START setup
 
+  // validate date format in args
+  if (startDateArg && !/^\d{4}-\d{2}-\d{2}$/.test(startDateArg)) {
+    throw new Error("Invalid start date format. Please use YYYY-MM-DD.");
+  }
+  if (endDateArg && !/^\d{4}-\d{2}-\d{2}$/.test(endDateArg)) {
+    throw new Error("Invalid end date format. Please use YYYY-MM-DD.");
+  }
   // Determine date range from command line arguments, or default to yesterday --> today
   // Note: The Profound API expects date inputs in EST, bc they execute prompts within a 24 hour EST window.
   const today: Date = new Date();
@@ -145,16 +152,20 @@ export const main = async (startDateArg?: string, endDateArg?: string) => {
   yesterday.setDate(yesterday.getDate() - 1);
   const start: string = startDateArg
     ? startDateArg
-    : `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(
-        2,
-        "0"
-      )}-${String(yesterday.getDate()).padStart(2, "0")}`;
+    : new Intl.DateTimeFormat("en-CA", {
+        timeZone: "America/New_York",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(yesterday);
   const end: string = endDateArg
     ? endDateArg
-    : `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(
-        2,
-        "0"
-      )}-${String(today.getDate()).padStart(2, "0")}`;
+    : new Intl.DateTimeFormat("en-CA", {
+        timeZone: "America/New_York",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(today);
 
   const client = await MongoClient.connect(MONGODB_CONNECTION_URI);
   const db = client.db(MONGODB_DATABASE_NAME);
@@ -334,8 +345,8 @@ if (process.argv.includes("--help")) {
 Usage: node getAndProcessAnswers.js [startDate] [endDate]
 
 Optional arguments:
-  startDate   date string (e.g., 2025-06-01). If omitted, defaults to yesterday (EST).
-  endDate     date string (e.g., 2025-06-02). If omitted, defaults to today (EST).
+  startDate   YYYY-MM-DD date string (e.g., 2025-06-01). If omitted, defaults to yesterday (EST).
+  endDate     YYYY-MM-DD date string (e.g., 2025-06-02). If omitted, defaults to today (EST).
 
 The end date is exclusive. 
 For example, if you want to process answers from June 1st to June 5th, you should use 2025-06-01 and 2025-06-06.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1245

## Changes

- replaced UTC dates with local dates to match what Profound expects
- update cron schedule to run after profound is done running prompts for the day 

## Notes

Notes on Profound and handling timezone, quotes are taken from [this slack conversation](https://mongodb.slack.com/archives/C07U8029681/p1754423135991149).

- According to Profound, 
> API responses are returned as UTC timestamps, but the input is parsed as EST.
So, an input of 2025-08-04 is parsed as EST and becomes 2025-08-04 04:00:00 UTC. The timestamps in the returned responses are UTC timestamps.
This is because our system executes prompts within a 12-hour EST time window, which is 4 a.m. UTC

- Profound support suggested querying by YYYY-MM-DD without any timestamps or timezone indication. This input will be parsed by Profound as YYYY-MM-DD 04:00:00 UTC. The date field on records is in UTC, so if we query for prompt runs on Aug 4th 2025 like this: `{ "start_date": "2025-08-04", "end_date": "2025-08-05" }`, we will get all the prompts run that day, with record dates ranging from 2025-08-04 04:00:00 UTC --> 2025-08-05 04:00:00 UTC
> What I mostly recommend if you want to get responses day by day is to just send the date of the day you want as the start_date and the next day as the end_date. For example:
{ "start_date": "2025-08-04", "end_date": "2025-08-05" }

- The Profound team mentioned they are not handling timezone correctly and will be making a fix. Depending on how that goes, there may be future changes to make. For now, this PR will get our cron running again. 
> The Z at the end determines the timezone, which we don't seem to be handling correctly. 

- There were some things that did not add up in the slack conversation. Profound said they are querying within a 12 hour EST time window, but it looks like its closer to 24 hours. They also said -4 UTC, but that is EDT, not EST. I am assuming they are working with a timezone like "America/New_York" which would use EDT in the summer and EST in the winter. I asked about this but haven't gotten a response yet. 
> our system executes prompts within a 12-hour EST time window, which is 4 a.m. UTC

Additional Work:
- We will need to update the UI reflect these changes, to load records for 2025-08-04 by querying for 2025-08-04 04:00:00 UTC --> 2025-08-05 04:00:00 UTC
