### PR TITLE
Upgrade Vercel AI SDK to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,14 +30,14 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/azure": {
-      "version": "2.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.0-beta.13.tgz",
-      "integrity": "sha512-doae5dg+U8e+LBvGlY4HI5W5hyvGCynOKKZ4ybMtgRp2RwjTxc58QBJeznM/kKSagYEnjikMXTM0qo0zqCeUYA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.14.tgz",
+      "integrity": "sha512-2lUIb70+IC2f5iyOeW1OqOrsSPycYpTOG1fPDqgf562ntPOpXmZLOBJh+Uh+cHsVKvtLUoSXzHAMgI+OftWwFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/openai": "2.0.0-beta.13",
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "3.0.0-beta.7"
+        "@ai-sdk/openai": "2.0.14",
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -47,13 +47,13 @@
       }
     },
     "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/openai": {
-      "version": "2.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.0-beta.13.tgz",
-      "integrity": "sha512-0hxkegu+qx+31OfNbn+pVjOlKkdVVqthRVZo8ccWklCnrEvd1DdLLJg9N/GDzTz/QSYnXhmIzXmT0J7u2SB5Aw==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.14.tgz",
+      "integrity": "sha512-u/wi1ixcvcg29wAJySjO803HlXpyCl6mkcOHn+Zn7DA+CtjuQNkKikJ4pZBc7I3Qhi90kA4XnOfKikhBXh4c4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "3.0.0-beta.7"
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Z8SPncMtS3RsoXITmT7NVwrAq6M44dmw0DoUOYJqNNtCu8iMWuxB8Nxsoqpa0uEEy9R1V1ZThJAXTYgjTUxl3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -75,12 +75,12 @@
       }
     },
     "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0-beta.7.tgz",
-      "integrity": "sha512-w1nMJegq98/TpVOUlYPehX/tyTmyx4b0NCWH2VMHF6hpnJjGuS3UfzkEAKTkHCWYbNZY038b4IkGDx24C0xNOA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+      "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
+        "@ai-sdk/provider": "2.0.0",
         "@standard-schema/spec": "^1.0.0",
         "eventsource-parser": "^3.0.3",
         "zod-to-json-schema": "^3.24.1"
