### PR TITLE
(EAI-1259) Normalize URL in user msg formatting

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/processors/formatUserMessageForGeneration.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/formatUserMessageForGeneration.test.ts
@@ -8,16 +8,19 @@ beforeAll(() => {
 describe("formatUserMessageForGeneration", () => {
   const userMessageText = "Hello, world!";
   const reqId = "test-request-id";
+  const testMongoDbPageUrl = "https://mongodb.com";
+  const resultMongoDbPageUrl = "mongodb.com";
 
   it("formats front matter correctly for mongodb.com origin", () => {
-    const origin = "https://mongodb.com";
     const result = formatUserMessageForGeneration({
       userMessageText,
       reqId,
-      customData: { origin } satisfies ConversationCustomData,
+      customData: {
+        origin: testMongoDbPageUrl,
+      } satisfies ConversationCustomData,
     });
     expect(result).toEqual(`---
-pageUrl: ${origin}
+pageUrl: ${resultMongoDbPageUrl}
 ---
 
 ${userMessageText}`);
@@ -31,7 +34,40 @@ ${userMessageText}`);
       customData: { origin } satisfies ConversationCustomData,
     });
     expect(result).toEqual(`---
-pageUrl: ${origin}
+pageUrl: learn.mongodb.com
+---
+
+${userMessageText}`);
+  });
+
+  it("normalizes a URL with trailing backslash", () => {
+    const origin = testMongoDbPageUrl + "/docs/pageName/";
+    const result = formatUserMessageForGeneration({
+      userMessageText,
+      reqId,
+      customData: {
+        origin,
+      } satisfies ConversationCustomData,
+    });
+    expect(result).toEqual(`---
+pageUrl: ${resultMongoDbPageUrl + "/docs/pageName"}
+---
+
+${userMessageText}`);
+  });
+
+  it("normalizes a URL with query", () => {
+    const origin =
+      "https://learn.mongodb.com/courses/mongodb-for-sql-experts?param1=value1&param2=value2";
+    const result = formatUserMessageForGeneration({
+      userMessageText,
+      reqId,
+      customData: {
+        origin,
+      } satisfies ConversationCustomData,
+    });
+    expect(result).toEqual(`---
+pageUrl: learn.mongodb.com/courses/mongodb-for-sql-experts
 ---
 
 ${userMessageText}`);
@@ -119,19 +155,18 @@ ${userMessageText}`);
   });
 
   it("adds both pageUrl and client front matter if both are present", () => {
-    const origin = "https://mongodb.com";
     const originCode = "VSCODE";
     const expectedClientLabel = "MongoDB VS Code plugin";
     const result = formatUserMessageForGeneration({
       userMessageText,
       reqId,
       customData: {
-        origin,
+        origin: testMongoDbPageUrl,
         originCode,
       } satisfies ConversationCustomData,
     });
     expect(result).toEqual(`---
-pageUrl: ${origin}
+pageUrl: ${resultMongoDbPageUrl}
 client: ${expectedClientLabel}
 ---
 

--- a/packages/chatbot-server-mongodb-public/src/processors/formatUserMessageForGeneration.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/formatUserMessageForGeneration.ts
@@ -1,4 +1,5 @@
 import { updateFrontMatter, ConversationCustomData } from "mongodb-rag-core";
+import { normalizeUrl } from "mongodb-rag-core/dataSources";
 import { originCodes } from "mongodb-chatbot-server";
 import { z } from "zod";
 import { logRequest } from "../utils";
@@ -52,7 +53,7 @@ export function formatUserMessageForGeneration({
         url.hostname === "mongodb.com" ||
         url.hostname.endsWith(".mongodb.com")
       ) {
-        frontMatter.pageUrl = parsedCustomData.origin;
+        frontMatter.pageUrl = normalizeUrl({ url: parsedCustomData.origin });
       }
     } catch (e) {
       logRequest({


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1259

## Changes

- Normalize URL in message formatting so that the LLM doesn't have to handle parsing and passing really long URLs as tool args (cases when there's long query strings, hash fragments)
