### PR TITLE
(EAI-1150) Improve cleanliness in generateResponseWithTools.ts

### DIFF
--- a/packages/chatbot-server-mongodb-public/src/config.ts
+++ b/packages/chatbot-server-mongodb-public/src/config.ts
@@ -60,7 +60,7 @@ import {
   makeRateMessageUpdateTrace,
 } from "./tracing/traceHandlers";
 import { useSegmentIds } from "./middleware/useSegmentIds";
-import { makeSearchTool } from "./tools/search";
+import { makeSearchTool, SEARCH_TOOL_NAME } from "./tools/search";
 import { makeMongoDbInputGuardrail } from "./processors/mongoDbInputGuardrail";
 import {
   makeGenerateResponseWithTools,
@@ -72,7 +72,7 @@ import { makeMongoDbScrubbedMessageStore } from "./tracing/scrubbedMessages/Mong
 import { MessageAnalysis } from "./tracing/scrubbedMessages/analyzeMessage";
 import { makeFindContentWithMongoDbMetadata } from "./processors/findContentWithMongoDbMetadata";
 import { makeMongoDbAssistantSystemPrompt } from "./systemPrompt";
-import { makeFetchPageTool } from "./tools/fetchPage";
+import { FETCH_PAGE_TOOL_NAME, makeFetchPageTool } from "./tools/fetchPage";
 import { makeCorsOptions } from "./corsOptions";
 
 export const {
@@ -282,15 +282,17 @@ export const makeGenerateResponse = (args?: MakeGenerateResponseParams) =>
           filterPreviousMessages,
           llmNotWorkingMessage:
             conversations.conversationConstants.LLM_NOT_WORKING,
-          searchTool: makeSearchTool({
-            findContent,
-            makeReferences: makeMongoDbReferences,
-          }),
-          fetchPageTool: makeFetchPageTool({
-            loadPage,
-            findContent,
-            makeReferences: makeMongoDbReferences,
-          }),
+          internalTools: {
+            [SEARCH_TOOL_NAME]: makeSearchTool({
+              findContent,
+              makeReferences: makeMongoDbReferences,
+            }),
+            [FETCH_PAGE_TOOL_NAME]: makeFetchPageTool({
+              loadPage,
+              findContent,
+              makeReferences: makeMongoDbReferences,
+            }),
+          },
           maxSteps,
           stream: args?.responseWithSearchToolStream,
         }),

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.test.ts
@@ -312,8 +312,10 @@ const makeGenerateResponseWithToolsArgs = () =>
     languageModel: makeMockLanguageModel(),
     llmNotWorkingMessage: mockLlmNotWorkingMessage,
     llmRefusalMessage: mockLlmRefusalMessage,
-    searchTool: mockSearchTool,
-    fetchPageTool: mockFetchPageTool,
+    internalTools: {
+      [SEARCH_TOOL_NAME]: mockSearchTool,
+      [FETCH_PAGE_TOOL_NAME]: mockFetchPageTool,
+    },
     maxSteps: 5,
     stream: mockStreamConfig,
     makeSystemPrompt: () => {
@@ -394,7 +396,10 @@ describe("generateResponseWithTools", () => {
       const userMessage = result.messages.find(
         (message) => message.role === "user"
       ) as UserMessage;
-      expect(userMessage.customData).toMatchObject(searchToolMockArgs);
+      expect(userMessage.customData).toMatchObject({
+        search_content: searchToolMockArgs,
+        fetch_page: fetchPageToolMockArgs,
+      });
     });
     describe("non-streaming", () => {
       test("should handle successful generation non-streaming", async () => {
@@ -743,7 +748,7 @@ function expectSuccessfulResult(result: GenerateResponseReturnValue) {
   expect(result.messages[0]).toMatchObject({
     role: "user",
     content: latestMessageText,
-    customData: expect.objectContaining(searchToolMockArgs),
+    customData: expect.objectContaining({ search_content: searchToolMockArgs }),
   });
 
   expect(result.messages[1]).toMatchObject({

--- a/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
+++ b/packages/chatbot-server-mongodb-public/src/processors/generateResponseWithTools.ts
@@ -472,10 +472,12 @@ export function makeGenerateResponseWithTools({
             },
           });
 
-          // Wait for guardrail so we don't get streaming overlap (addresses race condition)
+          // Wait for guardrail before streaming content (addresses race condition)
           const guardrailResult = await guardrailMonitor;
           if (guardrailResult?.rejected) {
-            throw new Error("Guardrail rejected (just exit this block)");
+            throw new Error(
+              "Guardrail rejected. Aborting generation (you shouldn't see this)"
+            );
           }
 
           let fullStreamText = "";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1150

## Changes

- handle tool call outside of generation loop
- pass the tools into the function as a list instead of individually

## Notes

- I decided to keep the tool result references handling in the generation loop. It's quick and the current code is generic for all tools. 
