### PR TITLE
(EAI-1279): dataset sampling args

### DIFF
--- a/packages/benchmarks/src/cli/benchmarkCli.test.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.test.ts
@@ -108,6 +108,8 @@ describe("makeBenchmarkCli", () => {
         "run",
         "--type",
         "unknown-benchmark",
+        "--model",
+        "test-model-1",
         "--dataset",
         "dataset1",
       ]);
@@ -121,6 +123,8 @@ describe("makeBenchmarkCli", () => {
         "run",
         "--type",
         "test-benchmark",
+        "--model",
+        "test-model-1",
         "--dataset",
         "dataset1",
         "--task",
@@ -136,6 +140,8 @@ describe("makeBenchmarkCli", () => {
         "run",
         "--type",
         "test-benchmark",
+        "--model",
+        "test-model-1",
         "--dataset",
         "unknown-dataset",
       ]);
@@ -164,6 +170,8 @@ describe("makeBenchmarkCli", () => {
         "run",
         "--type",
         "test-benchmark",
+        "--model",
+        "test-model-1",
         "--dataset",
         "dataset1",
         "--taskConcurrency",
@@ -177,6 +185,8 @@ describe("makeBenchmarkCli", () => {
         "run",
         "--type",
         "test-benchmark",
+        "--model",
+        "test-model-1",
         "--dataset",
         "dataset1",
         "--taskConcurrency",
@@ -209,6 +219,54 @@ describe("makeBenchmarkCli", () => {
         "dataset1",
         "--modelConcurrency",
         "6",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+    it("should validate sampleSize is a positive integer", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "--sampleSize",
+        "-1",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate sampleSize and no sampleType", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "dataset1",
+        "--sampleType",
+        "random",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate sampleSize and sampleType", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "dataset1",
+        "--sampleType",
+        "random",
+        "--sampleSize",
+        "10.5",
       ]);
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
@@ -279,6 +337,9 @@ describe("makeBenchmarkCli", () => {
         models: [mockConfig.models[0]], // Only test-model-1
         datasets: ["dataset1", "dataset2"],
         modelConcurrency: 1,
+        taskConcurrency: 3,
+        sampleType: undefined,
+        sampleSize: undefined,
       });
     });
 

--- a/packages/benchmarks/src/cli/benchmarkCli.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.ts
@@ -31,6 +31,18 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
             describe:
               "Tasks to run per benchmark. Defaults to first provided task for type.",
           })
+          .option("sampleSize", {
+            type: "number",
+            describe:
+              "Number of samples to run per task. Defaults to all samples.",
+            default: undefined,
+          })
+          .option("sampleType", {
+            type: "string",
+            choices: ["firstN", "random"] as const,
+            describe: "Sampling strategy. Defaults to first N elements.",
+            default: undefined,
+          })
           .option("taskConcurrency", {
             type: "number",
             describe:
@@ -102,6 +114,19 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               errors.push("modelConcurrency must be integer between 1 and 5");
             }
 
+            // Validate sampling
+            if (argv.sampleType && argv.sampleSize === undefined) {
+              errors.push(
+                "sampleSize is required when sampleType is provided."
+              );
+            }
+            if (
+              argv.sampleSize !== undefined &&
+              (!Number.isInteger(argv.sampleSize) || argv.sampleSize <= 0)
+            ) {
+              errors.push("sampleSize must be a positive integer");
+            }
+
             if (errors.length > 0) {
               throw new Error(errors.join(", "));
             }
@@ -125,7 +150,10 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
             task: argv.task ?? tasks[0],
             models: config.models.filter((m) => models.includes(m.label)),
             datasets,
+            taskConcurrency: argv.taskConcurrency,
             modelConcurrency: argv.modelConcurrency,
+            sampleSize: argv.sampleSize,
+            sampleType: argv.sampleType,
           };
           await runBenchmark(config, args);
         } catch (error) {

--- a/packages/benchmarks/src/cli/runBenchmark.test.ts
+++ b/packages/benchmarks/src/cli/runBenchmark.test.ts
@@ -1,6 +1,6 @@
 import PromisePool from "@supercharge/promise-pool";
 import { Eval } from "mongodb-rag-core/braintrust";
-import { runBenchmark, RunBenchmarkArgs } from "./runBenchmark";
+import { runBenchmark, RunBenchmarkArgs, getSample } from "./runBenchmark";
 import { BenchmarkCliConfig } from "./BenchmarkConfig";
 import { makeExperimentName } from "../makeExperimentName";
 import { ModelConfig } from "mongodb-rag-core/models";
@@ -215,6 +215,61 @@ describe("runBenchmark", () => {
       };
 
       await runBenchmark(mockConfig, multiDatasetArgs);
+    });
+
+    it("should sample sampleSize correctly with firstN", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, 3, "firstN");
+      expect(result).toEqual([1, 2, 3]);
+      expect(result.length).toBe(3);
+    });
+
+    it("should sample sampleType=undefined correctly (defaults to firstN)", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, 3, undefined);
+      expect(result).toEqual([1, 2, 3]);
+      expect(result.length).toBe(3);
+    });
+
+    it("should sample sampleType=firstN correctly", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, 2, "firstN");
+      expect(result).toEqual([1, 2]);
+      expect(result.length).toBe(2);
+    });
+
+    it("should sample sampleType=random correctly", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, 3, "random");
+
+      expect(result.length).toBe(3);
+      expect(result.every((item) => dataset.includes(item))).toBe(true);
+    });
+
+    it("should return full dataset when no sampleSize provided", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, undefined, undefined);
+      expect(result).toEqual(dataset);
+    });
+
+    it("should return full dataset when sampleSize is 0 (falsy behavior)", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      const result = getSample(dataset, 0, "firstN");
+      expect(result).toEqual(dataset);
+    });
+
+    it("should throw error when sampleSize is negative", () => {
+      const dataset = [1, 2, 3, 4, 5];
+      expect(() => getSample(dataset, -1, "firstN")).toThrow(
+        "sampleSize is required"
+      );
+    });
+
+    it("should throw error when sampleSize exceeds dataset length", () => {
+      const dataset = [1, 2, 3];
+      expect(() => getSample(dataset, 5, "firstN")).toThrow(
+        "sampleSize must be less than or equal to the length of the dataset"
+      );
     });
   });
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1279

## Changes

- Add `--sampleSize` and `--sampleType` args to get subset of dataset
  - These are quite useful when iterating on prompts.
- Fix bug in `benchmarkCli.test.ts` where tests were failing w/ a different err type than expected (needed to pass a valid `--model` arg to all cases)

## Notes

-