@@ -102,7 +102,9 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.22",
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "1.1.3",
@@ -65294,11 +65296,11 @@
       }
     },
     "packages/mongodb-rag-core": {
-      "version": "0.7.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/azure": "2.0.0-beta.13",
-        "@ai-sdk/openai": "2.0.0-beta.13",
+        "@ai-sdk/azure": "2.0.14",
+        "@ai-sdk/openai": "2.0.14",
         "@apidevtools/swagger-parser": "^10.1.0",
         "@langchain/anthropic": "^0.3.6",
         "@langchain/community": "^0.3.10",
@@ -65308,8 +65310,8 @@
         "@supercharge/promise-pool": "^3.2.0",
         "acquit": "^1.3.0",
         "acquit-require": "^0.1.1",
-        "ai": "5.0.0-beta.28",
-        "braintrust": "^0.2.1",
+        "ai": "5.0.14",
+        "braintrust": "^0.2.4",
         "common-tags": "^1",
         "deep-equal": "^2.2.3",
         "dotenv": "^16.3.1",
@@ -65368,13 +65370,13 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/@ai-sdk/openai": {
-      "version": "2.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.0-beta.13.tgz",
-      "integrity": "sha512-0hxkegu+qx+31OfNbn+pVjOlKkdVVqthRVZo8ccWklCnrEvd1DdLLJg9N/GDzTz/QSYnXhmIzXmT0J7u2SB5Aw==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.14.tgz",
+      "integrity": "sha512-u/wi1ixcvcg29wAJySjO803HlXpyCl6mkcOHn+Zn7DA+CtjuQNkKikJ4pZBc7I3Qhi90kA4XnOfKikhBXh4c4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "3.0.0-beta.7"
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -65384,12 +65386,12 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0-beta.7.tgz",
-      "integrity": "sha512-w1nMJegq98/TpVOUlYPehX/tyTmyx4b0NCWH2VMHF6hpnJjGuS3UfzkEAKTkHCWYbNZY038b4IkGDx24C0xNOA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+      "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
+        "@ai-sdk/provider": "2.0.0",
         "@standard-schema/spec": "^1.0.0",
         "eventsource-parser": "^3.0.3",
         "zod-to-json-schema": "^3.24.1"
@@ -65402,9 +65404,9 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Z8SPncMtS3RsoXITmT7NVwrAq6M44dmw0DoUOYJqNNtCu8iMWuxB8Nxsoqpa0uEEy9R1V1ZThJAXTYgjTUxl3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -66046,18 +66048,15 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/ai": {
-      "version": "5.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.0-beta.28.tgz",
-      "integrity": "sha512-RYAYmrM+mfS4DFT7Qq/WQF9OMEdxTqRffc8UISJ+GwwHtjT+tAcq08KBySJwGa/x+69T9AVKZKfWeVc3XzwcDg==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.14.tgz",
+      "integrity": "sha512-xiujFa879skB7YxGzbeHAxepsr6AEaWcHPXrc5a9MRM6p4WdVAwn6mGwVZkBnhqGfZtXFr4LUnU2ayvcjWp5ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "1.0.0-beta.14",
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "3.0.0-beta.6",
+        "@ai-sdk/gateway": "1.0.6",
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3",
         "@opentelemetry/api": "1.9.0"
-      },
-      "bin": {
-        "ai": "dist/bin/ai.min.js"
       },
       "engines": {
         "node": ">=18"
@@ -66067,13 +66066,13 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/ai/node_modules/@ai-sdk/gateway": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.0-beta.14.tgz",
-      "integrity": "sha512-jsOZoz4hd1vSQ6PBftdQ/j3hPC4Fxf7tY2slCgdpMEevrqFVmRBp6W5xEELDa2wXuPQ/3QxtrQhQU7Qxj42p2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.6.tgz",
+      "integrity": "sha512-JuSj1MtTr4vw2VBBth4wlbciQnQIV0o1YV9qGLFA+r85nR5H+cJp3jaYE0nprqfzC9rYG8w9c6XGHB3SDKgcgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "3.0.0-beta.6"
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -66083,12 +66082,12 @@
       }
     },
     "packages/mongodb-rag-core/node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0-beta.6.tgz",
-      "integrity": "sha512-r8Nswwko+7nuLnLxprPgAxjGcpjq5fnFmfFwtkz4k9KfF1Z6Nkwvl8+Ee9BULBWXOqbtJGh9iCiJaTPBnhZrqw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+      "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
+        "@ai-sdk/provider": "2.0.0",
         "@standard-schema/spec": "^1.0.0",
         "eventsource-parser": "^3.0.3",
         "zod-to-json-schema": "^3.24.1"

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
@@ -460,22 +460,28 @@ export function makeGenerateResponseWithTools({
 
             // Appends references when a reference-returning tool is called
             onStepFinish: async ({ toolResults, toolCalls }) => {
-              toolCalls?.forEach((toolCall) => {
+              for (const toolCall of toolCalls) {
+                if (toolCall.dynamic) {
+                  continue;
+                }
                 if (toolCall.toolName === SEARCH_TOOL_NAME) {
                   userMessageCustomData = {
                     ...userMessageCustomData,
                     ...toolCall.input,
                   };
                 }
-              });
-              toolResults?.forEach((toolResult) => {
+              }
+              for (const toolResult of toolResults) {
+                if (toolResult.dynamic) {
+                  continue;
+                }
                 if (
                   toolResult.type === "tool-result" &&
                   toolResult.output?.references
                 ) {
                   references.push(...toolResult.output.references);
                 }
-              });
+              }
             },
           });
 

--- a/packages/chatbot-server-mongodb-public/src/tools/search.ts
+++ b/packages/chatbot-server-mongodb-public/src/tools/search.ts
@@ -5,7 +5,7 @@ import {
   Reference,
   logger,
 } from "mongodb-rag-core";
