### PR TITLE
(EAI-1268) Fix guardrail race condition (x2!)

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
@@ -267,6 +267,7 @@ const makeMockGuardrail =
   (pass: boolean): InputGuardrail =>
   async () =>
     pass ? mockGuardrailPassResult : mockGuardrailRejectResult;
+
 const mockThrowingLanguageModel: LanguageModel = {
   doGenerate: async () => {
     throw new Error("LLM error: should always fail");
@@ -396,34 +397,6 @@ describe("generateResponseWithTools", () => {
       ) as UserMessage;
       expect(userMessage.customData).toMatchObject(searchToolMockArgs);
     });
-    it("should not generate until guardrail has resolved (reject)", async () => {
-      const generateResponse = makeGenerateResponseWithTools({
-        ...makeGenerateResponseWithToolsArgs(),
-        inputGuardrail: async () => {
-          // sleep for 2 seconds
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          return mockGuardrailRejectResult;
-        },
-      });
-
-      const result = await generateResponse(generateResponseBaseArgs);
-
-      expectGuardrailRejectResult(result);
-    });
-    it("should not generate until guardrail has resolved (pass)", async () => {
-      const generateResponse = makeGenerateResponseWithTools({
-        ...makeGenerateResponseWithToolsArgs(),
-        inputGuardrail: async () => {
-          // sleep for 2 seconds
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          return mockGuardrailPassResult;
-        },
-      });
-
-      const result = await generateResponse(generateResponseBaseArgs);
-
-      expectSuccessfulResult(result);
-    });
     describe("non-streaming", () => {
       test("should handle successful generation non-streaming", async () => {
         const generateResponse = makeGenerateResponseWithTools(
@@ -473,30 +446,26 @@ describe("generateResponseWithTools", () => {
     });
 
     describe("streaming mode", () => {
-      const makeMockDataStreamer = () => {
-        const mockConnect = jest.fn();
-        const mockDisconnect = jest.fn();
-        const mockStreamData = jest.fn();
-        const mockStreamResponses = jest.fn();
-        const mockStream = jest.fn().mockImplementation(async () => {
+      const mockDataStreamerConfig = {
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        streamData: jest.fn(),
+        streamResponses: jest.fn(),
+        stream: jest.fn().mockImplementation(async () => {
           // Process the stream and return a string result
           return "Hello";
-        });
-
-        const dataStreamer = {
-          connected: true,
-          connect: mockConnect,
-          disconnect: mockDisconnect,
-          streamData: mockStreamData,
-          streamResponses: mockStreamResponses,
-          stream: mockStream,
-        } as DataStreamer;
-
-        return dataStreamer;
+        }),
       };
+      const mockDataStreamer = {
+        connected: true,
+        ...mockDataStreamerConfig,
+      } as DataStreamer;
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
 
       test("should handle successful streaming", async () => {
-        const mockDataStreamer = makeMockDataStreamer();
         const generateResponse = makeGenerateResponseWithTools(
           makeGenerateResponseWithToolsArgs()
         );
@@ -523,10 +492,13 @@ describe("generateResponseWithTools", () => {
       });
 
       test("should handle successful generation with guardrail", async () => {
-        const mockDataStreamer = makeMockDataStreamer();
         const generateResponse = makeGenerateResponseWithTools({
           ...makeGenerateResponseWithToolsArgs(),
-          inputGuardrail: makeMockGuardrail(true),
+          inputGuardrail: async () => {
+            // sleep for 2 seconds
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            return mockGuardrailPassResult;
+          },
         });
 
         const result = await generateResponse({
@@ -551,10 +523,13 @@ describe("generateResponseWithTools", () => {
       });
 
       test("should handle streaming with guardrail rejection", async () => {
-        const mockDataStreamer = makeMockDataStreamer();
         const generateResponse = makeGenerateResponseWithTools({
           ...makeGenerateResponseWithToolsArgs(),
-          inputGuardrail: makeMockGuardrail(false),
+          inputGuardrail: async () => {
+            // sleep for 2 seconds
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+            return mockGuardrailRejectResult;
+          },
         });
 
         const result = await generateResponse({
@@ -563,16 +538,25 @@ describe("generateResponseWithTools", () => {
           dataStreamer: mockDataStreamer,
         });
 
+        // Ensure the streamed data only contains the guardrail result
+        expect(mockStreamConfig.onTextDelta).toHaveBeenCalledTimes(0);
+        expect(mockStreamConfig.onLlmRefusal).toHaveBeenCalledTimes(1);
         expect(mockStreamConfig.onLlmRefusal).toHaveBeenCalledWith({
           dataStreamer: mockDataStreamer,
           refusalMessage: mockLlmRefusalMessage,
+        });
+        expect(mockDataStreamerConfig.streamData).toHaveBeenCalledTimes(1);
+        expect(
+          mockDataStreamerConfig.streamData.mock.calls[0][0]
+        ).toStrictEqual({
+          type: "delta",
+          data: mockLlmRefusalMessage,
         });
 
         expectGuardrailRejectResult(result);
       });
 
       test("should handle error in language model", async () => {
-        const mockDataStreamer = makeMockDataStreamer();
         const generateResponse = makeGenerateResponseWithTools({
           ...makeGenerateResponseWithToolsArgs(),
           languageModel: mockThrowingLanguageModel,

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
@@ -267,7 +267,6 @@ const makeMockGuardrail =
   (pass: boolean): InputGuardrail =>
   async () =>
     pass ? mockGuardrailPassResult : mockGuardrailRejectResult;
-
 const mockThrowingLanguageModel: LanguageModel = {
   doGenerate: async () => {
     throw new Error("LLM error: should always fail");
@@ -495,8 +494,8 @@ describe("generateResponseWithTools", () => {
         const generateResponse = makeGenerateResponseWithTools({
           ...makeGenerateResponseWithToolsArgs(),
           inputGuardrail: async () => {
-            // sleep for 2 seconds
-            await new Promise((resolve) => setTimeout(resolve, 2000));
+            // sleep for 1 seconds, so guardrail finishes after LLM streaming
+            await new Promise((resolve) => setTimeout(resolve, 1000));
             return mockGuardrailPassResult;
           },
         });
@@ -526,8 +525,8 @@ describe("generateResponseWithTools", () => {
         const generateResponse = makeGenerateResponseWithTools({
           ...makeGenerateResponseWithToolsArgs(),
           inputGuardrail: async () => {
-            // sleep for 2 seconds
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            // sleep for 1 seconds, so guardrail finishes after LLM streaming
+            await new Promise((resolve) => setTimeout(resolve, 1000));
             return mockGuardrailRejectResult;
           },
         });

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
@@ -432,7 +432,7 @@ export function makeGenerateResponseWithTools({
           generationController.abort();
         }
         return result;
-      });
+      }) ?? Promise.resolve(undefined);
 
       // Start generation immediately (in parallel with guardrail)
       const generationPromise = (async () => {
@@ -485,6 +485,12 @@ export function makeGenerateResponseWithTools({
               }
             },
           });
+
+          // Wait for guardrail so we don't get streaming overlap 
+          const guardrailResult = await guardrailMonitor
+          if (guardrailResult?.rejected) {
+            throw new Error("Guardrail rejected (just exit this block)");
+          }
 
           let fullStreamText = "";
           let textPartId = ""; // Shared between text-start and text-end

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
@@ -486,7 +486,7 @@ export function makeGenerateResponseWithTools({
             },
           });
 
-          // Wait for guardrail so we don't get streaming overlap 
+          // Wait for guardrail so we don't get streaming overlap (addresses race condition)
           const guardrailResult = await guardrailMonitor
           if (guardrailResult?.rejected) {
             throw new Error("Guardrail rejected (just exit this block)");

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
@@ -426,13 +426,14 @@ export function makeGenerateResponseWithTools({
       let guardrailRejected = false;
 
       // Start guardrail check immediately and monitor it
-      const guardrailMonitor = inputGuardrailPromise?.then((result) => {
-        if (result?.rejected) {
-          guardrailRejected = true;
-          generationController.abort();
-        }
-        return result;
-      }) ?? Promise.resolve(undefined);
+      const guardrailMonitor =
+        inputGuardrailPromise?.then((result) => {
+          if (result?.rejected) {
+            guardrailRejected = true;
+            generationController.abort();
+          }
+          return result;
+        }) ?? Promise.resolve(undefined);
 
       // Start generation immediately (in parallel with guardrail)
       const generationPromise = (async () => {
@@ -487,7 +488,7 @@ export function makeGenerateResponseWithTools({
           });
 
           // Wait for guardrail so we don't get streaming overlap (addresses race condition)
-          const guardrailResult = await guardrailMonitor
+          const guardrailResult = await guardrailMonitor;
           if (guardrailResult?.rejected) {
             throw new Error("Guardrail rejected (just exit this block)");
           }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1268

## Changes

- Fixes cases where LLM generation loop finishes before guardrail does by waiting for guardrail to resolve before streaming results
- And unit test it

## Notes

- without this, for short messages that trip the guardrail, 2 results are streamed to chatbot UI/responses API, one for LLM response and one for guardrail rejection
- [Braintrust](https://www.braintrust.dev/app/mongodb-education-ai/p/mongodb-chatbot-conversations/experiments/EAI-1268-race-condition-again) run looks good, no dropoffs
