### PR TITLE
(EAI-1202): [bug_fix] Missing context for multiple input messages on Responses API

### DIFF
--- a/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
+++ b/packages/mongodb-chatbot-server/src/routes/responses/createResponse.ts
@@ -552,6 +552,7 @@ const loadConversationByMessageId = async ({
       userId,
       customData: { metadata: formattedMetadata },
       creationInterface,
+      storeMessageContent,
     });
   }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1202

## Changes

- Fixes generation missing context for multiple input messages. (When request `input` was a list & `previous_response_id` was not given, `loadConversationByMessageId` would get an empty conversation and use that for generation instead of the input messages.)