-import { Tool, tool, ToolResultUnion } from "mongodb-rag-core/aiSdk";
+import { Tool, tool, TypedToolResult } from "mongodb-rag-core/aiSdk";
 import { z } from "zod";
 import {
   mongoDbProducts,
@@ -47,7 +47,7 @@ export type SearchToolReturnValue = {
 
 export type SearchTool = Tool<MongoDbSearchToolArgs, SearchToolReturnValue>;
 
-export type SearchToolResult = ToolResultUnion<{
+export type SearchToolResult = TypedToolResult<{
   [SEARCH_TOOL_NAME]: SearchTool;
 }>;
 
@@ -64,8 +64,6 @@ export function makeSearchTool({
     inputSchema: MongoDbSearchToolArgsSchema,
     description: "Search MongoDB content",
 
-    // TODO: I get type errors when I try to implement this..Unclear why
-    // This shows only the URL and text of the result, not the metadata (needed for references) to the model.
     toModelOutput(result) {
       return {
         type: "content",

--- a/packages/mercury-case-analysis/src/analyzeCases.ts
+++ b/packages/mercury-case-analysis/src/analyzeCases.ts
@@ -1,12 +1,12 @@
 import { makeSimpleTextGenerator } from "./generateText";
 import { makeGenerateRating, PromptResponseRating } from "./rating";
-import { assessRelevance, Relevance } from "./relevance";
-import { EmbeddingModel, LanguageModel } from "mongodb-rag-core/aiSdk";
+import { assessRelevance, EmbeddingModelV2, Relevance } from "./relevance";
+import { LanguageModel } from "mongodb-rag-core/aiSdk";
 import { PromisePool } from "@supercharge/promise-pool";
 import { makeShortName } from "./utils";
 
 export type MakeAnalyzeCaseParams = {
-  embeddingModels: EmbeddingModel<string>[];
+  embeddingModels: EmbeddingModelV2[];
   generatorModel: LanguageModel;
   judgementModel: LanguageModel;
   ratingStyleGuide?: string;

--- a/packages/mongodb-rag-core/package.json
+++ b/packages/mongodb-rag-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-rag-core",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "description": "Common elements used by MongoDB Chatbot Framework components.",
   "author": "MongoDB, Inc.",
   "license": "Apache-2.0",
@@ -78,8 +78,8 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@ai-sdk/azure": "2.0.0-beta.13",
-    "@ai-sdk/openai": "2.0.0-beta.13",
+    "@ai-sdk/azure": "2.0.14",
+    "@ai-sdk/openai": "2.0.14",
     "@apidevtools/swagger-parser": "^10.1.0",
     "@langchain/anthropic": "^0.3.6",
     "@langchain/community": "^0.3.10",
@@ -89,8 +89,8 @@
     "@supercharge/promise-pool": "^3.2.0",
     "acquit": "^1.3.0",
     "acquit-require": "^0.1.1",
-    "ai": "5.0.0-beta.28",
-    "braintrust": "^0.2.1",
+    "ai": "5.0.14",
+    "braintrust": "^0.2.4",
     "common-tags": "^1",
     "deep-equal": "^2.2.3",
     "dotenv": "^16.3.1",

--- a/packages/scripts/src/main/assessCasesMain.ts
+++ b/packages/scripts/src/main/assessCasesMain.ts
@@ -52,6 +52,10 @@ const assessRelevanceMain = async () => {
     ],
   });
 
+  const model = createOpenAI({
+    apiKey: BRAINTRUST_API_KEY,
+    baseURL: BRAINTRUST_PROXY_ENDPOINT,
+  }).textEmbeddingModel(OPENAI_RETRIEVAL_EMBEDDING_DEPLOYMENT);
   const analyzeCases = makeAnalyzeCases({
     embeddingModels: [
       createOpenAI({


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1227

## Changes

- Upgrade Vercel AI SDK to stable version of v5 SDK.
  - Previously had been on a beta version
- Also updated Braintrust version in core. No impact, just maintenance.

## Notes

- The migration guide was incredibly helpful https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0
